### PR TITLE
chore(ssm): drop redundant `mx.array()` wrap before `mx.contiguous` (vmlx#105)

### DIFF
--- a/vmlx_engine/mllm_batch_generator.py
+++ b/vmlx_engine/mllm_batch_generator.py
@@ -2308,7 +2308,7 @@ class MLLMBatchGenerator:
                                     cloned = deepcopy(c)
                                     # Ensure MLX arrays are fully materialized copies
                                     cloned.cache = [
-                                        mx.contiguous(mx.array(a)) if a is not None else None
+                                        mx.contiguous(a) if a is not None else None
                                         for a in c.cache
                                     ]
                                     ssm_layers.append(cloned)
@@ -2935,7 +2935,7 @@ class MLLMBatchGenerator:
                     from copy import deepcopy
                     cloned = deepcopy(c)
                     cloned.cache = [
-                        mx.contiguous(mx.array(a)) if a is not None else None
+                        mx.contiguous(a) if a is not None else None
                         for a in c.cache
                     ]
                     ssm_layers.append(cloned)

--- a/vmlx_engine/scheduler.py
+++ b/vmlx_engine/scheduler.py
@@ -4630,9 +4630,7 @@ class Scheduler:
 
                                 cloned = deepcopy(c)
                                 cloned.cache = [
-                                    mx.contiguous(mx.array(a))
-                                    if a is not None
-                                    else None
+                                    mx.contiguous(a) if a is not None else None
                                     for a in c.cache
                                 ]
                                 ssm_layers.append(cloned)


### PR DESCRIPTION
## Summary

Closes #105. Three SSM-companion cache-clone sites wrap `a in c.cache` with `mx.array()` before passing it to `mx.contiguous()`. Since `c.cache` is typed `List[mx.array]` and `mx.array(existing_mx_array)` is a no-op, the outer wrap is pure noise. This PR simplifies all three sites to `mx.contiguous(a) if a is not None else None`.

## Changed sites

| File | Line | Context |
|---|---|---|
| `vmlx_engine/scheduler.py` | 4633 | Deferred SSM re-derive (LLM scheduler) |
| `vmlx_engine/mllm_batch_generator.py` | 2311 | Async MLLM re-derive watcher |
| `vmlx_engine/mllm_batch_generator.py` | 2938 | MLLM immediate one-shot re-derive |

## Correctness

Zero behavior change. `mx.array(x)` returns `x` when `x` is already an `mx.array` (identity dispatch in mlx-core's Python binding constructor). Materialization comes from `mx.contiguous()` itself — the outer wrap was never doing anything. The `isinstance(c.cache, list)` guard above each call site confirms the type assumption.

## Test plan

- [x] Verified against `upstream/main` tip `fa1fdb8`
- [ ] Existing hybrid SSM regression tests pass unchanged (`tests/test_vl_video_regression.py`, `tests/test_jit_toggle.py`)
- [ ] Smoke test with Qwen3.6 A3B / Qwen3.5 GatedDeltaNet — clean-cache clone path still produces usable companion caches

## Notes for review

Small hygiene patch intended to pair with the neighboring #104 starvation-gate fix — both touch the same re-derive code paths. Happy to squash or merge in either order.