### PR TITLE
WIP: live-app testing harness + protocol/status docs + VL stream-fix attempts

### DIFF
--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -55,6 +55,7 @@
         "electron-vite": "^2.0.0",
         "eslint": "^8.56.0",
         "eslint-plugin-react": "^7.33.2",
+        "playwright-core": "^1.60.0",
         "postcss": "^8.4.35",
         "prettier": "^3.2.5",
         "sharp": "^0.34.5",
@@ -9135,6 +9136,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/plist": {

--- a/panel/package.json
+++ b/panel/package.json
@@ -70,6 +70,7 @@
     "electron-vite": "^2.0.0",
     "eslint": "^8.56.0",
     "eslint-plugin-react": "^7.33.2",
+    "playwright-core": "^1.60.0",
     "postcss": "^8.4.35",
     "prettier": "^3.2.5",
     "sharp": "^0.34.5",

--- a/panel/scripts/uidrv.cjs
+++ b/panel/scripts/uidrv.cjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/* Live-app UI automation driver for vMLX dev build (CDP).
+ * Connects to the running Electron renderer over CDP and runs a sub-command.
+ * Usage: node scripts/uidrv.cjs <cmd> [args...]
+ *   inspect                 - screenshot + dump interactive elements & headings
+ *   shot [path]             - screenshot only
+ *   click "<text>"          - click first visible element whose text matches
+ *   type "<sel>" "<text>"   - fill an input/textarea by selector
+ *   eval "<js>"             - run JS in page, print JSON result
+ */
+const { chromium } = require('playwright-core')
+const CDP = process.env.VMLX_CDP || 'http://127.0.0.1:9333'
+
+async function getPage(browser) {
+  // Electron exposes contexts; find the vMLX renderer page.
+  for (const ctx of browser.contexts()) {
+    for (const p of ctx.pages()) {
+      const u = p.url()
+      if (u.includes('5173') || u.includes('index.html') || u.startsWith('file:')) return p
+    }
+  }
+  const ctx = browser.contexts()[0]
+  return ctx.pages()[0]
+}
+
+async function main() {
+  const [cmd, a1, a2] = process.argv.slice(2)
+  const browser = await chromium.connectOverCDP(CDP)
+  const page = await getPage(browser)
+  if (!page) { console.error('NO_PAGE'); process.exit(2) }
+  await page.waitForLoadState('domcontentloaded').catch(() => {})
+
+  if (cmd === 'shot' || cmd === 'inspect') {
+    const out = a1 || '/tmp/vmlx-ui.png'
+    await page.screenshot({ path: out, fullPage: false }).catch(e => console.error('shot err', e.message))
+    console.log('SHOT', out)
+  }
+  if (cmd === 'inspect') {
+    const info = await page.evaluate(() => {
+      const vis = (el) => {
+        const r = el.getBoundingClientRect()
+        const s = getComputedStyle(el)
+        return r.width > 0 && r.height > 0 && s.visibility !== 'hidden' && s.display !== 'none'
+      }
+      const txt = (el) => (el.innerText || el.value || el.getAttribute('aria-label') || el.title || '').trim().replace(/\s+/g, ' ').slice(0, 60)
+      const clickable = [...document.querySelectorAll('button,[role=button],a,[role=tab],input[type=checkbox],input[type=radio],select,label')]
+        .filter(vis).map(el => ({ tag: el.tagName.toLowerCase(), type: el.getAttribute('type') || '', t: txt(el), checked: el.checked ?? null }))
+        .filter(x => x.t || x.type)
+      const inputs = [...document.querySelectorAll('input,textarea')].filter(vis).map(el => ({
+        tag: el.tagName.toLowerCase(), type: el.type || '', ph: el.placeholder || '', name: el.name || '', val: (el.value || '').slice(0, 30)
+      }))
+      const headings = [...document.querySelectorAll('h1,h2,h3,[class*=title],[class*=header]')].filter(vis).map(txt).filter(Boolean).slice(0, 25)
+      return { url: location.href, title: document.title, headings: [...new Set(headings)], clickable, inputs }
+    })
+    console.log(JSON.stringify(info, null, 2))
+  }
+  if (cmd === 'click') {
+    const loc = page.getByText(a1, { exact: false }).first()
+    await loc.click({ timeout: 5000 })
+    console.log('CLICKED', a1)
+  }
+  if (cmd === 'type') {
+    await page.fill(a1, a2, { timeout: 5000 })
+    console.log('TYPED into', a1)
+  }
+  if (cmd === 'press') {
+    await page.press(a1, a2, { timeout: 5000 })
+    console.log('PRESSED', a2, 'in', a1)
+  }
+  if (cmd === 'send') {
+    // fill the message textarea and submit with Enter
+    await page.fill(a1 || 'textarea', a2)
+    await page.press(a1 || 'textarea', 'Enter')
+    console.log('SENT')
+  }
+  if (cmd === 'setfile') {
+    // set a file input (a1=selector or 'auto' to pick the first file input) to path a2
+    const sel = (a1 && a1 !== 'auto') ? a1 : 'input[type=file]'
+    const inp = page.locator(sel).first()
+    await inp.setInputFiles(a2)
+    console.log('SETFILE', a2, '->', sel)
+  }
+  if (cmd === 'text') {
+    const r = await page.evaluate(() => document.body.innerText.replace(/\n{2,}/g, '\n').trim())
+    console.log(r)
+  }
+  if (cmd === 'eval') {
+    const r = await page.evaluate(a1)
+    console.log(JSON.stringify(r, null, 2))
+  }
+  await browser.close().catch(() => {})
+}
+main().catch(e => { console.error('DRV_ERR', e.message); process.exit(1) })

