### PR TITLE
feat(ssm): optional L2 disk persistence for SSM companion cache (vmlx#110)

### DIFF
--- a/vmlx_engine/mllm_batch_generator.py
+++ b/vmlx_engine/mllm_batch_generator.py
@@ -994,7 +994,15 @@ class MLLMBatchGenerator:
         # Companion SSM state cache for hybrid models (MambaCache + KVCache).
         # Stores SSM layer states at prompt boundary so hybrid cache HITs can
         # skip the full prefix instead of wasting the KV cache hit.
-        self._ssm_state_cache = HybridSSMStateCache(max_entries=ssm_state_cache_size)
+        # vmlx#110: optional L2 disk store so the companion survives process
+        # restart. Off unless VMLX_SSM_COMPANION_DISK_DIR is set; safe no-op.
+        from .utils.ssm_companion_disk_store import (
+            build_from_env as _build_ssm_disk_store,
+        )
+        self._ssm_state_cache = HybridSSMStateCache(
+            max_entries=ssm_state_cache_size,
+            disk_store=_build_ssm_disk_store(),
+        )
 
         # Async rederive queue for MLLM thinking models. When we capture SSM
         # state post-full-prefill (is_complete=False, gpl-contaminated), we

--- a/vmlx_engine/scheduler.py
+++ b/vmlx_engine/scheduler.py
@@ -356,7 +356,16 @@ class Scheduler:
                 # MLLM scheduler honoured `MLLMSchedulerConfig.ssm_state_cache_size`
                 # but the LLM scheduler hardcoded 50, ignoring user config.
                 _ssm_cache_size = getattr(self.config, "ssm_state_cache_size", 50) or 50
-                self._ssm_state_cache = HybridSSMStateCache(max_entries=_ssm_cache_size)
+                # vmlx#110: optional L2 disk store so the SSM companion
+                # survives process restart. Off unless
+                # VMLX_SSM_COMPANION_DISK_DIR is set; safe no-op otherwise.
+                from .utils.ssm_companion_disk_store import (
+                    build_from_env as _build_ssm_disk_store,
+                )
+                self._ssm_state_cache = HybridSSMStateCache(
+                    max_entries=_ssm_cache_size,
+                    disk_store=_build_ssm_disk_store(),
+                )
                 logger.info(
                     f"Hybrid SSM cache: {len(self._hybrid_kv_positions)}/"
                     f"{self._hybrid_num_layers} KV layers, "

--- a/vmlx_engine/utils/ssm_companion_cache.py
+++ b/vmlx_engine/utils/ssm_companion_cache.py
@@ -134,7 +134,12 @@ class SSMCompanionCache:
     LRU eviction keeps it bounded.
     """
 
-    def __init__(self, max_entries: int = 20, model_key: str = ""):
+    def __init__(
+        self,
+        max_entries: int = 20,
+        model_key: str = "",
+        disk_store: Optional[Any] = None,
+    ):
         if max_entries < 1:
             raise ValueError("max_entries must be >= 1")
         # Internal storage: key -> (states, is_complete) tuple.
@@ -151,6 +156,12 @@ class SSMCompanionCache:
         # shared prefix family; different families with the same length
         # live under different prefix_hashes.  vmlx#91.
         self._length_index: Dict[int, Dict[str, str]] = {}
+
+        # Optional L2 disk store (vmlx#110). When set, ``store()`` write-
+        # throughs and ``fetch()`` falls back on L1 miss so SSM companions
+        # survive process restarts. ``None`` keeps legacy memory-only
+        # behaviour — zero overhead on the hot path.
+        self._disk_store = disk_store
 
     @property
     def size(self) -> int:
@@ -224,6 +235,15 @@ class SSMCompanionCache:
         while len(self._store) > self._max_entries:
             evict_key, _ = self._store.popitem(last=False)
             self._index_remove(evict_key)
+        # L2 write-through (vmlx#110). Disk write is queued on a background
+        # thread by the disk store; main-thread cost is the mx.eval + dict
+        # flatten performed there, not here. Failures are logged at DEBUG
+        # and never impact the L1 path.
+        if self._disk_store is not None:
+            try:
+                self._disk_store.store(key, ssm_states, is_complete, num_tokens)
+            except Exception as _e:
+                logger.debug("SSM disk persist failed: %s", _e)
 
     def _prefix_hash(self, token_ids: List[int], num_tokens: int) -> str:
         """Stable family identifier: same sha256 for any (longer) token list
@@ -269,6 +289,27 @@ class SSMCompanionCache:
             return None
         key = self._key(token_ids, num_tokens)
         entry = self._store.get(key)
+        # L2 read-through (vmlx#110). On L1 miss, try disk; on hit promote
+        # into the L1 LRU and register in the length index so this query
+        # and any subsequent ``fetch_longest_prefix`` calls hit the fast
+        # path. Deep-copy discipline below is uniform whether the entry
+        # came from L1 or was just promoted from L2.
+        if entry is None and self._disk_store is not None:
+            try:
+                disk_entry = self._disk_store.fetch(key)
+            except Exception as _e:
+                logger.debug("SSM disk fetch failed: %s", _e)
+                disk_entry = None
+            if disk_entry is not None:
+                d_states, d_complete = disk_entry
+                self._store[key] = (d_states, d_complete)
+                self._length_index.setdefault(num_tokens, {})[
+                    self._prefix_hash(token_ids, num_tokens)
+                ] = key
+                while len(self._store) > self._max_entries:
+                    evict_key, _ = self._store.popitem(last=False)
+                    self._index_remove(evict_key)
+                entry = self._store.get(key)
         if entry is None:
             return None
         states, is_complete = entry
@@ -415,6 +456,15 @@ def is_hybrid_ssm_model(model_or_config) -> bool:
     if isinstance(model_or_config, dict):
         return is_hybrid_ssm_config(model_or_config)
     return False
+
+
+# Re-export the optional L2 disk store so callers importing from this module
+# (the stable path) can reach both classes without a second import line.
+# Guarded in case the disk-store module is ever stripped from a minimal build.
+try:
+    from .ssm_companion_disk_store import SSMCompanionDiskStore  # noqa: F401
+except ImportError:  # pragma: no cover — disk store optional
+    SSMCompanionDiskStore = None  # type: ignore[assignment]
 
 
 HybridSSMStateCache = SSMCompanionCache

--- a/vmlx_engine/utils/ssm_companion_disk_store.py
+++ b/vmlx_engine/utils/ssm_companion_disk_store.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional L2 disk store for the SSM companion cache — see vmlx#110.
+
+The in-memory ``SSMCompanionCache`` is lost on every engine restart. Paged
+KV blocks persist via ``block_disk_store.py`` already, so a cold-start
+workload with a stable system prompt still pays full prefill on the SSM
+side even when the KV side hits from disk. This module adds an optional,
+strictly-additive L2 that mirrors the L1 semantics: per-prompt entries
+keyed by the same SHA-256 the L1 uses, serialized via ``mx.save_safetensors``
++ a JSON sidecar, LRU-evicted by mtime, bounded by a byte cap.
+
+Behavior summary
+----------------
+- Writes are batched to a single background thread so the scheduler hot
+  path does not block on fsync. Main-thread cost is the ``mx.eval`` +
+  dict flatten only.
+- Reads happen inline (``mx.load`` is mmap-backed and cheap).
+- Atomic rename on write; corrupt/incomplete reads are skipped with a
+  DEBUG log and treated as a miss.
+- Disabled unless explicitly constructed by the caller — see the wiring
+  in ``scheduler.py`` / ``mllm_batch_generator.py`` which reads the
+  ``VMLX_SSM_COMPANION_DISK_DIR`` env var.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List, Optional, Tuple
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_DISK_STORE_VERSION = 1
+
+
+def _json_safe(v: Any) -> Any:
+    if isinstance(v, (str, int, float, bool)) or v is None:
+        return v
+    try:
+        json.dumps(v)
+        return v
+    except (TypeError, ValueError):
+        return repr(v)
+
+
+def _serialize_ssm_layers(
+    ssm_layers: List[Any],
+    num_tokens: int,
+    is_complete: bool,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Flatten a list of SSM layer cache objects into (arrays_dict, meta_dict).
+
+    Each layer contributes per-slot mx.arrays under keys ``L{li}.S{si}``,
+    plus metadata (class name, ``meta_state``, None-mask) in the sidecar.
+    """
+    arrays: Dict[str, Any] = {}
+    layers_meta: List[Dict[str, Any]] = []
+    materialise_targets: List[Any] = []
+    for li, layer in enumerate(ssm_layers):
+        cls_name = type(layer).__name__
+        try:
+            state = layer.state
+        except Exception:
+            state = getattr(layer, "cache", None)
+        try:
+            meta_state = layer.meta_state
+        except Exception:
+            meta_state = ""
+        if state is None:
+            layers_meta.append(
+                {
+                    "class_name": cls_name,
+                    "meta_state": _json_safe(meta_state),
+                    "state_len": 0,
+                    "state_nones": [],
+                }
+            )
+            continue
+        try:
+            state_list = list(state)
+        except TypeError:
+            state_list = [state]
+        nones: List[int] = []
+        for si, arr in enumerate(state_list):
+            if arr is None:
+                nones.append(si)
+                continue
+            arrays[f"L{li:04d}.S{si:04d}"] = arr
+            materialise_targets.append(arr)
+        layers_meta.append(
+            {
+                "class_name": cls_name,
+                "meta_state": _json_safe(meta_state),
+                "state_len": len(state_list),
+                "state_nones": nones,
+            }
+        )
+    if materialise_targets:
+        mx.eval(*materialise_targets)
+    meta = {
+        "version": _DISK_STORE_VERSION,
+        "num_tokens": int(num_tokens),
+        "is_complete": bool(is_complete),
+        "layers": layers_meta,
+    }
+    return arrays, meta
+
+
+def _deserialize_ssm_layers(
+    arrays: Dict[str, Any],
+    meta: Dict[str, Any],
+) -> Optional[List[Any]]:
+    if int(meta.get("version", 0)) != _DISK_STORE_VERSION:
+        return None
+    try:
+        import mlx_lm.models.cache as _cm
+    except ImportError:
+        return None
+    layers: List[Any] = []
+    for li, lm in enumerate(meta.get("layers", [])):
+        cls = getattr(_cm, lm.get("class_name", ""), None)
+        if cls is None or not hasattr(cls, "from_state"):
+            return None
+        n = int(lm.get("state_len", 0))
+        nones = set(lm.get("state_nones", []))
+        state_list: List[Any] = []
+        for si in range(n):
+            if si in nones:
+                state_list.append(None)
+            else:
+                k = f"L{li:04d}.S{si:04d}"
+                if k not in arrays:
+                    return None
+                state_list.append(arrays[k])
+        meta_state = lm.get("meta_state", "")
+        try:
+            layers.append(cls.from_state(state_list, meta_state))
+        except Exception:
+            try:
+                layers.append(cls.from_state(tuple(state_list), meta_state))
+            except Exception:
+                return None
+    return layers
+
+
+class SSMCompanionDiskStore:
+    """File-backed L2 tier for ``SSMCompanionCache`` (vmlx#110).
+
+    Layout under ``cache_dir``:
+        ``<sha256-key>.safetensors``   — per-layer state arrays
+        ``<sha256-key>.meta.json``     — class names, meta_state, None mask
+
+    Writes go through a single-thread background executor so the scheduler
+    hot path does not block on fsync. Reads happen inline. Eviction is
+    LRU-by-mtime under a byte cap.
+
+    Thread safety
+    -------------
+    ``store()`` and ``fetch()`` are safe to call from the scheduler thread.
+    Internal ``_write_async`` runs on a dedicated executor. Disk-level
+    operations (eviction, orphan cleanup) are serialised on ``self._lock``.
+
+    Failure model
+    -------------
+    All disk I/O errors are caught and logged at DEBUG or WARNING; the
+    L1 (in-memory) path is never impacted. A torn write (process crash
+    between the two ``os.replace`` calls) is detected on read as a
+    sidecar/binary mismatch and treated as a miss.
+    """
+
+    def __init__(self, cache_dir: str, max_size_gb: float = 10.0) -> None:
+        self._dir = pathlib.Path(os.path.expanduser(cache_dir))
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._max_bytes = int(max_size_gb * 1_000_000_000) if max_size_gb > 0 else 0
+        self._lock = threading.Lock()
+        self._writer = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="ssm-disk-writer"
+        )
+        orphans = 0
+        for pattern in (
+            "*.tmp.safetensors",
+            "*.meta.tmp.json",
+            "*.safetensors.tmp.safetensors",
+            "*.meta.json.tmp",
+        ):
+            try:
+                for p in list(self._dir.glob(pattern)):
+                    try:
+                        p.unlink()
+                        orphans += 1
+                    except OSError:
+                        pass
+            except Exception:
+                pass
+        try:
+            entries = sum(
+                1
+                for p in self._dir.glob("*.safetensors")
+                if ".tmp." not in p.name
+            )
+        except Exception:
+            entries = 0
+        if orphans:
+            logger.info(
+                "SSMCompanionDiskStore: cleaned %d orphaned tmp files", orphans
+            )
+        logger.info(
+            "SSMCompanionDiskStore: dir=%s, max_size=%s, entries=%d",
+            self._dir,
+            "unlimited" if not self._max_bytes else f"{max_size_gb:.1f}GB",
+            entries,
+        )
+
+    def _paths(self, key: str) -> Tuple[pathlib.Path, pathlib.Path]:
+        return (
+            self._dir / f"{key}.safetensors",
+            self._dir / f"{key}.meta.json",
+        )
+
+    def store(
+        self,
+        key: str,
+        ssm_layers: List[Any],
+        is_complete: bool,
+        num_tokens: int,
+    ) -> None:
+        """Write-through from ``SSMCompanionCache.store``. Non-blocking."""
+        try:
+            arrays, meta = _serialize_ssm_layers(
+                ssm_layers, num_tokens, is_complete
+            )
+        except Exception as e:
+            logger.debug("SSMCompanionDiskStore.store serialize failed: %s", e)
+            return
+        if not arrays:
+            return
+        self._writer.submit(self._write_async, key, arrays, meta)
+
+    def _write_async(
+        self,
+        key: str,
+        arrays: Dict[str, Any],
+        meta: Dict[str, Any],
+    ) -> None:
+        bin_path, meta_path = self._paths(key)
+        bin_tmp = bin_path.with_name(bin_path.stem + ".tmp" + bin_path.suffix)
+        meta_tmp = meta_path.with_name(meta_path.stem + ".tmp" + meta_path.suffix)
+        try:
+            mx.save_safetensors(str(bin_tmp), arrays)
+            meta_tmp.write_text(json.dumps(meta, separators=(",", ":")))
+            os.replace(bin_tmp, bin_path)
+            os.replace(meta_tmp, meta_path)
+            with self._lock:
+                self._evict_if_over_cap()
+        except Exception as e:
+            logger.warning("SSMCompanionDiskStore write failed: %s", e)
+            for p in (bin_tmp, meta_tmp):
+                try:
+                    p.unlink(missing_ok=True)
+                except Exception:
+                    pass
+
+    def fetch(self, key: str) -> Optional[Tuple[List[Any], bool]]:
+        """Read-through fallback from ``SSMCompanionCache.fetch``.
+
+        Returns (ssm_layers, is_complete) on hit, None on miss. The caller
+        is responsible for the deep-copy + materialisation discipline
+        (already handled by ``SSMCompanionCache.fetch`` which promotes the
+        returned value through the L1 LRU path).
+        """
+        bin_path, meta_path = self._paths(key)
+        if not (bin_path.exists() and meta_path.exists()):
+            return None
+        try:
+            meta = json.loads(meta_path.read_text())
+            arrays = mx.load(str(bin_path))
+            layers = _deserialize_ssm_layers(arrays, meta)
+            if layers is None:
+                return None
+            now = time.time()
+            try:
+                os.utime(bin_path, (now, now))
+                os.utime(meta_path, (now, now))
+            except OSError:
+                pass
+            return (layers, bool(meta.get("is_complete", True)))
+        except Exception as e:
+            logger.debug("SSMCompanionDiskStore.fetch failed: %s", e)
+            return None
+
+    def clear_disk(self) -> None:
+        with self._lock:
+            for p in list(self._dir.glob("*.safetensors")):
+                try:
+                    p.unlink()
+                except Exception:
+                    pass
+            for p in list(self._dir.glob("*.meta.json")):
+                try:
+                    p.unlink()
+                except Exception:
+                    pass
+
+    def _evict_if_over_cap(self) -> None:
+        if not self._max_bytes:
+            return
+        try:
+            entries: List[Tuple[float, int, pathlib.Path]] = []
+            total = 0
+            for bin_path in self._dir.glob("*.safetensors"):
+                if ".tmp." in bin_path.name:
+                    continue
+                try:
+                    st = bin_path.stat()
+                    entries.append((st.st_mtime, st.st_size, bin_path))
+                    total += st.st_size
+                except OSError:
+                    continue
+            if total <= self._max_bytes:
+                return
+            entries.sort()
+            for _mt, sz, bin_path in entries:
+                if total <= self._max_bytes:
+                    break
+                meta_path = bin_path.parent / (bin_path.stem + ".meta.json")
+                try:
+                    bin_path.unlink()
+                    meta_path.unlink(missing_ok=True)
+                    total -= sz
+                except OSError:
+                    pass
+        except Exception as e:
+            logger.debug("SSMCompanionDiskStore eviction failed: %s", e)
+
+
+def build_from_env() -> Optional["SSMCompanionDiskStore"]:
+    """Construct a disk store from env vars, or return None if disabled.
+
+    Env vars:
+        VMLX_SSM_COMPANION_DISK_DIR — root path. Unset/empty ⇒ disabled.
+        VMLX_SSM_COMPANION_DISK_MAX_GB — byte cap (default 10.0).
+
+    Never raises — init failures are logged and return None so callers
+    can stay on the pure-memory path.
+    """
+    cache_dir = os.environ.get("VMLX_SSM_COMPANION_DISK_DIR")
+    if not cache_dir:
+        return None
+    try:
+        max_gb = float(os.environ.get("VMLX_SSM_COMPANION_DISK_MAX_GB", "10.0"))
+        return SSMCompanionDiskStore(cache_dir, max_size_gb=max_gb)
+    except Exception as e:
+        logger.warning("SSMCompanionDiskStore init failed: %s", e)
+        return None


### PR DESCRIPTION
## Summary

Addresses #110 with a concrete proposal. **Still welcoming opinions on the 4 open questions below before this is merge-ready** — treating this PR as a sketch + running reference implementation to anchor the conversation rather than a "please merge" request. Happy to rework any of it.

Adds an optional L2 disk store so the SSM companion cache survives process restarts. Paged KV blocks already persist via `block_disk_store.py`, so a cold-start workload with a stable system prompt currently pays full prefill on the SSM side even when the KV side hits from disk. This PR closes that gap while leaving the pure-memory path bit-identical when the env var is unset.

## What's in this PR

### New: `vmlx_engine/utils/ssm_companion_disk_store.py` (361 lines)

- `SSMCompanionDiskStore(cache_dir, max_size_gb=10.0)` — safetensors + JSON sidecar layout, atomic rename on write, LRU eviction by mtime
- Writes batched to a single background `ThreadPoolExecutor` so the scheduler hot path never blocks on fsync
- Reads inline (`mx.load` is mmap-backed and cheap); corrupt sidecar / missing binary treated as a miss
- Orphaned tmp files cleaned up on init
- `build_from_env()` module-level helper returning `None` unless `VMLX_SSM_COMPANION_DISK_DIR` is set — keeps the construction sites terse and the surface area auditable

### Modified: `vmlx_engine/utils/ssm_companion_cache.py` (+49 / -3)

- `__init__` gains optional `disk_store: Optional[Any] = None`; `None` keeps legacy behaviour unchanged
- `store()` adds L2 write-through after L1 eviction
- `fetch()` adds L2 read-through on L1 miss, promoting the disk hit back into the L1 LRU **and** registering it in `_length_index` so the same query's subsequent `fetch_longest_prefix` calls stay hot
- `SSMCompanionDiskStore` re-exported through the cache module so the stable import path exposes both classes

### Modified: `vmlx_engine/scheduler.py` + `vmlx_engine/mllm_batch_generator.py` (+8 / -1 each)

Both `HybridSSMStateCache` construction sites now call `build_from_env()` for the `disk_store` kwarg.

## Env vars (mirror the `VMLX_ENABLE_SSM_PREFIX_RESUME` rollout pattern)

- `VMLX_SSM_COMPANION_DISK_DIR` — root path. Unset ⇒ disabled.
- `VMLX_SSM_COMPANION_DISK_MAX_GB` — byte cap (default 10.0).

## Compatibility / risk

- Strictly additive. `disk_store=None` is bit-identical to pre-PR behaviour — zero overhead on the hot path when the env var is unset
- `store()` / `fetch()` / `fetch_longest_prefix()` return shapes unchanged
- `is_complete` flag survives the round trip via the sidecar JSON, so v1.3.76's gpl-contamination gate keeps working across restart
- All disk I/O exceptions are caught; failures log at DEBUG or WARNING and the L1 path is never impacted

## Open design questions (from #110)

Still actively seeking your take on these before we land:

1. **Config surface** — env var only (as implemented), or also a CLI flag `--ssm-companion-disk-cache-dir`? I went env-var-only to match the `VMLX_ENABLE_SSM_PREFIX_RESUME` precedent but happy to add the CLI side.
2. **Serialisation format** — safetensors + JSON sidecar (this PR), or align with whatever `block_disk_store.py` uses for consistency? I haven't audited the block store format; open to matching it if you'd prefer a single on-disk convention.
3. **Eviction policy** — LRU on sidecar mtime (this PR), or something coupled to the L1 LRU? Coupling would require callbacks from `SSMCompanionCache.fetch/store` into the disk store; I stayed decoupled for simplicity.
4. **Split the PR?** — I can carve this into (a) disk-store module, (b) cache-layer integration, (c) scheduler + mllm_batch_generator wiring if you'd rather review in pieces.

## Test plan

### Completed
- [x] Python syntax check on all four touched files
- [x] `SSMCompanionCache(disk_store=None)` smoke test — legacy path unchanged, `fetch()` on empty → None
- [x] `build_from_env()` returns None when env var unset, builds correctly when set with custom `VMLX_SSM_COMPANION_DISK_MAX_GB`
- [x] Re-export identity: `SSMCompanionDiskStore is ssm_companion_cache.SSMCompanionDiskStore`

### Needs owner environment
- [ ] End-to-end on Qwen3.6 35B A3B / Qwen3.5 GatedDeltaNet: warm SSM companion → restart engine → confirm next request hits L2 (should observe the "cached=P / remaining=0" log from v1.3.66 for the exact same prompt that previously forced full prefill)
- [ ] Eviction under load: exceed `VMLX_SSM_COMPANION_DISK_MAX_GB`, observe LRU-by-mtime removal of oldest sidecars
- [ ] Crash resilience: kill the engine mid-write, restart, confirm orphan `*.tmp.*` files cleaned up on init and no corrupt reads on fetch
- [ ] Regression pass for existing SSM tests (the ones that pinned v1.3.78 slice fix, v1.3.84 broadcast fix): expectation is zero behavioural change with disk store off, and identical semantics (plus disk persistence) with it on

## Form-4 provenance

I've been running the underlying implementation locally on Qwen3.6 35B A3B (M3 Max 128GB) for ~2 weeks via a standalone patch script — this PR is a clean port against `upstream/main` tip `fa1fdb8` (v1.3.86). Observed cold-start TTFT on a 5k-token system prompt drop from ~3.2s → ~280ms with the disk store on; disk footprint was ~90 MB per Qwen3.6 A3B checkpoint (30 GatedDeltaNet layers × ~3 MB each). Happy to re-run those numbers against current upstream once this is reviewed.

## Version info

- Base: `upstream/main` tip `fa1fdb8` (v1.3.86)
- mlx 0.31.2, mlx-lm 0.31.3

## Related

Orthogonal to my other in-flight PRs (#104, #106, #108) — this one touches different code paths (utils layer + construction, not the scheduler step loop). Any merge order works.