### PR TITLE
fix(reranker): unwrap TokenizerWrapper before calling tokenizer

### DIFF
--- a/vmlx_engine/reranker.py
+++ b/vmlx_engine/reranker.py
@@ -115,10 +115,13 @@ class Reranker:
         """Score using encoder cross-encoder (sequence classification)."""
         import mlx.core as mx
 
+        # Unwrap TokenizerWrapper (mlx_embeddings wraps the HF tokenizer)
+        tokenizer = getattr(self._tokenizer, "_tokenizer", self._tokenizer)
+
         scores = []
         for doc in documents:
             # Cross-encoder: concatenate query and document
-            inputs = self._tokenizer(
+            inputs = tokenizer(
                 query, doc,
                 padding=True,
                 truncation=True,


### PR DESCRIPTION
## Problem

`/v1/rerank` endpoint returns 500 with:
```
'TokenizerWrapper' object is not callable
```

## Root Cause

`mlx_embeddings.load()` returns a `TokenizerWrapper` that doesn't implement `__call__`. The reranker's `_score_encoder()` calls `self._tokenizer(query, doc, ...)` directly, which fails.

## Fix

Apply the same unwrap pattern already used in `embedding.py` (line 72):
```python
tokenizer = getattr(self._tokenizer, "_tokenizer", self._tokenizer)
```

This extracts the underlying HF tokenizer which supports `__call__`.

## Testing

- Verified `embedding.py` uses the same pattern successfully
- One-line change, no behavior change for non-wrapped tokenizers (getattr fallback)