### PR TITLE
fix: add gemma4 to --tool-call-parser argparse choices

### DIFF
--- a/vmlx_engine/cli.py
+++ b/vmlx_engine/cli.py
@@ -1068,6 +1068,7 @@ Examples:
             "functionary",
             "glm47",
             "step3p5",
+            "gemma4",
             # Aliases (map to same parsers)
             "generic",
             "qwen3",


### PR DESCRIPTION
## Summary
- Adds `"gemma4"` to the `--tool-call-parser` argparse choices list in `vmlx_engine/cli.py`

## Problem
The Gemma 4 tool parser (`gemma4_tool_parser.py`) and model config registry entry (`tool_parser="gemma4"`) were added in v1.3.25, but the argparse `choices` list for `--tool-call-parser` was not updated to include `"gemma4"`.

This causes a startup crash when auto-detecting Gemma 4 models:

```
cli.py serve: error: argument --tool-call-parser: invalid choice: 'gemma4'
```

The model config registry auto-applies `tool_parser="gemma4"` for Gemma 4 models, which then gets rejected by argparse before the server can start.

## Fix
One line — add `"gemma4"` to the choices list, alongside the other primary parser names.

Fixes #46