--- a/panel/src/main/index.ts
+++ b/panel/src/main/index.ts
@@ -30,6 +30,14 @@ import { startMemoryEnforcer, stopMemoryEnforcer } from './memory-enforcer'
 import { registerModelSettingsHandlers } from './db/model-settings'
 import { registerImageHandlers } from './ipc/image'
 
+// Dev-only: expose Chrome DevTools Protocol for live UI automation when
+// VMLX_REMOTE_DEBUG_PORT is set. No-op in normal/production launches.
+// Must run before app is ready.
+if (process.env.VMLX_REMOTE_DEBUG_PORT) {
+  app.commandLine.appendSwitch('remote-debugging-port', process.env.VMLX_REMOTE_DEBUG_PORT)
+  app.commandLine.appendSwitch('remote-allow-origins', '*')
+}
+
 let mainWindow: BrowserWindow | null = null
 let downloadWindow: BrowserWindow | null = null
 let handlersRegistered = false

--- a/vmlx_engine/engine/batched.py
+++ b/vmlx_engine/engine/batched.py
@@ -215,15 +215,29 @@ class BatchedEngine(BaseEngine):
             call_kwargs["tools"] = convert_tools_for_template(tools)
         executor = getattr(self._mllm_scheduler, "_step_executor", None)
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(
-            executor,
-            lambda: self._mllm_instance.chat(
+
+        def _run_simple_mllm_chat():
+            # The mlx-vlm generate path (Gemma4 vision encoder + wired_limit's
+            # bare mx.synchronize()) runs implicit ops on the *default* GPU
+            # stream of the current thread. On a ThreadPoolExecutor worker that
+            # default stream may be unset, raising "There is no Stream(gpu, 0)
+            # in current thread". Pin the worker thread's default stream to the
+            # device default before generating so the synchronize/vision ops
+            # resolve. (Belt-and-suspenders with mllm.chat's _MaybeVLMStream.)
+            try:
+                import mlx.core as mx
+
+                mx.set_default_stream(mx.default_stream(mx.default_device()))
+            except Exception:
+                pass
+            return self._mllm_instance.chat(
                 messages,
                 max_tokens=max_tokens,
                 temperature=temperature,
                 **call_kwargs,
-            ),
-        )
+            )
+
+        result = await loop.run_in_executor(executor, _run_simple_mllm_chat)
         text = clean_output_text(getattr(result, "text", "") or "")
         return GenerationOutput(
             text=text,

--- a/vmlx_engine/models/mllm.py
+++ b/vmlx_engine/models/mllm.py
@@ -6149,19 +6149,27 @@ class MLXMultimodalLM:
             resize_shape=kwargs.get("resize_shape"),
         )
 
