### PR TITLE
Guard default repetition penalty flag for older external engines

### DIFF
--- a/panel/src/main/engine-manager.ts
+++ b/panel/src/main/engine-manager.ts
@@ -101,7 +101,7 @@ export async function checkEngineInstallation(): Promise<EngineInstallation> {
 /**
  * Get version from vmlx-engine binary
  */
-async function getVersionFromBinary(path: string): Promise<string> {
+export async function getVersionFromBinary(path: string): Promise<string> {
   // Get version via Python package metadata (works with editable installs)
   try {
     const { readFileSync } = await import('fs')
@@ -132,6 +132,29 @@ async function getVersionFromBinary(path: string): Promise<string> {
   } catch (_) { /* not supported */ }
 
   return 'unknown'
+}
+
+export function isVersionAtLeast(version: string | undefined, minimum: string): boolean {
+  if (!version) return false
+
+  const parse = (value: string): number[] | null => {
+    const match = value.match(/^(\d+)\.(\d+)\.(\d+)/)
+    if (!match) return null
+    return match.slice(1).map(Number)
+  }
+
+  const current = parse(version)
+  const target = parse(minimum)
+  if (!current || !target) return false
+
+  for (let i = 0; i < Math.max(current.length, target.length); i++) {
+    const a = current[i] ?? 0
+    const b = target[i] ?? 0
+    if (a > b) return true
+    if (a < b) return false
+  }
+
+  return true
 }
 
 /**

--- a/panel/src/main/ipc/developer.ts
+++ b/panel/src/main/ipc/developer.ts
@@ -17,8 +17,8 @@ function buildCliEnv(): Record<string, string | undefined> {
 }
 
 /** Resolve the CLI spawn command + args using the same path as sessions.ts */
-function resolveCliSpawn(subcommandArgs: string[]): { cmd: string; args: string[]; env: Record<string, string | undefined> } {
-  const engineResult = sessionManager.findEnginePath()
+async function resolveCliSpawn(subcommandArgs: string[]): Promise<{ cmd: string; args: string[]; env: Record<string, string | undefined> }> {
+  const engineResult = await sessionManager.findEnginePath()
   const env = buildCliEnv()
   if (engineResult?.type === 'bundled') {
     return {
@@ -58,7 +58,7 @@ function emitComplete(getWin: () => BrowserWindow | null, result: { success: boo
 
 /** Run a quick CLI command that buffers output and returns it. 30s timeout. */
 async function runQuickCommand(subcommand: string, args: string[]): Promise<{ success: boolean; output: string; error?: string }> {
-  const spawn_info = resolveCliSpawn([subcommand, ...args])
+  const spawn_info = await resolveCliSpawn([subcommand, ...args])
   return new Promise((resolve) => {
     const proc = spawn(spawn_info.cmd, spawn_info.args, {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -110,7 +110,7 @@ async function runStreamingCommand(
     return { success: false, error: 'Another operation is already running' }
   }
 
-  const spawn_info = resolveCliSpawn(cliArgs)
+  const spawn_info = await resolveCliSpawn(cliArgs)
   cancelled = false
   bufferedLogLines = []  // Clear previous buffer
 

--- a/panel/src/main/server.ts
+++ b/panel/src/main/server.ts
@@ -83,6 +83,7 @@ export interface ServerConfig {
   // Generation defaults
   defaultTemperature?: number
   defaultTopP?: number
+  defaultRepetitionPenalty?: number
 
   // Embedding model (separate from main model)
   embeddingModel?: string

--- a/panel/src/main/sessions.ts
+++ b/panel/src/main/sessions.ts
@@ -12,12 +12,14 @@ import { db, Session } from './database'
 export type { ServerConfig, DetectedProcess } from './server'
 import type { ServerConfig, DetectedProcess } from './server'
 import { detectModelConfigFromDir } from './model-config-registry'
-import { getBundledPythonPath } from './engine-manager'
+import { getBundledPythonPath, getVersionFromBinary, isVersionAtLeast } from './engine-manager'
 
 /** Result of findEnginePath: either bundled Python or a system binary */
 type EnginePath =
-  | { type: 'bundled'; pythonPath: string }
-  | { type: 'system'; binaryPath: string }
+  | { type: 'bundled'; pythonPath: string; version: string }
+  | { type: 'system'; binaryPath: string; version: string }
+
+const DEFAULT_REPETITION_PENALTY_MIN_VERSION = '1.3.37'
 
 interface ManagedProcess {
   process: ChildProcess | null
@@ -485,7 +487,7 @@ export class SessionManager extends EventEmitter {
     if (modelSettings?.reasoning_mode === 'on') config.defaultEnableThinking = true
     else if (modelSettings?.reasoning_mode === 'off') config.defaultEnableThinking = false
 
-    const engineResult = this.findEnginePath()
+    const engineResult = await this.findEnginePath()
     if (!engineResult) throw new Error('vmlx-engine not found. Please install it first.')
 
     // Image models may use mflux named models (e.g., "schnell") that are NOT filesystem paths
@@ -593,7 +595,21 @@ export class SessionManager extends EventEmitter {
     this.loadProgressState.delete(sessionId) // Reset loading progress for fresh start
     this.emit('session:starting', { sessionId, modelPath: session.modelPath })
 
-    const args = this.buildArgs(config)
+    const supportsDefaultRepetitionPenalty =
+      engineResult.type === 'bundled' ||
+      isVersionAtLeast(engineResult.version, DEFAULT_REPETITION_PENALTY_MIN_VERSION)
+
+    if (config.defaultRepetitionPenalty != null && config.defaultRepetitionPenalty > 0 && !supportsDefaultRepetitionPenalty) {
+      const versionLabel = engineResult.version === 'unknown'
+        ? 'an older or unknown external vmlx-engine build'
+        : `vmlx-engine ${engineResult.version}`
+      this.pushLog(
+        sessionId,
+        `[INFO] ${versionLabel} does not support --default-repetition-penalty yet. Starting without that default. Upgrade to v${DEFAULT_REPETITION_PENALTY_MIN_VERSION} or newer to enable it.`
+      )
+    }
+
+    const args = this.buildArgs(config, { supportsDefaultRepetitionPenalty })
 
     // Ensure PATH includes pyenv/homebrew so the engine finds its Python
     const extraPath = [
@@ -1671,9 +1687,13 @@ export class SessionManager extends EventEmitter {
 
   // ─── Helpers (from ServerManager) ──────────────────────────────────
 
-  buildArgs(config: ServerConfig): string[] {
+  buildArgs(
+    config: ServerConfig,
+    options: { supportsDefaultRepetitionPenalty?: boolean } = {}
+  ): string[] {
     const args = ['serve', config.modelPath]
     const isImage = config.modelType === 'image'
+    const supportsDefaultRepetitionPenalty = options.supportsDefaultRepetitionPenalty ?? true
 
     // Server settings — always pass explicitly (both text and image)
     args.push('--host', config.host)
@@ -1950,8 +1970,8 @@ export class SessionManager extends EventEmitter {
     // (slider convention matching temp/top-p). Default 110 = 1.10, which
     // prevents Gemma 4 word-loops and 2-bit quant dash-loops on external
     // API clients (Ollama, OpenAI SDK, Anthropic SDK, raw curl).
-    if ((config as any).defaultRepetitionPenalty != null && (config as any).defaultRepetitionPenalty > 0) {
-      args.push('--default-repetition-penalty', ((config as any).defaultRepetitionPenalty / 100).toFixed(2))
+    if (supportsDefaultRepetitionPenalty && config.defaultRepetitionPenalty != null && config.defaultRepetitionPenalty > 0) {
+      args.push('--default-repetition-penalty', (config.defaultRepetitionPenalty / 100).toFixed(2))
     }
 
     // Embedding model
@@ -1994,18 +2014,18 @@ export class SessionManager extends EventEmitter {
     return args
   }
 
-  findEnginePath(): EnginePath | null {
+  async findEnginePath(): Promise<EnginePath | null> {
     // Bundled Python: use python3 -m vmlx_engine.cli instead of vmlx-engine binary
     // This avoids shebang path issues in relocatable Python builds
     const bundledPython = getBundledPythonPath()
     if (bundledPython) {
       try {
-        execSync(`"${bundledPython}" -s -c "import vmlx_engine"`, {
+        const version = execSync(`"${bundledPython}" -s -c "import vmlx_engine; print(getattr(vmlx_engine, '__version__', 'unknown'))"`, {
           encoding: 'utf-8',
           timeout: 10000,
           env: { ...process.env, PYTHONNOUSERSITE: '1', PYTHONPATH: '' },
-        })
-        return { type: 'bundled', pythonPath: bundledPython }
+        }).trim() || 'unknown'
+        return { type: 'bundled', pythonPath: bundledPython, version }
       } catch (_) {
         console.log('[SESSIONS] Bundled Python found but vmlx_engine import failed, trying system')
       }
@@ -2034,7 +2054,9 @@ export class SessionManager extends EventEmitter {
     } catch (_) { }
 
     for (const loc of locations) {
-      if (existsSync(loc)) return { type: 'system', binaryPath: loc }
+      if (existsSync(loc)) {
+        return { type: 'system', binaryPath: loc, version: await getVersionFromBinary(loc) }
+      }
     }
 
     // Fallback: check PATH via login shell (picks up pyenv, nvm, etc.)
@@ -2044,14 +2066,18 @@ export class SessionManager extends EventEmitter {
           `${shell} -lc "which vmlx-engine"`,
           { encoding: 'utf-8', timeout: 5000 }
         ).trim()
-        if (result && existsSync(result)) return { type: 'system', binaryPath: result }
+        if (result && existsSync(result)) {
+          return { type: 'system', binaryPath: result, version: await getVersionFromBinary(result) }
+        }
       } catch (_) { }
     }
 
     // Last resort: plain which
     try {
       const result = execSync('which vmlx-engine', { encoding: 'utf-8', timeout: 3000 }).trim()
-      if (result && existsSync(result)) return { type: 'system', binaryPath: result }
+      if (result && existsSync(result)) {
+        return { type: 'system', binaryPath: result, version: await getVersionFromBinary(result) }
+      }
     } catch (_) { }
 
     // Development fallback: project .venv relative to source directory
@@ -2060,13 +2086,13 @@ export class SessionManager extends EventEmitter {
       const venvPython = join(sourceDir, '.venv', 'bin', 'python3')
       if (existsSync(venvPython)) {
         try {
-          execFileSync(venvPython, ['-s', '-c', 'import vmlx_engine'], {
+          const version = execFileSync(venvPython, ['-s', '-c', "import vmlx_engine; print(getattr(vmlx_engine, '__version__', 'unknown'))"], {
             encoding: 'utf-8',
             timeout: 10000,
             env: { ...process.env, PYTHONNOUSERSITE: '1', PYTHONPATH: '' },
-          })
+          }).trim() || 'unknown'
           console.log(`[SESSIONS] Using project venv: ${venvPython}`)
-          return { type: 'bundled', pythonPath: venvPython }
+          return { type: 'bundled', pythonPath: venvPython, version }
         } catch (_) { }
       }
     } catch (_) { }

--- a/panel/tests/settings-flow.test.ts
+++ b/panel/tests/settings-flow.test.ts
@@ -50,6 +50,7 @@ interface SessionConfig {
     numDraftTokens: number
     defaultTemperature: number
     defaultTopP: number
+    defaultRepetitionPenalty: number
     embeddingModel: string
     additionalArgs: string
     enableJit: boolean
@@ -97,6 +98,7 @@ const DEFAULT_CONFIG: SessionConfig = {
     numDraftTokens: 3,
     defaultTemperature: 0,
     defaultTopP: 0,
+    defaultRepetitionPenalty: 110,
     embeddingModel: '',
     additionalArgs: '',
     enableJit: false,
@@ -120,10 +122,12 @@ type DetectedConfig = {
 function buildCommandPreview(
     modelPath: string,
     config: SessionConfig,
-    detected?: DetectedConfig
+    detected?: DetectedConfig,
+    options: { supportsDefaultRepetitionPenalty?: boolean } = {}
 ): string {
     const parts = ['vmlx-engine serve', modelPath]
     const isVLM = config.isMultimodal ?? !!detected?.isMultimodal
+    const supportsDefaultRepetitionPenalty = options.supportsDefaultRepetitionPenalty ?? true
 
     parts.push('--host', config.host)
     parts.push('--port', config.port.toString())
@@ -233,6 +237,9 @@ function buildCommandPreview(
     if (config.defaultTopP && config.defaultTopP > 0) {
         parts.push('--default-top-p', (config.defaultTopP / 100).toFixed(2))
     }
+    if (supportsDefaultRepetitionPenalty && config.defaultRepetitionPenalty > 0) {
+        parts.push('--default-repetition-penalty', (config.defaultRepetitionPenalty / 100).toFixed(2))
+    }
 
     // Embedding model
     if (config.embeddingModel) parts.push('--embedding-model', config.embeddingModel)
@@ -255,8 +262,12 @@ function buildCommandPreview(
 
 // ─── Helper ──────────────────────────────────────────────────────────────────
 
-function preview(overrides: Partial<SessionConfig> = {}, detected?: DetectedConfig): string {
-    return buildCommandPreview('/models/test-model', { ...DEFAULT_CONFIG, ...overrides }, detected)
+function preview(
+    overrides: Partial<SessionConfig> = {},
+    detected?: DetectedConfig,
+    options?: { supportsDefaultRepetitionPenalty?: boolean }
+): string {
+    return buildCommandPreview('/models/test-model', { ...DEFAULT_CONFIG, ...overrides }, detected, options)
 }
 
 function hasFlag(output: string, flag: string): boolean {
@@ -730,6 +741,20 @@ describe('Generation Defaults', () => {
         const out = preview({ defaultTopP: 100 })
         expect(getFlagValue(out, '--default-top-p')).toBe('1.00')
     })
+
+    it('sets default repetition penalty (converted from ×100 integer)', () => {
+        const out = preview({ defaultRepetitionPenalty: 110 })
+        expect(getFlagValue(out, '--default-repetition-penalty')).toBe('1.10')
+    })
+
+    it('omits default repetition penalty for older external engines', () => {
+        const out = preview(
+            { defaultRepetitionPenalty: 110 },
+            undefined,
+            { supportsDefaultRepetitionPenalty: false }
+        )
+        expect(hasFlag(out, '--default-repetition-penalty')).toBe(false)
+    })
 })
 
 describe('Embedding Model', () => {
@@ -874,6 +899,7 @@ describe('Default IP and New Settings', () => {
         expect(DEFAULT_CONFIG.corsOrigins).toBe('*')
         expect(DEFAULT_CONFIG.maxContextLength).toBe(0)
         expect(DEFAULT_CONFIG.enableJit).toBe(false)
+        expect(DEFAULT_CONFIG.defaultRepetitionPenalty).toBe(110)
     })
 })
 
@@ -999,6 +1025,7 @@ describe('Feature Interaction', () => {
         expect(hasFlag(out, '--num-draft-tokens')).toBe(false)
         expect(hasFlag(out, '--default-temperature')).toBe(false)
         expect(hasFlag(out, '--default-top-p')).toBe(false)
+        expect(getFlagValue(out, '--default-repetition-penalty')).toBe('1.10')
         expect(hasFlag(out, '--embedding-model')).toBe(false)
         expect(hasFlag(out, '--served-model-name')).toBe(false)
     })
@@ -1244,7 +1271,7 @@ describe('Settings → CLI Round-Trip Completeness', () => {
         'mcpConfig', 'enableAutoToolChoice', 'toolCallParser', 'reasoningParser',
         'isMultimodal', 'servedModelName',
         'speculativeModel', 'numDraftTokens',
-        'defaultTemperature', 'defaultTopP',
+        'defaultTemperature', 'defaultTopP', 'defaultRepetitionPenalty',
         'embeddingModel', 'additionalArgs',
         'enableJit', 'logLevel', 'corsOrigins', 'maxContextLength',
     ]
@@ -1293,6 +1320,7 @@ describe('Settings → CLI Round-Trip Completeness', () => {
         expect(normalized).toContain('--max-tokens')
         expect(normalized).toContain('--continuous-batching')
         expect(normalized).toContain('--use-paged-cache')
+        expect(normalized).toContain('--default-repetition-penalty')
     })
 
     it('mutual exclusion: disk cache NOT emitted when paged cache is active', () => {


### PR DESCRIPTION
Fixes #75

## Summary
- detect the resolved local engine version before building session launch args
- omit `--default-repetition-penalty` when the app is launching an older external `vmlx-engine` that predates that CLI flag
- log a clear upgrade hint instead of hard-failing session startup
- keep bundled/project-venv engines on the current behavior
- update the settings-flow test mirror to cover the real default repetition penalty and the legacy-engine compatibility path

## Verification
- `npm test -- settings-flow.test.ts`
- `npm run typecheck` *(currently still fails on the pre-existing renderer typing error at `panel/src/renderer/src/components/sessions/SessionConfigForm.tsx:937`)*