### PR TITLE
fix: gracefully handle pixel_values TypeError for text-only Gemma 4 models

### DIFF
--- a/vmlx_engine/engine/batched.py
+++ b/vmlx_engine/engine/batched.py
@@ -59,7 +59,17 @@ class MLLMModelWrapper:
         if self._inject_pixel_values and "pixel_values" not in kwargs:
             kwargs["pixel_values"] = None
 
-        output = self._model(*args, **kwargs)
+        try:
+            output = self._model(*args, **kwargs)
+        except TypeError as e:
+            if "pixel_values" in str(e) and self._inject_pixel_values:
+                # Model doesn't accept pixel_values (e.g., text-only Gemma 4
+                # with model_type="gemma4") — disable injection permanently.
+                self._inject_pixel_values = False
+                kwargs.pop("pixel_values", None)
+                output = self._model(*args, **kwargs)
+            else:
+                raise
         # If output has logits attribute, return just the logits
         if hasattr(output, "logits"):
             return output.logits


### PR DESCRIPTION
## Summary

- Text-only Gemma 4 models (e.g., `Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2`) have `model_type="gemma4"` in `config.json` but do **not** accept `pixel_values`
- The fallback heuristic in `MLLMModelWrapper.__init__` detects `"gemma4"` in `model_type` and enables `pixel_values` injection, causing a `TypeError` crash in continuous-batching mode
- This PR adds a self-healing `try/except` in `__call__`: on the first `pixel_values` TypeError, it permanently disables injection and retries — all subsequent calls work without overhead

## Reproducer

```bash
vmlx serve Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2 \
  --continuous-batching
```

**Before:** Every request fails with `[Engine error: Model.__call__() got an unexpected keyword argument 'pixel_values']`, retries 3 times, then crashes the engine loop.

**After:** First request auto-detects text-only model, disables `pixel_values` injection for the session, and all subsequent requests work normally.

## Root cause

The `model_config_registry.lookup()` receives a HuggingFace model name (e.g., `Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2`) and tries to read `config.json` from the relative path — which doesn't exist (the model is in the HF cache). It falls back to the `"unknown"` config, and the fallback heuristic at line 47-53 then checks `model.model_type == "gemma4"` and enables `pixel_values` injection, even though the model is text-only (`text_config.model_type="gemma4_text"`, `is_mllm=False`).

## Test plan

- [x] Verified `vmlx serve` with `--continuous-batching` on `Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2` — requests succeed after patch
- [x] VLM models with `inject_pixel_values: True` in registry are unaffected (injection still happens, no TypeError)
- [x] Change is minimal and backward-compatible — only catches the specific `pixel_values` TypeError