### PR TITLE
feat: opt-in chunked prefill for hybrid SSM models via VMLX_ALLOW_HYBRID_CHUNKED_PREFILL

### DIFF
--- a/vmlx_engine/mllm_batch_generator.py
+++ b/vmlx_engine/mllm_batch_generator.py
@@ -98,6 +98,7 @@ HELPER FUNCTIONS
 """
 
 import logging
+import os
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -1040,6 +1041,28 @@ class MLLMBatchGenerator:
             and len(self._hybrid_kv_positions) < self._hybrid_num_layers
         )
 
+        # Opt-in: enable chunked prefill for hybrid SSM models on text-only
+        # requests. Default OFF preserves the conservative single-shot path.
+        # When enabled, long text-only prompts (>~34K tokens) avoid the Metal
+        # single-buffer OOM from full-sequence attention scores:
+        #   (1, num_heads, seq_len, seq_len) * 2 bytes exceeds 72 GB at
+        #   seq_len >~ 34K on M3 Max 128 GB (72 GB = Metal's per-buffer cap).
+        # Verified safe for Qwen3.5 (GatedDeltaNet + attention): its
+        # create_attention_mask / create_ssm_mask in mlx_lm are cache-aware
+        # and produce correct masks for any chunk size, and both KVCache and
+        # ArraysCache carry state across chunks via mx.eval() at each step.
+        # Other hybrid architectures are not verified — hence opt-in.
+        self._allow_hybrid_chunked_prefill: bool = os.environ.get(
+            "VMLX_ALLOW_HYBRID_CHUNKED_PREFILL", "0"
+        ).lower() in ("1", "true", "yes", "on")
+        if self._is_hybrid and self._allow_hybrid_chunked_prefill:
+            logger.info(
+                "MLLMBatchGenerator: VMLX_ALLOW_HYBRID_CHUNKED_PREFILL=1 — "
+                "chunked prefill enabled for this hybrid SSM model on "
+                "text-only requests. Verified safe for Qwen3.5; other hybrid "
+                "architectures are unverified."
+            )
+
         # Vision embedding cache for repeated images
         self.vision_cache = VisionEmbeddingCache(
             max_pixel_entries=vision_cache_size,
@@ -1424,8 +1447,13 @@ class MLLMBatchGenerator:
         # The VLM wrapper adds overhead from vision encoder path and some VLM
         # wrappers (e.g. Gemma 4 loaded via smelt) may not accept pixel_values.
         # Using language_model directly avoids this entirely.
-        # Hybrid SSM models must go through the full model for correct mask computation.
-        if not has_images and not self._is_hybrid:
+        # Hybrid SSM models default to the full model for correct mask computation.
+        # Users with known-safe hybrid models (e.g. Qwen3.5) can opt in via
+        # VMLX_ALLOW_HYBRID_CHUNKED_PREFILL=1 — see __init__ for details.
+        _skip_hybrid_chunked = (
+            self._is_hybrid and not self._allow_hybrid_chunked_prefill
+        )
+        if not has_images and not _skip_hybrid_chunked:
             lm = getattr(self.model, 'language_model', None)
             if lm is not None and cache is not None:
                 if seq_len <= self.prefill_step_size * 2:
@@ -1438,10 +1466,12 @@ class MLLMBatchGenerator:
 
         # Chunked prefill for text-only VLM requests with long prompts.
         # Image requests must run in one shot (vision encoder needs full sequence).
-        # Hybrid SSM models (GatedDeltaNet/Mamba + attention) must run in one shot
+        # Hybrid SSM models (GatedDeltaNet/Mamba + attention) default to single-shot
         # because the language_model's forward pass computes masks from specific
-        # cache positions (fa_idx/ssm_idx) that assume full-sequence processing.
-        if not has_images and seq_len > self.prefill_step_size * 2 and not self._is_hybrid:
+        # cache positions (fa_idx/ssm_idx) — verified safe to chunk for Qwen3.5
+        # (cache-aware mask creation) but not universally verified.
+        # Opt in via VMLX_ALLOW_HYBRID_CHUNKED_PREFILL=1 — see __init__ for details.
+        if not has_images and seq_len > self.prefill_step_size * 2 and not _skip_hybrid_chunked:
             # Use language_model directly for chunked text prefill
             lm = getattr(self.model, 'language_model', None)
             if lm is not None and cache is not None:


### PR DESCRIPTION
Fixes #89.

## Summary

Adds an opt-in env var `VMLX_ALLOW_HYBRID_CHUNKED_PREFILL=1` that allows hybrid SSM models (GatedDeltaNet/Mamba + attention) to use chunked prefill on text-only requests. Default remains OFF — no behavior change for existing users.

## Why

Without chunked prefill, hybrid models run full-sequence attention, which allocates `(1, num_heads, seq_len, seq_len) * 2 bytes` of attention scores. On M3 Max 128 GB this exceeds Metal's ~72 GiB per-buffer cap at seq_len ≈ 34K (Qwen3.5 27B hits `kIOGPUCommandBufferCallbackErrorOutOfMemory` around seq_len ≈ 48K).

See #89 for full repro + memory math.

## Changes

One file, `vmlx_engine/mllm_batch_generator.py`:

1. `import os`.
2. In `MLLMBatchGenerator.__init__`, read `VMLX_ALLOW_HYBRID_CHUNKED_PREFILL` into `self._allow_hybrid_chunked_prefill` and log an INFO line when enabled on a hybrid model.
3. Both prefill guards (L1428 fast path, L1444 chunked path) now skip hybrid only when the flag is NOT set. Diff stat: `1 file changed, 35 insertions(+), 5 deletions(-)`.

## Safety

Chunked prefill is safe for Qwen3.5 hybrid:

- `mlx_lm/models/qwen3_5.py` uses cache-aware `create_attention_mask` / `create_ssm_mask` that delegate to `cache.make_mask(N)` — correct for any chunk size.
- Both `KVCache` and `ArraysCache` expose `state` properties that carry across chunks.
- vmlx already `mx.eval`s cache state between chunks.

Other hybrid architectures are unverified — that's why this is opt-in rather than an unconditional guard removal.

## Test plan

- [x] Syntax: `python3 -m py_compile vmlx_engine/mllm_batch_generator.py`
- [x] Default (flag unset): hybrid models go through single-shot path unchanged
- [x] Flag set: Qwen3.5 27B with a 48K-token text-only prompt completes without Metal OOM; prefill chunks at `prefill_step_size` (512)
- [x] Flag set: VLM requests with images still run in one shot (vision encoder needs full sequence)
- [x] Non-hybrid models unaffected (`self._is_hybrid=False` short-circuits regardless of flag)

Happy to adjust the flag name, default, or gating strategy (e.g. allowlist by model architecture) based on review.