### PR TITLE
Fix opencode config error by moving _mlxstudio marker to options

### DIFF
--- a/panel/src/main/ipc/coding-tools.ts
+++ b/panel/src/main/ipc/coding-tools.ts
@@ -177,7 +177,7 @@ const openCode: ToolConfig = {
     const cfg = safeReadJSON(join(homedir(), '.config', 'opencode', 'opencode.json'))
     if (!cfg?.provider) return []
     return Object.entries(cfg.provider)
-      .filter(([_, v]: any) => v?.[MLXSTUDIO_TAG])
+      .filter(([_, v]: any) => v?.[MLXSTUDIO_TAG] || (v as any)?.options?.[MLXSTUDIO_TAG])
       .map(([k, v]: any) => ({ label: k, baseUrl: (v as any)?.options?.baseURL || '' }))
   },
   addEntry: (baseUrl, modelName) => {
@@ -188,7 +188,10 @@ const openCode: ToolConfig = {
     cfg.provider[key] = {
       npm: '@ai-sdk/openai-compatible',
       name: `MLX Studio (${modelName})`,
-      options: { baseURL: `${baseUrl}/v1` },
+      options: {
+        baseURL: `${baseUrl}/v1`,
+        [MLXSTUDIO_TAG]: true,
+      },
       models: {
         [modelName]: {
           name: modelName,
@@ -196,7 +199,6 @@ const openCode: ToolConfig = {
           modalities: { input: ['text'], output: ['text'] },
         },
       },
-      [MLXSTUDIO_TAG]: true,
     }
     safeWriteJSON(path, cfg)
   },


### PR DESCRIPTION
The _mlxstudio marker was being placed at the top level of the provider object in opencode.json, which caused opencode to fail with a validation error (Unrecognized key). This PR moves it inside the options object and updates getEntries for backward compatibility.