### PR TITLE
fix(deps): jang extra uses correct PyPI name + version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,13 +133,18 @@ audio = [
     "unidic-lite>=1.0.0",    # Japanese dictionary for fugashi
     "jieba>=0.42.0",         # Chinese word segmentation
 ]
-# JANG / MXTQ runtime + conversion. `jang-tools` provides both the
-# runtime dequant codec and the conversion CLI; covers DSV4-Flash,
-# MiniMax-M2.7-JANG_*, NemotronH-Omni-*, MXTQ shards, and any other
-# JANG-stamped bundle. Mirrors `mxtq` extra above (intentionally same
-# pin) so `pip install vmlx[jang]` is a friendly alias.
+# JANG / MXTQ runtime + conversion. The PyPI distribution name is
+# `jang` (NOT `jang-tools` — that name doesn't exist on PyPI; the
+# import name is `jang_tools` only because the wheel ships its
+# package directory as `jang_tools/`). Provides both the runtime
+# dequant codec and the conversion CLI; covers DSV4-Flash,
+# MiniMax-M2.7-JANG_*, NemotronH-Omni-*, Laguna-XS.2-JANGTQ,
+# Mistral-Medium-3.5-JANGTQ, Qwen 3.5/3.6-JANGTQ, MXTQ shards, and
+# any other JANG-stamped bundle. Mirrors `mxtq` extra above
+# (intentionally same pin) so `pip install vmlx[jang]` is a
+# friendly alias. Pin tracks the hard dep above — bump in lockstep.
 jang = [
-    "jang-tools>=2.5.0",
+    "jang>=2.5.13",
 ]
 # Image generation dependencies (Flux, Z-Image-Turbo via mflux)
 image = [


### PR DESCRIPTION
## Summary
- The `[jang]` optional-dependency extra pinned `jang-tools>=2.5.0` — wrong PyPI name (it's `jang`, not `jang-tools`; `jang_tools` is only the import name) AND stale version (hard deps at lines 67+99 already pin `jang>=2.5.13`).
- Now matches the hard dep in lockstep so `pip install vmlx` and `pip install vmlx[jang]` resolve to the same minimum.

## Why this matters
Without this fix, `pip install vmlx[jang]` would silently fall back to whatever `jang-tools` resolves to on PyPI — nothing, in this case, since that name doesn't exist. The hard dep above caught the install path through `pip install vmlx` directly, but anyone using the friendly `[jang]` alias was getting an unresolved extra.

## Test plan
- [x] `grep 'jang-tools' pyproject.toml` returns no matches.
- [x] `grep 'jang>=' pyproject.toml` shows three lines all at 2.5.13.
- [x] `git apply --check` verified clean against origin/main.

## Notes
Restore my working tree on the local clone via `git stash pop` after merge — the engine repo had unrelated swift/Tests untracked files I left alone.
