### PR TITLE
Fix MiniMax-M3 native fallback tool prompts

### DIFF
--- a/tests/test_tool_fallback_injection.py
+++ b/tests/test_tool_fallback_injection.py
@@ -220,6 +220,107 @@ def test_fallback_triggered_when_one_tool_missing(mock_tools, mock_messages):
     assert "list_directory" in result
 
 
+def test_minimax_m3_fallback_uses_native_concrete_invoke_examples(mock_messages):
+    """MiniMax-M3 fallback must teach the native tag format with real tool names."""
+    mock_tokenizer = MagicMock()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a command.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "write_file",
+                "description": "Write a file.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                    "required": ["path", "content"],
+                },
+            },
+        },
+    ]
+
+    def mock_apply(messages, **kwargs):
+        return messages[0]["content"] if messages[0]["role"] == "system" else ""
+
+    mock_tokenizer.apply_chat_template.side_effect = mock_apply
+
+    result = check_and_inject_fallback_tools(
+        prompt="<system>No tools here.</system><user>Run a command.</user>",
+        messages=mock_messages,
+        template_tools=tools,
+        tokenizer=mock_tokenizer,
+        template_kwargs={"tools": tools, "tool_choice": "required"},
+        tool_parser_id="minimax_m3",
+    )
+
+    assert "MiniMax-M3 native tools" in result
+    assert "tool_choice=required" in result
+    assert "<tool_call>" in result
+    assert '<invoke name="terminal">' in result
+    assert "<command>VALUE_HERE</command>" in result
+    assert '<invoke name="write_file">' in result
+    assert "<path>VALUE_HERE</path>" in result
+    assert "<content>VALUE_HERE</content>" in result
+    assert "FUNCTION_NAME" not in result
+    assert "Do not emit JSON" in result
+
+
+def test_minimax_m3_generic_template_examples_get_concrete_fallback(mock_messages):
+    """A generic MiniMax-M3 tool example is not enough for native tool parsing."""
+    mock_tokenizer = MagicMock()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+    prompt = (
+        "<system><tool_call><invoke name=\"$TOOL_NAME\">"
+        "<query>$VALUE</query></invoke></tool_call> search</system>"
+    )
+
+    def mock_apply(messages, **kwargs):
+        return messages[0]["content"] if messages[0]["role"] == "system" else ""
+
+    mock_tokenizer.apply_chat_template.side_effect = mock_apply
+
+    result = check_and_inject_fallback_tools(
+        prompt=prompt,
+        messages=mock_messages,
+        template_tools=tools,
+        tokenizer=mock_tokenizer,
+        template_kwargs={"tools": tools},
+        tool_parser_id="minimax_m3",
+    )
+
+    assert result != prompt
+    assert '<invoke name="search">' in result
+    assert "<query>VALUE_HERE</query>" in result
+    assert "$TOOL_NAME" not in result
+
+
 def test_fallback_with_empty_name_tools(mock_messages):
     """Tools with empty function names should not cause errors."""
     mock_tokenizer = MagicMock()

