### PR TITLE
fix: add image placeholder tokens for assistant role messages in MLLM

### DIFF
--- a/tests/test_mllm.py
+++ b/tests/test_mllm.py
@@ -345,6 +345,82 @@ class TestExtractMultimodalMessages:
         assert "tool_calls" in assistant_msg
         assert assistant_msg["tool_calls"] == tool_calls
 
+    def test_assistant_image_tokens_included(self):
+        """Assistant messages with images must produce image placeholders.
+
+        Regression test: previously only user role got image content lists.
+        Some UIs (e.g. klite) send images on assistant messages when
+        attaching context images to the conversation.
+        """
+        from vmlx_engine.models.mllm import MLXMultimodalLM
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Here is the image analysis."},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}},
+                ],
+            }
+        ]
+
+        chat_msgs, images, _videos = MLXMultimodalLM._extract_multimodal_messages(messages)
+        assert len(images) == 1
+        assert images[0] == "https://example.com/img.jpg"
+        # Assistant message should have content list with image placeholder
+        assistant_msg = chat_msgs[0]
+        assert assistant_msg["role"] == "assistant"
+        assert isinstance(assistant_msg["content"], list)
+        # 1 image placeholder + 1 text part
+        assert len(assistant_msg["content"]) == 2
+        image_items = [c for c in assistant_msg["content"] if c.get("type") == "image"]
+        assert len(image_items) == 1
+
+    def test_assistant_image_with_tool_calls_preserved(self):
+        """Assistant messages with both images and tool_calls keep both."""
+        from vmlx_engine.models.mllm import MLXMultimodalLM
+
+        tool_calls = [{"id": "call_1", "type": "function", "function": {"name": "analyze", "arguments": "{}"}}]
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Analyzing image."},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}},
+                ],
+                "tool_calls": tool_calls,
+            }
+        ]
+
+        chat_msgs, images, _ = MLXMultimodalLM._extract_multimodal_messages(messages)
+        assert len(images) == 1
+        assistant_msg = chat_msgs[0]
+        assert "tool_calls" in assistant_msg
+        assert assistant_msg["tool_calls"] == tool_calls
+        assert isinstance(assistant_msg["content"], list)
+
+    def test_user_image_still_works(self):
+        """User messages with images must continue to work (no regression)."""
+        from vmlx_engine.models.mllm import MLXMultimodalLM
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is this?"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/photo.png"}},
+                ],
+            }
+        ]
+
+        chat_msgs, images, _ = MLXMultimodalLM._extract_multimodal_messages(messages)
+        assert len(images) == 1
+        user_msg = chat_msgs[0]
+        assert user_msg["role"] == "user"
+        assert isinstance(user_msg["content"], list)
+        image_items = [c for c in user_msg["content"] if c.get("type") == "image"]
+        assert len(image_items) == 1
+
 
 class TestMLLMFinishReason:
     """Tests for MLLM finish_reason correctness (BUG 9 fix)."""

--- a/vmlx_engine/models/mllm.py
+++ b/vmlx_engine/models/mllm.py
@@ -950,16 +950,23 @@ class MLXMultimodalLM:
             msg_name = msg.get("name")
 
             if msg_text or msg_image_count > 0 or tool_calls or role == "tool":
-                if role == "user" and msg_image_count > 0:
+                if msg_image_count > 0 and role in ("user", "assistant"):
+                    # Build multimodal content list with image markers for
+                    # any role that carries images (user or assistant).
+                    # Some UIs (e.g. klite) send images on assistant messages
+                    # when attaching an image to the conversation context.
                     content_list: list[dict] = []
                     for _ in range(msg_image_count):
                         content_list.append({"type": "image"})
                     content_list.append(
                         {"type": "text", "text": msg_text, "content": msg_text}
                     )
-                    chat_messages.append({"role": role, "content": content_list})
+                    out_msg = {"role": role, "content": content_list}
+                    if role == "assistant" and tool_calls:
+                        out_msg["tool_calls"] = tool_calls
+                    chat_messages.append(out_msg)
                 elif role == "assistant":
-                    out_msg: dict = {"role": role, "content": msg_text}
+                    out_msg = {"role": role, "content": msg_text}
                     if tool_calls:
                         out_msg["tool_calls"] = tool_calls
                     chat_messages.append(out_msg)


### PR DESCRIPTION
## Summary
Fix an error when images are attached to assistant-role messages in multimodal conversations. The vision encoder produces image features but no matching placeholder tokens exist in the prompt, causing a `ValueError` during generation.
## Problem
`_extract_multimodal_messages()` only builds the multimodal content list (with `{"type": "image"}` placeholder entries) for `user`-role messages. When a UI sends images on `assistant` messages — e.g. [klite](https://github.com/LostRuins/lite.koboldai.net) attaches images to conversation context on the assistant turn — the vision encoder produces features for those images but the rendered prompt has no corresponding image tokens:

> **ValueError: Image features and image tokens do not match: tokens: 0, features 900**


## Fix
Extend the image-placeholder branch in `_extract_multimodal_messages()` (`mllm.py:950`) from `role == "user"` to `role in ("user", "assistant")`, so both roles get the `{"type": "image"}` markers that the vision encoder expects. When the assistant message also carries `tool_calls`, those are preserved on the output dict.
## Tests
3 new tests in `test_mllm.py`:
- `test_assistant_image_tokens_included` — assistant message with image produces placeholder and extracts the URL
- `test_assistant_image_with_tool_calls_preserved` — assistant message with both images and tool_calls retains both
- `test_user_image_still_works` — regression guard confirming user-role images are unaffected