### PR TITLE
feat(cli): add --uds flag for Unix domain socket serving

### DIFF
--- a/vmlx_engine/cli.py
+++ b/vmlx_engine/cli.py
@@ -1214,8 +1214,12 @@ def serve_command(args):
         print()
 
     # Start server
-    print(f"Starting server at http://{args.host}:{args.port}")
-    uvicorn.run(app, host=args.host, port=args.port, log_level=log_level.lower())
+    if args.uds:
+        print(f"Starting server on Unix domain socket {args.uds}")
+        uvicorn.run(app, uds=args.uds, log_level=log_level.lower())
+    else:
+        print(f"Starting server at http://{args.host}:{args.port}")
+        uvicorn.run(app, host=args.host, port=args.port, log_level=log_level.lower())
 
 
 def bench_command(args):
@@ -1752,6 +1756,11 @@ Examples:
     serve_parser.add_argument(
         "--port", type=int, default=8000,
         help="TCP port for the API server (default: 8000). Example: --port 8092",
+    )
+    serve_parser.add_argument(
+        "--uds", type=str, default=None,
+        help="Path to a Unix domain socket to bind instead of host/port. "
+             "When set, --host and --port are ignored. Example: --uds /tmp/vmlx.sock",
     )
     serve_parser.add_argument(
         "--max-num-seqs", type=int, default=1,


### PR DESCRIPTION
**Summary**

Adds a --uds <path> flag to vmlx-server serve that binds the server to a Unix domain socket instead of TCP. This is what embedded sidecars need: each Alfred install gets an isolated server without having to hunt for a free TCP port.

**Implementation**

Forwards the path straight to uvicorn's uds= kwarg through the existing serve runner.
TCP host/port path is unchanged when --uds is omitted — fully backward compatible.

**Usage**

`vmlx-server serve --uds /tmp/alfred-vmlx.sock`