### PR TITLE
fix(scheduler): gate deferred SSM re-derive on empty waiting queue (vmlx#103)

### DIFF
--- a/vmlx_engine/scheduler.py
+++ b/vmlx_engine/scheduler.py
@@ -4594,17 +4594,20 @@ class Scheduler:
         # ── Deferred SSM re-derive (idle-time processing) ──
         # For thinking models (gen_prompt_len > 0), the SSM companion store
         # queues a re-derive task instead of skipping entirely. We run the
-        # re-derive here ONLY when the scheduler is idle (no running
-        # requests) — the forward pass uses the Metal GPU so it can't
-        # overlap with active generation. The re-derive runs a separate
-        # prefill pass on just the prompt tokens (no thinking/output
-        # contamination) and stores the clean SSM state for future prefix
-        # cache hits. This means the CURRENT conversation pays full
-        # re-prefill on each turn, but the NEXT conversation with the
+        # re-derive here ONLY when the scheduler is fully idle (no running
+        # AND no queued-waiting requests) — the forward pass uses the Metal
+        # GPU so it can't overlap with active generation, and `self.waiting`
+        # must also be empty so we don't steal TTFT from interactive requests
+        # that just landed on the admission queue (vmlx#103). The re-derive
+        # runs a separate prefill pass on just the prompt tokens (no
+        # thinking/output contamination) and stores the clean SSM state for
+        # future prefix cache hits. This means the CURRENT conversation pays
+        # full re-prefill on each turn, but the NEXT conversation with the
         # same prompt prefix gets an instant KV+SSM cache hit.
         if (
             self._is_hybrid
             and not self.running
+            and not self.waiting
             and hasattr(self, "_ssm_rederive_queue")
             and self._ssm_rederive_queue
             and self._ssm_state_cache is not None


### PR DESCRIPTION
## Summary

Closes #103. The deferred SSM re-derive loop at `vmlx_engine/scheduler.py:4605-4611` only guarded on `not self.running`, so any request sitting in `self.waiting` (FCFS admission queue) paid a full re-derive prefill's worth of TTFT for every queued item in `_ssm_rederive_queue` before being admitted to generation.

This one-line fix adds `and not self.waiting` to the gate so re-derive runs only when the engine is *fully* idle — no generating requests **and** no queued admissions.

## Why this is safe

Re-derive is opportunistic by design — it trades current-turn latency for next-turn cache warmth on hybrid SSM models. The change only **narrows** the condition under which an optional background task runs; it never blocks a user-visible operation and never changes generation output.

- Throughput on a busy engine: unchanged (queue never met the gate)
- Throughput on a drained engine: unchanged (queue drains as before, just one step later when a new request happens to arrive)
- Latency for a request arriving on an idle engine with queued re-derives: eliminates N × re-derive TTFT penalty

## Test plan

- [x] Read verified against `upstream/main` tip `fa1fdb8` — `self.waiting` confirmed as `deque[Request]` at `scheduler.py:268` with admission at `scheduler.py:2768`
- [ ] Reproduction on hybrid model (Qwen3.6 A3B or Qwen3.5 GatedDeltaNet): warm `_ssm_rederive_queue` with ≥5 items, drain `running`, submit new request, measure TTFT before/after patch
- [ ] Existing hybrid SSM regression tests (`tests/test_vl_video_regression.py`, `tests/test_jit_toggle.py`) pass unchanged

## Notes for review

- Follow-up candidate (not in this PR): reconsider `_ssm_rederive_queue_max = 20` — with this gate the queue still drains, but an unbounded queue can hold memory proportional to prompt length × queue size. Current cap looks fine.
- Related recent work: v1.3.84 fixed a different re-derive bug (broadcast-shape mismatch on auto-chunked prefill). This PR is independent and composes cleanly.