### PR TITLE
feat: add --chat-template-kwargs CLI flag for server-wide template defaults

### DIFF
--- a/vmlx_engine/cli.py
+++ b/vmlx_engine/cli.py
@@ -95,6 +95,22 @@ def serve_command(args):
             sys.exit(1)
         server._default_top_p = args.default_top_p
 
+    # Parse --chat-template-kwargs JSON and apply server-wide defaults
+    if getattr(args, 'chat_template_kwargs', None) is not None:
+        try:
+            ct_kwargs = _json.loads(args.chat_template_kwargs)
+            if not isinstance(ct_kwargs, dict):
+                print("Error: --chat-template-kwargs must be a JSON object")
+                sys.exit(1)
+        except _json.JSONDecodeError as e:
+            print(f"Error: --chat-template-kwargs is not valid JSON: {e}")
+            sys.exit(1)
+        # Extract enable_thinking into the dedicated server default
+        if "enable_thinking" in ct_kwargs:
+            server._default_enable_thinking = bool(ct_kwargs["enable_thinking"])
+        # Store full kwargs for forwarding to chat templates
+        server._default_chat_template_kwargs = ct_kwargs
+
     # Configure reasoning parser (strictly explicit)
     parser_name = getattr(args, 'reasoning_parser', None)
     if parser_name in ("auto", "none", None) or not parser_name:
@@ -176,6 +192,8 @@ def serve_command(args):
         print(f"    Draft tokens per step: {getattr(args, 'num_draft_tokens', 3)}")
     else:
         print("  Speculative decoding: Use --speculative-model to enable")
+    if getattr(args, 'chat_template_kwargs', None):
+        print(f"  Chat template kwargs: {args.chat_template_kwargs}")
     print("=" * 60)
 
     print(f"Loading model: {args.model}")
@@ -1096,6 +1114,14 @@ Examples:
              "tokens whose cumulative probability ≤ this value: 0.9 = use top 90%% of probability mass. "
              "Lower = more focused, higher = more diverse. Overridden by per-request 'top_p'. "
              "If not set, uses model default.",
