### PR TITLE
UI: Fix custom model directory picker using .fileImporter

### DIFF
--- a/Sources/vMLXApp/Server/ModelDirectoriesPanel.swift
+++ b/Sources/vMLXApp/Server/ModelDirectoriesPanel.swift
@@ -31,6 +31,8 @@ struct ModelDirectoriesPanel: View {
     @State private var pullRepo: String = ""
     @State private var isEnqueuing: Bool = false
 
+    @State private var isShowingFolderPicker = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
             header
@@ -52,6 +54,20 @@ struct ModelDirectoriesPanel: View {
                         .stroke(Theme.Colors.border, lineWidth: 1)
                 )
         )
+        .fileImporter(
+            isPresented: $isShowingFolderPicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    Task { await addDir(url) }
+                }
+            case .failure(let error):
+                bannerMessage = "Failed to pick directory: \(error.localizedDescription)"
+            }
+        }
         .task { await refreshDirs() }
     }
 
@@ -139,7 +155,7 @@ struct ModelDirectoriesPanel: View {
     private var footer: some View {
         HStack {
             Button {
-                pickAndAddDir()
+                isShowingFolderPicker = true
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "plus")
@@ -337,21 +353,6 @@ struct ModelDirectoriesPanel: View {
                 bannerMessage = nil
             }
         }
-    }
-
-    private func pickAndAddDir() {
-        #if canImport(AppKit)
-        let panel = NSOpenPanel()
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.title = "Pick a model directory"
-        panel.prompt = "Add directory"
-        panel.message = "Choose a folder vMLX should scan for model directories. Each immediate subfolder is treated as one model."
-        if panel.runModal() == .OK, let url = panel.url {
-            Task { await addDir(url) }
-        }
-        #endif
     }
 
     private func addDir(_ url: URL) async {


### PR DESCRIPTION
### Summary
This PR replaces the legacy NSOpenPanel().runModal() implementation with SwiftUI's native .fileImporter in the ModelDirectoriesPanel.

### Motivation
- **Main Thread Safety**: runModal() is a blocking synchronous call that can lead to UI hangs or deadlocks in complex SwiftUI view hierarchies.
- **Reliability**: Some users reported that the folder picker failed to appear in recent beta builds. The native .fileImporter modifier is managed by the SwiftUI lifecycle, ensuring the sheet is properly anchored to the active window.
- **Modernization**: Removes explicit import AppKit logic and conditional compilation where native SwiftUI primitives are now available.

### Changes
- Added @State private var isShowingFolderPicker to manage the picker state.
- Implemented .fileImporter modifier with .folder content type.
- Updated the 'Add Directory' button to trigger the new async flow.
- Added a fallback error message in the UI banner if the picker fails.

### Verification
- Compiled using swift build.
- Verified on macOS that clicking 'Add Directory' now correctly triggers the system folder picker without blocking the app.
