### PR TITLE
fix: capture SSM companion state on every turn (fixes #45)

### DIFF
--- a/vmlx_engine/mllm_batch_generator.py
+++ b/vmlx_engine/mllm_batch_generator.py
@@ -1960,8 +1960,16 @@ class MLLMBatchGenerator:
                 all_logprobs.append(logprobs.squeeze(0))
                 succeeded_requests.append(req)
 
-                # Capture SSM state at prompt boundary for hybrid models
-                if self._is_hybrid and req.prompt_cache is None:
+                # Capture SSM state at prompt boundary for hybrid models.
+                # The SSM advances during generation on every turn, so the
+                # stored state must be refreshed after each prefill, not only
+                # on cache-MISS turns. Gating on `req.prompt_cache is None`
+                # leaves the SSM cache stale after cache-HIT turns, producing
+                # an alternating HIT/MISS pattern on repeated multi-turn
+                # conversations (the next fetch key references a longer token
+                # list that has no matching SSM entry, forcing full prefill).
+                # See https://github.com/jjang-ai/vmlx/issues/45 for repro.
+                if self._is_hybrid:
                     try:
                         kv_set = set(self._hybrid_kv_positions)
                         ssm_layers = []


### PR DESCRIPTION
## Problem

On hybrid MoE+SSM models (Qwen3.5-397B-A17B with MambaCache + KVCache layers), multi-turn conversations with a stable prefix show an alternating MISS/HIT pattern: every other turn falls back to full prefill even though the KV cache has the prefix available.

**Observed impact:** ~220s full-prefill on 33k-token turns that should have been sub-10s cache hits.

See #45 for the detailed repro log.

## Root cause

In `vmlx_engine/mllm_batch_generator.py:1964`, SSM state capture is gated on `req.prompt_cache is None`:

```python
# Capture SSM state at prompt boundary for hybrid models
if self._is_hybrid and req.prompt_cache is None:
    ...
    self._ssm_state_cache.store(all_tokens, prompt_len, ssm_layers)
```

That condition restricts storage to cache-MISS turns only. On cache-HIT turns:

1. SSM state is loaded from the cache (correctly)
2. Generation advances the SSM state (prefilling new user input + generating response)
3. The advanced SSM state is never stored back
4. The next turn's fetch key (longer token list) has no matching SSM entry → MISS → full prefill

## Fix

Remove the `req.prompt_cache is None` guard. Keep the `if self._is_hybrid:` check so non-hybrid models stay on the fast path. Added an inline comment explaining why the guard was removed so it does not get added back.

## Validation

Verified locally on a 512GB Mac Studio running Qwen3.5-122B-A10B-4bit:

- Before: alternating MISS/HIT, turn-3 prefill of 33k tokens at ~226s
- After: consistent HITs on all subsequent turns, turn-3 prefill at ~3-10s
- No regression on non-hybrid models (the outer `_is_hybrid` guard is unchanged)

## Risk

Zero known risk. The branch that stores the SSM state already runs without issue on cache-MISS turns; this PR just lets it run on HIT turns too. The existing try/except inside the block continues to catch any layer-specific serialization failures.

Closes #45