-        result = generate(
-            self.model,
-            self.processor,
-            formatted_prompt,
-            all_images if all_images else None,
-            audio=all_audio if all_audio else None,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            verbose=False,
-            prompt_cache=prompt_cache,
-            skip_prompt_processing=skip_prompt_processing,
-            **kwargs,
-        )
+        # Pin mlx-vlm generation to a dedicated MLX stream. Without this, when
+        # chat() runs inside a ThreadPoolExecutor worker (the simple media-turn
+        # path in BatchedEngine._simple_mllm_chat_output), the Gemma4 vision
+        # encoder / wired_limit execute on a thread with no current GPU stream
+        # and raise "RuntimeError: There is no Stream(gpu, 0) in current thread".
+        # See _vlm_stream() / _MaybeVLMStream — the simple path must pin the
+        # stream just like the batched VLM scheduler does.
+        with _MaybeVLMStream():
+            result = generate(
+                self.model,
+                self.processor,
+                formatted_prompt,
+                all_images if all_images else None,
+                audio=all_audio if all_audio else None,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                verbose=False,
+                prompt_cache=prompt_cache,
+                skip_prompt_processing=skip_prompt_processing,
+                **kwargs,
+            )
 
         # Store KV cache for future reuse (on cache miss)
         # IMPORTANT: We need to store only the prompt portion, not generated tokens


### PR DESCRIPTION
Captures all in-flight vMLX Python-engine work so it can be paused and resumed cleanly (pivoting to the MiniMax M3 prefix-cache task). Base: `main` @ v1.5.58.

## Adds
- **`docs/LIVE-APP-TESTING-PROTOCOL.md`** — mandatory live-app test protocol + default cache policy (paged OFF / SSD prefix per family) + per-model matrix.
- **`docs/LIVE-APP-TESTING-STATUS.md`** — findings, cross-check matrix, reusable harness usage.
- **`docs/VMLX-ENGINE-WIP-HANDOFF.md`** — done / open / TODO placeholder for resume.
- **`panel/scripts/uidrv.cjs`** — CDP driver for the dev app (`playwright-core`).
- **`panel/src/main/index.ts`** — dev-only, env-gated remote-debugging switch (`VMLX_REMOTE_DEBUG_PORT`); no-op in normal/production launches.

## Validated live (Gemma 4 E2B QAT MXFP4, real dev-build app)
Load + autodetect (gemma4 / VL / SWA RotatingKVCache), coherent multiturn, prefix cache HIT, reasoning On = clean (no leaks/thinking-tags), multiturn tool-calling (engine emits clean `tool_calls`), streaming clean.

## ⚠️ Open P0 — NOT fixed
**VL image input fails:** `RuntimeError: There is no Stream(gpu, 0) in current thread` (confirmed on a fresh engine). Gemma4 media turns run on a thread-pool worker with no default GPU stream; mlx_vlm `wired_limit`'s bare `mx.synchronize()` + the vision encoder fail there.
- The two engine edits here (`models/mllm.py` `_MaybeVLMStream` wrap; `engine/batched.py` worker default-stream) are documented **ATTEMPTS that are insufficient** and harmless to the text path.
- Recommended real fix: route Gemma4 media via the working batched VLM scheduler (see STATUS doc P0 section).

## TODO (mapped, not implemented)
Headline **SSD-prefix / paged-off cache-policy** change (release-engine-wide, correctness-critical) — touch points + sequencing in `VMLX-ENGINE-WIP-HANDOFF.md`. Plus matrix expansion (E4B/12B/26B/31B × JANG_4M/MXFP4/MXFP8) and VL audio.

This is a WIP/checkpoint PR — not for merge until the VL P0 and cache-policy items are resolved.
