### PR TITLE
fix(pld): require 2 consecutive zero-attempt windows before auto-disable (vmlx#107)

### DIFF
--- a/vmlx_engine/scheduler.py
+++ b/vmlx_engine/scheduler.py
@@ -393,6 +393,12 @@ class Scheduler:
         self._pld_win_zero: int = 0  # rounds where 0 drafts accepted
         self._pld_win_tokens: int = 0  # tokens emitted while PLD active
         self._pld_win_d0_skip: int = 0  # d0 pre-check skips (wasted cycles avoided)
+        # Hysteresis for the zero-attempt auto-disable (vmlx#107): the first
+        # summary window is only 1 token (slow-start), so a brand-new request
+        # is guaranteed to log 0 PLD attempts before its n-gram index warms
+        # up. Require 2 consecutive zero-attempt windows before disabling so
+        # warmup noise doesn't trip the kill switch.
+        self._pld_zero_streak: int = 0
         # Auto-tune: TCP slow-start inspired wall-clock throughput control.
         # Window starts at 10 tokens, doubles each positive window (exponential
         # growth), caps at _pld_summary_interval.  On congestion (PLD hurting),
@@ -3891,17 +3897,39 @@ class Scheduler:
 
         if n == 0:
             if self._pld_auto_enabled:
-                # PLD was enabled but d0 pre-check filtered every cycle —
-                # no opportunities to help. Disable to avoid per-token
-                # overhead from find_draft_tokens + d0 check.
-                self._pld_auto_enabled = False
-                self._pld_at_window = 1
-                self._pld_at_probe_tokens = 0
-                logger.info(
-                    "[PLD:3b1f] auto-tune — disabled (0 rounds in %d tokens, "
-                    "d0 pre-check filtered all)",
-                    self._pld_win_total_tokens,
-                )
+                # Zero attempts this window. Could be real uselessness
+                # (d0 pre-check filtered every cycle) OR a warmup window
+                # where the n-gram index hadn't built up yet. Require two
+                # consecutive zero-attempt windows before disabling so the
+                # 1-token first-window doesn't trip the kill switch
+                # (vmlx#107). Double the window on the first zero so the
+                # second observation has a fair sample.
+                self._pld_zero_streak += 1
+                if self._pld_zero_streak >= 2:
+                    self._pld_auto_enabled = False
+                    self._pld_at_window = 1
+                    self._pld_at_probe_tokens = 0
+                    self._pld_zero_streak = 0
+                    logger.info(
+                        "[PLD:3b1f] auto-tune — disabled (2 consecutive 0-"
+                        "attempt windows, %d tokens total)",
+                        self._pld_win_total_tokens,
+                    )
+                else:
+                    # First zero window — grow summary window (same rule as
+                    # the positive-window path) and wait for one more sample
+                    # before making the kill decision.
+                    old_window = self._pld_at_window
+                    self._pld_at_window = min(
+                        self._pld_at_window * 2, self._pld_summary_interval
+                    )
+                    logger.info(
+                        "[PLD:3b1f] auto-tune — 0 attempts in %d tokens "
+                        "(warmup?), window %d→%d before deciding",
+                        self._pld_win_total_tokens,
+                        old_window,
+                        self._pld_at_window,
+                    )
             else:
                 # Already disabled.  Count toward probe interval.
                 self._pld_at_probe_tokens += self._pld_win_total_tokens
@@ -3909,6 +3937,7 @@ class Scheduler:
                     self._pld_auto_enabled = True
                     self._pld_at_window = 1
                     self._pld_at_probe_tokens = 0
+                    self._pld_zero_streak = 0
                     logger.info(
                         "[PLD:3b1f] auto-tune probe — re-enabling with window=%d",
                         self._pld_at_window,
@@ -3918,6 +3947,10 @@ class Scheduler:
             self._pld_win_cycle_wall_s = 0.0
             self._pld_summary_next = self._pld_at_window
             return
+
+        # Any positive window resets the zero-streak so the hysteresis only
+        # fires on *consecutive* zero windows.
+        self._pld_zero_streak = 0
 
         accepted = self._pld_win_accepted
         full_pct = 100 * self._pld_win_full / n


### PR DESCRIPTION
## Summary

Closes #107. The PLD auto-tune kill-switch at `_pld_maybe_log_summary` disabled PLD after a single summary window with `_pld_win_attempts == 0`. Because `_pld_summary_next` is initialized to **1 token** (slow-start, `scheduler.py:415`), the first summary fires on a 1-token window where the per-request n-gram index is empty and `find_draft_tokens` cannot return matches — guaranteeing `n == 0` and disabling PLD before any speculative attempt is possible.

This PR introduces `_pld_zero_streak` and requires **two consecutive** 0-attempt windows before flipping `_pld_auto_enabled` to False, so warmup noise no longer trips the kill switch while still preserving the disable on genuinely persistent uselessness.

## Behavior

**Before:**
```
[PLD] enabled — K=5 (pure-attention), d0 pre-check active, auto-tune on (slow-start window=1→256)
[PLD:3b1f] auto-tune — disabled (0 rounds in 1 tokens, d0 pre-check filtered all)
```
PLD sits idle for `5 * summary_interval` tokens before probe-retry. On a typical request this means PLD never actually runs.

**After:**
```
[PLD] enabled — K=5 ...
[PLD:3b1f] auto-tune — 0 attempts in 1 tokens (warmup?), window 1→2 before deciding
[PLD:3b1f] summary over last N tokens — rounds=M  accept=... (real measurement)
```
PLD gets its first real sample window once n-grams warm up. Zero-streak resets on any positive window.

Persistent-uselessness path is unchanged in outcome, just takes one extra window to confirm:

```
[PLD:3b1f] auto-tune — 0 attempts in K tokens (warmup?), window K→2K before deciding
[PLD:3b1f] auto-tune — disabled (2 consecutive 0-attempt windows, 3K tokens total)
```

## Implementation

- `__init__`: new `self._pld_zero_streak: int = 0` counter (around line 393)
- `_pld_maybe_log_summary`, `n == 0` branch:
  - increment streak; if ≥2 disable as before (and reset streak)
  - if 1, double `_pld_at_window` (same rule as positive-window growth) and wait
- Probe re-enable: reset streak to 0 so the fresh probe window starts clean
- Positive-window path: reset streak to 0 so hysteresis only fires on *consecutive* zeros

## Correctness / risk

- Zero functional change to the generation output — affects only the auto-disable timing
- Worst case: one extra summary window's worth of latency before disable fires on a truly wasted PLD configuration; perfectly symmetric to the warmup savings
- The new growth-on-first-zero mirrors the existing growth-on-positive path (line 3956), keeping the slow-start cwnd behavior consistent
- All three branches of the kill logic now clear the streak in the right spots (disabled→enabled probe, disabled stays disabled, positive window); no path can leak stale streak state

## Test plan

- [x] Syntax check: `python3 -c 'import ast; ast.parse(...)'` passes
- [ ] Smoke test on Qwen3.6 A3B (K=2 hybrid) and a pure-attention K=5 model: verify PLD stays enabled through warmup and auto-disables cleanly on workloads that actually have 0 n-gram hits (e.g., Unicode-heavy content with no repeated tokens)
- [ ] Existing PLD tests pass unchanged — no tests exercise the kill-switch behavior directly, so this is a behavior-only change

## Version info

- vmlx 1.3.86 (`fa1fdb8`)
- No new env var; pure scheduler-internal change

## Notes

Small companion to #104 (deferred re-derive starvation gate) and #106 (mx.array cleanup) — all three touch scheduler hot paths but are functionally independent, so any merge order works.