--- a/vmlx_engine/api/tool_calling.py
+++ b/vmlx_engine/api/tool_calling.py
@@ -206,6 +206,11 @@ def check_and_inject_fallback_tools(
         return prompt
     is_lfm2_native_tool_prompt = parser_id in {"lfm2", "liquid"}
     is_minimax_native_tool_prompt = parser_id in {"minimax", "minimax_m2"}
+    is_minimax_m3_native_tool_prompt = parser_id in {
+        "minimax_m3",
+        "minimax-m3",
+        "minimax_m3_vl",
+    }
     is_xml_function_native_tool_prompt = parser_id in {
         "xml_function",
         "mimo_xml_function",
@@ -257,6 +262,11 @@ def check_and_inject_fallback_tools(
         and "<minimax:tool_call>" in instruction_prompt
         and all(f'<invoke name="{name}">' in instruction_prompt for name in tool_names)
     )
+    _minimax_m3_has_concrete_tool_examples = (
+        is_minimax_m3_native_tool_prompt
+        and "<tool_call>" in instruction_prompt
+        and all(f'<invoke name="{name}">' in instruction_prompt for name in tool_names)
+    )
     _xml_function_has_native_tool_schema = (
         is_xml_function_native_tool_prompt
         and "<tool_call>" in instruction_prompt
@@ -285,6 +295,10 @@ def check_and_inject_fallback_tools(
         and (not is_zaya_native_tool_prompt or _zaya_has_concrete_tool_examples)
         and (not is_lfm2_native_tool_prompt or _lfm2_has_concrete_tool_examples)
         and (not is_minimax_native_tool_prompt or _minimax_has_concrete_tool_examples)
+        and (
+            not is_minimax_m3_native_tool_prompt
+            or _minimax_m3_has_concrete_tool_examples
+        )
         and (
             not is_xml_function_native_tool_prompt
             or (
@@ -613,6 +627,25 @@ def check_and_inject_fallback_tools(
                     f'<parameter name="{param.strip()}">{value.strip()}</parameter>'
                 )
             lines.extend(["</invoke>", "</minimax:tool_call>"])
+            blocks.append("\n".join(lines))
+        return "\n\n".join(blocks)
+
+    def _render_minimax_m3_examples(tools: list[dict]) -> str:
+        marker = "]<]minimax[>["
+        blocks: list[str] = []
+        for tool in tools:
+            name, props = _tool_props(tool)
+            if not name:
+                continue
+            lines = [
+                f"{marker}<tool_call>",
+                f'{marker}<invoke name="{name.strip()}">',
+            ]
+            for prop in props:
+                prop = prop.strip()
+                if prop:
+                    lines.append(f"{marker}<{prop}>VALUE_HERE</{prop}>")
+            lines.extend([f"{marker}</invoke>", f"{marker}</tool_call>"])
             blocks.append("\n".join(lines))
         return "\n\n".join(blocks)
 
@@ -1118,6 +1151,43 @@ def check_and_inject_fallback_tools(
             "If the user says the value argument must be the literal string blue-cat, put only blue-cat in value.\n"
             + _render_minimax_examples(minimax_prompt_tools)
         )
+    elif is_minimax_m3_native_tool_prompt:
+        minimax_prompt_tools = _requested_tools(template_tools)
+        minimax_lines = [
+            "You have access to MiniMax-M3 native tools. When the user asks for one, "
+            "call it instead of explaining what you would do.",
+            "If the user asks to read files, write files, run commands, search, "
+            "inspect services, or verify config, use the matching provided tool; "
+            "do not claim that tool-visible paths or hosts are inaccessible.",
+            "",
+        ]
+        if tool_choice_required:
+            minimax_lines.extend(
+                [
+                    "The current API request set tool_choice=required.",
+                    "Your next assistant output must be exactly one MiniMax-M3 tool call and no visible text.",
+                    "Do not emit only a partial tag; include the invoke name, every required parameter, and close the invoke/tool_call tags.",
+                    "",
+                ]
+            )
+        for tool in minimax_prompt_tools:
+            func = _tool_func(tool)
+            name = func.get("name", "") or "unknown_tool"
+            params = func.get("parameters", {}) or {}
+            props = params.get("properties", {}) if isinstance(params, dict) else {}
+            if props:
+                minimax_lines.append(f"{name} fields: {', '.join(str(p) for p in props)}")
+            else:
+                minimax_lines.append(f"{name} fields: none")
+        tool_prompt = (
+            "\n".join(minimax_lines).rstrip()
+            + "\n\nWhen a tool call is needed, emit ONLY this exact MiniMax-M3 XML shape. "
+            "Do not emit JSON, markdown, prose, duplicate <tool_call> tags, generic tool XML, or a fake result. "
+            "Use the exact invoke name from the tool schema and encode arguments as parameter tags. "
+            "Every required field must be present and non-empty. "
+            "Fill fields from the user's request exactly.\n"
+            + _render_minimax_m3_examples(minimax_prompt_tools)
+        )
     else:
         tool_prompt = (
             "You are an expert assistant with access to tools.\n\n"
@@ -1153,6 +1223,14 @@ def check_and_inject_fallback_tools(
         if is_minimax_native_tool_prompt:
             return (
                 "<minimax:tool_call>" in rendered
+                and all(
+                    f'<invoke name="{name}">' in rendered
+                    for name in tool_names
+                )
+            )
+        if is_minimax_m3_native_tool_prompt:
+            return (
+                "<tool_call>" in rendered
                 and all(
                     f'<invoke name="{name}">' in rendered
                     for name in tool_names

--- a/vmlx_engine/cli.py
+++ b/vmlx_engine/cli.py
@@ -675,6 +675,12 @@ def serve_command(args):
     # Configure tool calling
     _user_disabled_tool_parser = getattr(args, "tool_call_parser", None) == "none"
     server._tool_call_parser_disabled_explicitly = _user_disabled_tool_parser
+    server._tool_call_parser_explicit_name = (
+        args.tool_call_parser
+        if args.enable_auto_tool_choice
+        and args.tool_call_parser not in (None, "auto", "none")
+        else None
+    )
     if args.enable_auto_tool_choice and args.tool_call_parser and args.tool_call_parser != "none":
         server._enable_auto_tool_choice = True
         # "auto" → resolved below by model_config_registry auto-apply (lines 86-108)

--- a/vmlx_engine/engine/simple.py
+++ b/vmlx_engine/engine/simple.py
@@ -698,6 +698,7 @@ class SimpleEngine(BaseEngine):
         # Pop vmlx-engine-specific kwargs early to prevent leaking to mlx-lm calls
         extra_ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         reasoning_effort = kwargs.pop("reasoning_effort", None)
+        tool_parser_id = kwargs.pop("_tool_parser_id", None)
         kwargs.pop("request_id", None)
         thinking_enabled = kwargs.pop("enable_thinking", True)
         prompt_suffix = kwargs.pop("prompt_suffix", None)
@@ -829,7 +830,7 @@ class SimpleEngine(BaseEngine):
                         template_tools,
                         tokenizer,
                         tpl_kwargs,
-                        tool_parser_id=self._model_tool_parser_name(),
+                        tool_parser_id=tool_parser_id or self._model_tool_parser_name(),
                     )
 
                     if thinking_enabled is False:
@@ -933,6 +934,7 @@ class SimpleEngine(BaseEngine):
 
         # Pop vmlx-engine-specific kwargs early to prevent leaking to mlx-lm calls
         reasoning_effort = kwargs.pop("reasoning_effort", None)
+        tool_parser_id = kwargs.pop("_tool_parser_id", None)
         thinking_enabled = kwargs.pop("enable_thinking", True)
         extra_ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         prompt_suffix = kwargs.pop("prompt_suffix", None)
@@ -1133,7 +1135,7 @@ class SimpleEngine(BaseEngine):
                 template_tools,
                 tokenizer,
                 template_kwargs,
-                tool_parser_id=self._model_tool_parser_name(),
+                tool_parser_id=tool_parser_id or self._model_tool_parser_name(),
             )
 
             if thinking_enabled is False:

--- a/vmlx_engine/server.py
+++ b/vmlx_engine/server.py
@@ -12238,6 +12238,8 @@ async def create_chat_completion(
     if all_tools:
         chat_kwargs["tools"] = convert_tools_for_template(all_tools)
         chat_kwargs["_vmlx_tools_present"] = True
+        if _tool_call_parser:
+            chat_kwargs["_tool_parser_id"] = _tool_call_parser
 
     # Inject Harmony analysis prefix for GPT-OSS models when thinking is enabled.
     # The suffix replaces the template's generation prompt (<|start|>assistant<|message|>)


### PR DESCRIPTION
## Summary

- preserve the explicitly selected tool parser name from `vmlx serve --tool-call-parser ...`
- pass the active tool parser id through chat generation so fallback prompt injection can use the requested native format
- add MiniMax-M3-specific fallback tool instructions with concrete `<tool_call><invoke name="...">` examples
- cover MiniMax-M3 fallback behavior with focused tests

## Why

MiniMax-M3 chat templates can include generic tool placeholders or omit concrete tool examples. In that state, the fallback injector previously treated the template as tool-aware enough, or generated a generic fallback prompt, so MiniMax-M3 often produced prose/partial tags instead of parseable native tool calls.

This keeps explicit parser selection intact and teaches the fallback injector the native MiniMax-M3 tag shape with real tool names and argument tags.

## Verification

Targeted unit tests:

```bash
/Users/hermes/.hermes/profiles/model-lab/venv/bin/python -m pytest tests/test_tool_fallback_injection.py -q
# 15 passed

/Users/hermes/.hermes/profiles/model-lab/venv/bin/python -m pytest tests/test_engine_audit.py -q -k "loaded_model_parser_refresh or request_reasoning_parser"
# 4 passed, 580 deselected
```

Live local smoke/eval evidence with MiniMax-M3 JANG2L on current vMLX stock + this patch:

- `tool_choice: required` produced OpenAI `tool_calls` for MiniMax-M3 native output (`search({"query":"MiniMax M3"})`)
- VeraEval fast profile after harness/profile tuning completed cleanly: `174/180`, `18/18` tasks, no transport/tool schema failures

