### PR TITLE
Engine: Fix UTF-8 mojibake (乱码) during streaming

### DIFF
--- a/Sources/vMLXEngine/Stream.swift
+++ b/Sources/vMLXEngine/Stream.swift
@@ -1601,9 +1601,41 @@ extension Engine {
                     let emitLen = max(0, targetCap - emittedContentBytes)
                     if emitLen > 0 {
                         let allUtf8 = Array(combined.utf8)
-                        let slice = allUtf8[emittedContentBytes..<(emittedContentBytes + emitLen)]
-                        emittableContent = String(decoding: slice, as: UTF8.self)
-                        emittedContentBytes += emitLen
+                        let rawSlice = allUtf8[emittedContentBytes..<(emittedContentBytes + emitLen)]
+
+                        // UTF-8 Boundary Fix: If the slice ends in the middle of a multi-byte
+                        // character, hold back the partial bytes.
+                        var validatedLen = emitLen
+                        var i = emittedContentBytes + emitLen - 1
+                        while i >= emittedContentBytes && i >= (emittedContentBytes + emitLen - 4) {
+                            let byte = allUtf8[i]
+                            if (byte & 0x80) == 0 { // 1-byte ASCII, valid boundary
+                                break
+                            }
+                            if (byte & 0xC0) == 0xC0 { // Start of multi-byte sequence
+                                let sequenceLen: Int
+                                if (byte & 0xF8) == 0xF0 { sequenceLen = 4 }
+                                else if (byte & 0xF0) == 0xE0 { sequenceLen = 3 }
+                                else if (byte & 0xC0) == 0xC0 { sequenceLen = 2 }
+                                else { sequenceLen = 1 }
+
+                                let bytesAvailable = (emittedContentBytes + emitLen) - i
+                                if bytesAvailable < sequenceLen {
+                                    // Truncate this partial sequence
+                                    validatedLen -= bytesAvailable
+                                }
+                                break
+                            }
+                            i -= 1
+                        }
+
+                        if validatedLen > 0 {
+                            let slice = allUtf8[emittedContentBytes..<(emittedContentBytes + validatedLen)]
+                            emittableContent = String(decoding: slice, as: UTF8.self)
+                            emittedContentBytes += validatedLen
+                        } else {
+                            emittableContent = ""
+                        }
                     } else {
                         emittableContent = ""
                     }

--- a/Sources/vMLXLMCommon/Tokenizer.swift
+++ b/Sources/vMLXLMCommon/Tokenizer.swift
@@ -95,13 +95,14 @@ public struct NaiveStreamingDetokenizer: StreamingDetokenizer {
 
     public mutating func next() -> String? {
         let newSegment = tokenizer.decode(tokenIds: segmentTokens)
-        let new = newSegment.suffix(newSegment.count - segment.count)
 
         // if the new segment ends with REPLACEMENT CHARACTER this means
         // that the token didn't produce a complete unicode character
-        if new.last == "\u{fffd}" {
+        if newSegment.last == "\u{fffd}" {
             return nil
         }
+
+        let new = newSegment.suffix(newSegment.count - segment.count)
 
         if new.hasSuffix("\n") {
             startNewSegment()


### PR DESCRIPTION
### Summary
This PR fixes a critical streaming issue where multi-byte UTF-8 characters (e.g., Chinese, Japanese, Emojis) would occasionally render as replacement characters (`\ufffd`) when a token boundary splits the character's byte sequence.

### Motivation
In LLM streaming, a single token might only contain a partial byte sequence of a multi-byte character.
- **The Bug**: The previous logic used a fixed-length truncation (based on tool-call markers) and decoded the resulting bytes immediately. If the truncation hit the middle of a UTF-8 sequence, it produced a decoding error.
- **The Fix**: Introduced a trailing-byte validator that detects incomplete UTF-8 sequences at the end of a buffer and holds them back until the next chunk arrives to complete the sequence.

### Changes
- **Stream.swift**: Added a bitwise check on trailing bytes in the `performOneGenerationPass` loop to ensure we only emit complete UTF-8 sequences.
- **Tokenizer.swift**: Updated `NaiveStreamingDetokenizer` to avoid emitting partial segments when `\ufffd` is detected at the end of the decoded string.

### Verification
- Tested with `Qwen3.6-35B-A3B` on Chinese prompts.
- Confirmed that "mojibake" (random `\ufffd` inside words) is eliminated during high-speed streaming.
- Verified zero performance regression on ASCII-only text.