+    )
+    serve_parser.add_argument(
+        "--chat-template-kwargs",
+        type=str,
+        default=None,
+        help='Server-wide default kwargs passed to the chat template. JSON string, e.g. '
+             '\'{"enable_thinking": false}\'. Per-request chat_template_kwargs override these. '
+             "Common use: disable thinking for reasoning models like Qwen3.",
     )
     # JIT compilation
     serve_parser.add_argument(

--- a/vmlx_engine/server.py
+++ b/vmlx_engine/server.py
@@ -137,7 +137,21 @@ _default_max_tokens: int = 32768
 _default_timeout: float = 300.0  # Default request timeout in seconds (5 minutes)
 _default_temperature: float | None = None  # Set via --default-temperature
 _default_top_p: float | None = None  # Set via --default-top-p
-_default_enable_thinking: bool | None = None  # Set via --default-enable-thinking
+_default_enable_thinking: bool | None = None  # Set via --default-enable-thinking or --chat-template-kwargs
+_default_chat_template_kwargs: dict | None = None  # Set via --chat-template-kwargs
+
+
+def _merge_ct_kwargs(request_kwargs: dict | None) -> dict:
+    """Merge server-wide default chat_template_kwargs with per-request overrides.
+
+    Server defaults (from --chat-template-kwargs) are used as the base layer.
+    Per-request chat_template_kwargs override any matching keys.
+    """
+    base = dict(_default_chat_template_kwargs) if _default_chat_template_kwargs else {}
+    if request_kwargs:
+        base.update(request_kwargs)
+    return base
+
 _last_request_time: float = 0.0  # Epoch timestamp of last API request (for idle sleep timer)
 _model_load_error: str | None = None  # Surfaced via /health when model fails to load
 _stream_from_disk: bool = False  # --stream-from-disk: lazy mmap loading, no caching
@@ -3119,7 +3133,7 @@ async def create_chat_completion(
     # in context and mimics the pattern, producing reasoning even when the generation
     # prompt doesn't inject <think>. This is the root cause of "thinking OFF but model
     # still thinks on 2nd message" bugs.
-    _ct_kwargs = request.chat_template_kwargs or {}
+    _ct_kwargs = _merge_ct_kwargs(request.chat_template_kwargs)
     _explicit_thinking_off = (
         request.enable_thinking is False
         or (_ct_kwargs.get("enable_thinking") is False)
@@ -3346,8 +3360,8 @@ async def create_chat_completion(
         # not just raw request — covers --default-enable-thinking and auto-detect paths)
         _resolved = chat_kwargs.get("enable_thinking")
         _suppress = _resolved is False or request.enable_thinking is False
-        if not _suppress and request.chat_template_kwargs:
-            _suppress = request.chat_template_kwargs.get("enable_thinking") is False
+        if not _suppress:
+            _suppress = _ct_kwargs.get("enable_thinking") is False
         if _suppress:
             reasoning_text = None
 
@@ -3659,7 +3673,7 @@ async def create_response(
             messages = _inject_json_instruction(messages, json_instruction)
 
     # Strip <think> blocks from history when thinking is OFF (same as Chat Completions path)
-    _ct_kwargs = request.chat_template_kwargs or {}
+    _ct_kwargs = _merge_ct_kwargs(request.chat_template_kwargs)
     _explicit_thinking_off = (
         request.enable_thinking is False
         or (_ct_kwargs.get("enable_thinking") is False)
@@ -3875,8 +3889,8 @@ async def create_response(
         # not just raw request — covers --default-enable-thinking and auto-detect paths)
         _resolved = chat_kwargs.get("enable_thinking")
         _suppress = _resolved is False or request.enable_thinking is False
-        if not _suppress and request.chat_template_kwargs:
-            _suppress = request.chat_template_kwargs.get("enable_thinking") is False
+        if not _suppress:
+            _suppress = _ct_kwargs.get("enable_thinking") is False
         if _suppress:
             reasoning_text = None
 
@@ -4163,7 +4177,7 @@ async def stream_chat_completion(
 
     # Resolve effective enable_thinking:
     # Priority: top-level field > chat_template_kwargs > server default > auto-detect
-    _ct_kwargs = request.chat_template_kwargs or {}
+    _ct_kwargs = _merge_ct_kwargs(request.chat_template_kwargs)
     if request.enable_thinking is not None:
         _effective_thinking = request.enable_thinking
     elif "enable_thinking" in _ct_kwargs:
@@ -4846,7 +4860,7 @@ async def stream_responses_api(
 
     # Resolve effective enable_thinking:
     # Priority: top-level field > chat_template_kwargs > server default > auto-detect
-    _ct_kwargs = request.chat_template_kwargs or {}
+    _ct_kwargs = _merge_ct_kwargs(request.chat_template_kwargs)
     if request.enable_thinking is not None:
         _effective_thinking = request.enable_thinking
     elif "enable_thinking" in _ct_kwargs:


### PR DESCRIPTION
## Summary
Add a `--chat-template-kwargs` CLI flag that sets server-wide default kwargs passed to the chat template on every request. Per-request `chat_template_kwargs` override these defaults. This matches the behavior of **llama.cpp**'s `--chat-template-kwargs` flag.
## Motivation
Reasoning models like Qwen3 default to thinking-enabled mode, which requires every client to explicitly set `enable_thinking: false` per request to suppress it. This is cumbersome for deployments that want thinking off globally — there's currently no server-side knob for arbitrary template kwargs.
## Usage
```bash
vmlx serve model --chat-template-kwargs '{"enable_thinking": false}'
```
Any JSON object is accepted. Per-request `chat_template_kwargs` override matching keys, so individual requests can still opt back in.
## Implementation
- **CLI** (`cli.py`): New `--chat-template-kwargs` argument with JSON validation. If `enable_thinking` is present in the parsed dict, it's also extracted into `_default_enable_thinking` for consistency with the existing `--default-enable-thinking` flag. Shown in the startup banner when configured.
- **Server** (`server.py`): New `_default_chat_template_kwargs` global and `_merge_ct_kwargs()` helper that layers server defaults under per-request overrides. All 4 `_ct_kwargs` resolution points (non-streaming chat completions, streaming chat completions, non-streaming responses, streaming responses) updated to use the merged result.
- **Bug fix**: The two `_suppress` checks for reasoning output (lines ~3362 and ~3891) previously read from `request.chat_template_kwargs` directly, which missed server-wide defaults. Now reads from the merged `_ct_kwargs`, so `--chat-template-kwargs '{"enable_thinking": false}'` correctly suppresses reasoning blocks in responses.