### PR TITLE
fix: Gemma 4 JANG VLM loading — MoE key mismatch + vision float16 overflow

### DIFF
--- a/vmlx_engine/utils/jang_loader.py
+++ b/vmlx_engine/utils/jang_loader.py
@@ -816,6 +816,19 @@ def _load_jang_v2_vlm(path: Path, jang_cfg: dict, lazy: bool = False):
                             except Exception:
                                 continue
 
+        # Gemma 4 MoE: rename switch_mlp.* -> experts.switch_glu.* to match model
+        # model.sanitize() renames model.language_model -> language_model.model but
+        # does NOT rename switch_mlp -> experts.switch_glu, causing all MoE expert
+        # weights to silently fail loading (strict=False) and stay random-init.
+        _renamed = {}
+        for _k, _v in shard_weights.items():
+            if ".switch_mlp." in _k:
+                _new_k = _k.replace(".switch_mlp.", ".experts.switch_glu.")
+                _renamed[_new_k] = _v
+            else:
+                _renamed[_k] = _v
+        shard_weights = _renamed
+
         model.load_weights(list(shard_weights.items()), strict=False)
         del shard_weights
         gc.collect()
@@ -844,6 +857,19 @@ def _load_jang_v2_vlm(path: Path, jang_cfg: dict, lazy: bool = False):
 
     if not lazy:
         _chunked_eval_params(model)
+
+    # Gemma 4 VLM: upcast vision_tower to bfloat16 to prevent float16 overflow.
+    # Vision encoder attention scores can exceed float16 range (±65504) producing
+    # -inf values that propagate through embed_vision as NaN → all-pad output.
+    _text_mt2 = config.get("text_config", {}).get("model_type", "")
+    if _text_mt2 == "gemma4_text":
+        _vt = getattr(model, "vision_tower", None)
+        _ev = getattr(model, "embed_vision", None)
+        if _vt is not None:
+            _vt.set_dtype(mx.bfloat16)
+            logger.info("  Gemma4 vision_tower upcast to bfloat16 (float16 overflow fix)")
+        if _ev is not None:
+            _ev.set_dtype(mx.bfloat16)
 
     # TurboQuant: patch language_model.make_cache for JANG VLM with TQ enabled
     _lang_model = getattr(model, "language_model", None)


### PR DESCRIPTION
## Summary

Two bugs in `_load_jang_v2_vlm()` that break Gemma 4 JANG models:

### Bug 1: MoE expert weights not loaded → garbled text output

`model.sanitize()` renames `model.language_model.*` → `language_model.model.*` but does **not** rename `switch_mlp.*` → `experts.switch_glu.*`. Since `load_weights(strict=False)` silently skips unmatched keys, all 128×30 MoE expert weights stay random-initialized, producing garbage output.

**Fix:** Add `switch_mlp` → `experts.switch_glu` key rename before `load_weights()`.

### Bug 2: Vision produces all `<pad>` tokens → null content for image inputs

Vision tower weights are stored as float16. During attention computation, scores exceed float16 range (±65504), producing `-inf` values. These propagate through `embed_vision` as `NaN`, causing the model to generate only `<pad>` tokens.

**Fix:** Upcast `vision_tower` and `embed_vision` to bfloat16 (range ±3.4e38) after loading.

## Reproduction

```bash
vmlx serve dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK --port 8080

# Bug 1: garbled text
curl http://localhost:8080/v1/chat/completions \
  -d '{"model":"gemma4","messages":[{"role":"user","content":"What is 2+2?"}],"max_tokens":20}'
# Returns random characters instead of "4"

# Bug 2: vision all-pad (after fixing bug 1)
curl http://localhost:8080/v1/chat/completions \
  -d '{"model":"gemma4","messages":[{"role":"user","content":[
    {"type":"text","text":"Describe this image"},
    {"type":"image_url","image_url":{"url":"https://www.baidu.com/img/flexible/logo/pc/result.png"}}
  ]}],"max_tokens":50}'
# Returns content: null (all tokens are <pad>)
```

## Test plan

- [x] Text generation produces correct output after patch 1
- [x] Vision tower output has no `-inf` or `NaN` after patch 2
- [x] Image description returns meaningful content
- [x] Tested on `dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK` with vMLX 1.3.29 on M4 Max 36GB