### PR TITLE
fix: release paged cache block refs on request completion

### DIFF
--- a/vmlx_engine/paged_cache.py
+++ b/vmlx_engine/paged_cache.py
@@ -1112,6 +1112,48 @@ class PagedCacheManager:
         with self._lock:
             self.request_tables.pop(request_id, None)
 
+    def release_request_refs(self, block_table: Optional[BlockTable]) -> int:
+        """Release request-held refs while keeping zero-ref blocks cache-resident.
+
+        This implements "cached but free" semantics:
+        - decrement one ref per block-table entry,
+        - when a block reaches ref_count==0, keep its hash entries intact,
+          but move it to the free LRU queue so memory pressure can reclaim it.
+
+        Returns:
+            Number of blocks that transitioned to ref_count==0.
+        """
+        if block_table is None:
+            return 0
+
+        with self._lock:
+            released = 0
+
+            for block_id in block_table.block_ids:
+                block = self.allocated_blocks.get(block_id)
+                if block is None or block.is_null:
+                    continue
+
+                if block.ref_count <= 0:
+                    logger.warning(
+                        f"release_request_refs: block {block_id} already has "
+                        f"ref_count={block.ref_count}; skipping"
+                    )
+                    continue
+
+                block.ref_count -= 1
+
+                # Keep cache mapping (block_hash/hash_value) so prefix hits can
+                # revive this block, but make it reclaimable via free LRU queue.
+                if block.ref_count == 0:
+                    if block.prev_free_block is None and block.next_free_block is None:
+                        self.free_block_queue.append(block)
+                        self.stats.allocated_blocks = max(0, self.stats.allocated_blocks - 1)
+                        self.stats.free_blocks += 1
+                    released += 1
+
+            return released
+
     def add_block_to_table(
         self,
         table: BlockTable,
@@ -1292,6 +1334,7 @@ class PagedCacheManager:
 
             needed = requested_blocks - self.free_block_queue.num_free_blocks
             self.evict_lru_blocks(needed)
+            self.stats.free_blocks = self.free_block_queue.num_free_blocks
 
             return self.free_block_queue.num_free_blocks >= requested_blocks
 

--- a/vmlx_engine/prefix_cache.py
+++ b/vmlx_engine/prefix_cache.py
@@ -1388,7 +1388,11 @@ class BlockAwarePrefixCache:
             # Allocate new block
             block = self.paged_cache.allocate_block()
             if not block:
-                # Handle memory pressure
+                # First free low-priority entries (assistant -> user -> system)
+                # so their request refs drop and blocks can enter the free LRU queue.
+                self.release_low_priority(1)
+
+                # Then run block-level LRU eviction under memory pressure.
                 if not self.paged_cache.handle_memory_pressure(1):
                     logger.warning(f"Cannot allocate block for {request_id}")
                     break

--- a/vmlx_engine/scheduler.py
+++ b/vmlx_engine/scheduler.py
@@ -2350,9 +2350,14 @@ class Scheduler:
                                     extracted,
                                     cache_type=_l1_type,
                                 )
-                                # Clean up request table entry — blocks persist via LRU
-                                self.block_aware_cache._request_tables.pop(
+                                # Clean up request table entry. Release request refs so
+                                # blocks become "cached but free" (still hash-resident,
+                                # now reclaimable via LRU).
+                                _entry = self.block_aware_cache._request_tables.pop(
                                     request.request_id, None
+                                )
+                                self.block_aware_cache.paged_cache.release_request_refs(
+                                    _entry.block_table if _entry else None
                                 )
                                 self.block_aware_cache.paged_cache.detach_request(
                                     request.request_id
@@ -3138,8 +3143,13 @@ class Scheduler:
 
             # Always clean up paged cache tracking entries regardless of
             # cache skip, to prevent unbounded memory growth on benchmarks.
+            # Release request refs here so completed-request blocks can enter
+            # the free LRU queue while remaining cache-resident.
             if self.block_aware_cache is not None:
-                self.block_aware_cache._request_tables.pop(request_id, None)
+                _entry = self.block_aware_cache._request_tables.pop(request_id, None)
+                self.block_aware_cache.paged_cache.release_request_refs(
+                    _entry.block_table if _entry else None
+                )
                 self.block_aware_cache.paged_cache.detach_request(request_id)
 
             # Hybrid SSM companion state capture.


### PR DESCRIPTION
## Problem

Completed requests never release their block `ref_count`s in the paged cache. Blocks with `ref_count > 0` can never enter the free LRU queue, so:

- `evictions: 0` even at 100% block utilization
- `Cannot allocate block` errors under concurrent sessions
- Unbounded cache growth until OOM or manual restart

Repro: serve 10+ sequential requests with `--enable-prefix-cache --use-paged-cache`. After all complete, `/v1/cache/stats` shows `free_blocks: 0`, `evictions: 0`, `allocated_blocks` at max. New requests fail to allocate.

## Root Cause

`scheduler._cleanup_finished()` calls `detach_request()` which removes the request→table mapping but **never decrements block `ref_count`**. The existing LRU eviction code in `evict_lru_blocks()` only pops from `free_block_queue`, which stays empty because no blocks ever reach `ref_count == 0`.

## Fix

- **`PagedCacheManager.release_request_refs(block_table)`** — new method implementing "cached but free" semantics: decrements one ref per block, and when a block reaches `ref_count == 0`, keeps hash entries intact (prefix cache can still hit) but moves it to the free LRU queue for reclamation under memory pressure.

- **Wired into `_cleanup_finished()`** and the disk-L2 backfill cleanup path so both completion flows release refs.

- **Wired `release_low_priority()`** into the block allocation pressure path (`prefix_cache.py`) before `handle_memory_pressure()`, so priority-based eviction runs before block-level LRU.

- **Stats sync** — `handle_memory_pressure()` now syncs `stats.free_blocks` after eviction.

## Safety

Shared blocks (`ref_count > 1` from overlapping conversation prefixes) are safe: only the completing request's ref is decremented. A block only enters the free queue when ALL referencing requests have completed.

## Testing

Tested on Mac Studio M3 Ultra serving MiniMax-M2.5 (115GB JANG 4-bit) with `--max-cache-blocks 2400 --kv-cache-quantization q4`:

- **16 sequential requests** (~11K tokens each): eviction fires at request 9, flat 37s/request, zero degradation
- **2 concurrent sessions**: both complete, eviction reclaims correctly
- **Cache hits preserved**: "cached but free" blocks still serve prefix matches
- **Shared block safety**: overlapping prefixes don't prematurely free

| Metric | Before | After |
|--------|--------|-------|
| free_blocks after 10 requests | 0 | ~250/request released |
| evictions | 0 (always) | fires at capacity |
| concurrent session failures | Cannot allocate block | clean completion |

3 files changed, 61 insertions(+), 4 deletions(-)