### PR TITLE
chore(scheduler): prefer top-level mx.* memory API over deprecated mx.metal.* (#94)

### DIFF
--- a/tests/test_scheduler_mx_metal_deprecation.py
+++ b/tests/test_scheduler_mx_metal_deprecation.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression test for vmlx#94 — scheduler.py's memory-pressure guard in
+`_schedule_waiting` must prefer the top-level `mx.get_active_memory` /
+`mx.device_info` API over the deprecated `mx.metal.*` aliases when the
+top-level one exists, but still fall through to `mx.metal.*` on older
+MLX builds where the top-level API isn't present.
+"""
+
+import importlib
+import warnings
+
+import pytest
+
+
+class TestMxMetalDeprecationCleanup:
+    """vmlx#94 — scheduler memory-pressure guard uses non-deprecated API."""
+
+    def test_no_deprecation_warning_on_current_mlx(self):
+        """On MLX ≥ 0.31, calling the guard path must not emit
+        DeprecationWarning from `mx.metal.get_active_memory`."""
+        mx = pytest.importorskip("mlx.core")
+        if not hasattr(mx, "get_active_memory"):
+            pytest.skip("MLX too old to test top-level API preference")
+
+        # Replay the scheduler's exact lookup pattern and assert no
+        # DeprecationWarning fires.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+
+            _get_active = getattr(mx, "get_active_memory", None) or mx.metal.get_active_memory
+            _device_info = getattr(mx, "device_info", None) or mx.metal.device_info
+
+            # These calls would raise if they resolved to the deprecated alias.
+            _ = _get_active()
+            _ = _device_info()
+
+    def test_fallback_to_mx_metal_on_old_mlx(self, monkeypatch):
+        """On older MLX (no top-level `mx.get_active_memory`), the lookup
+        must fall through to `mx.metal.get_active_memory`. Simulate the
+        old-MLX shape by stripping the top-level attribute."""
+        mx = pytest.importorskip("mlx.core")
+
+        # Force the lookup to miss the top-level attribute.
+        monkeypatch.delattr(mx, "get_active_memory", raising=False)
+        monkeypatch.delattr(mx, "device_info", raising=False)
+
+        # The scheduler's lookup should still resolve something callable
+        # via the `mx.metal.*` fallback — no AttributeError.
+        _get_active = getattr(mx, "get_active_memory", None) or mx.metal.get_active_memory
+        _device_info = getattr(mx, "device_info", None) or mx.metal.device_info
+
+        assert callable(_get_active)
+        assert callable(_device_info)
+
+    def test_scheduler_module_imports_cleanly(self):
+        """Importing the scheduler module must not emit any DeprecationWarning
+        from the memory-pressure guard (the guard runs inside a function, not
+        at import time, but this pins that invariant)."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            # Force a fresh import so we catch any top-of-module side effects.
+            import vmlx_engine.scheduler  # noqa: F401
+
+            # Re-import to flush any caching.
+            importlib.reload(vmlx_engine.scheduler)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vmlx_engine/scheduler.py
+++ b/vmlx_engine/scheduler.py
@@ -2674,9 +2674,13 @@ class Scheduler:
             try:
                 import mlx.core as mx
 
-                active_mem = mx.metal.get_active_memory()
+                # Use top-level API (mx.*) when available, fall back to the
+                # deprecated mx.metal.* aliases for older MLX — vmlx#94.
+                _get_active = getattr(mx, "get_active_memory", None) or mx.metal.get_active_memory
+                _device_info = getattr(mx, "device_info", None) or mx.metal.device_info
+                active_mem = _get_active()
                 if active_mem > 0 and len(self.running) > 0:
-                    max_mem = mx.metal.device_info().get(
+                    max_mem = _device_info().get(
                         "max_recommended_working_set_size", 0
                     )
                     if max_mem > 0 and active_mem / max_mem > 0.85:


### PR DESCRIPTION
## Summary

Fixes #94.

MLX 0.31 emits:

\`\`\`
DeprecationWarning: mx.metal.get_active_memory is deprecated and will be removed
in a future version. Use mx.get_active_memory instead.
\`\`\`

The memory-pressure guard in \`Scheduler._schedule_waiting\` called \`mx.metal.get_active_memory()\` and \`mx.metal.device_info()\` bare — the only remaining bare call sites in \`vmlx_engine/\`. Other modules (\`mllm_batch_generator.py\`, \`server.py\`, \`benchmark.py\`) already use the \`getattr(mx, \"X\", None) or mx.metal.X\` fallback pattern that's been used consistently since the partial cleanup noted in CHANGELOG.md line 173.

This PR applies the same pattern here so current MLX resolves to the top-level API while older MLX still works via the metal alias.

## Diff

Two lines replaced inside the existing \`try/except\` block:

\`\`\`python
# Use top-level API (mx.*) when available, fall back to the
# deprecated mx.metal.* aliases for older MLX — vmlx#94.
_get_active = getattr(mx, \"get_active_memory\", None) or mx.metal.get_active_memory
_device_info = getattr(mx, \"device_info\", None) or mx.metal.device_info
active_mem = _get_active()
# ...
max_mem = _device_info().get(\"max_recommended_working_set_size\", 0)
\`\`\`

## Test plan

New: \`tests/test_scheduler_mx_metal_deprecation.py\` — 3 cases
- [x] \`test_no_deprecation_warning_on_current_mlx\` — replays the exact lookup pattern under \`warnings.simplefilter(\"error\", DeprecationWarning)\` and asserts it doesn't trip
- [x] \`test_fallback_to_mx_metal_on_old_mlx\` — uses \`monkeypatch.delattr\` to simulate older-MLX shape and confirms the \`mx.metal.*\` fallback resolves a callable
- [x] \`test_scheduler_module_imports_cleanly\` — pins the invariant that importing \`vmlx_engine.scheduler\` raises no \`DeprecationWarning\`

Regressions:
- [x] All 51 tests in \`tests/test_speculative.py\` still pass
- [x] PLD guard tests (\`tests/test_pld_non_mllm_guard.py\`, #93) still pass

## Risk / scope

- Pure API-name cleanup, no behavior change
- The fallback branch (\`mx.metal.*\`) is preserved for older MLX
- The surrounding \`try/except Exception: pass\` block (\"Metal API not available — skip check\") continues to catch any lookup or call failure
- No new dependencies