### PR TITLE
Fix MiniMax-M3 VL API routing

### DIFF
--- a/tests/test_minimax_m3_cache_paths.py
+++ b/tests/test_minimax_m3_cache_paths.py
@@ -615,6 +615,47 @@ def test_single_batch_m3_chunks_long_prompt_before_final_sample():
     assert model.calls == [[1, 2, 3], [4, 5, 6], [7, 8]]
 
 
+def test_single_batch_m3_vl_prefills_image_prompt_in_one_forward():
+    from vmlx_engine.utils.single_batch_generator import SingleBatchGenerator
+
+    class _FakeVLModel:
+        def __init__(self):
+            self.calls = []
+
+        def make_cache(self):
+            return []
+
+        def __call__(self, tokens, cache=None, pixel_values=None, image_grid_thw=None):
+            self.calls.append(
+                (
+                    tokens.tolist()[0],
+                    pixel_values is not None,
+                    image_grid_thw is not None,
+                )
+            )
+            return mx.zeros((1, tokens.shape[1], 8), dtype=mx.float32)
+
+    model = _FakeVLModel()
+    gen = SingleBatchGenerator(
+        model,
+        max_tokens=1,
+        sampler=lambda _logits: mx.array([3], dtype=mx.int32),
+        prefill_step_size=3,
+        stream=None,
+    )
+
+    gen.insert(
+        [[1, 2, 3, 4, 5, 6, 7, 8]],
+        pixel_values=[mx.zeros((1, 1), dtype=mx.bfloat16)],
+        image_grid_thw=[mx.array([[1, 1, 1]], dtype=mx.int32)],
+    )
+    prompt_responses, generation_responses = gen.next()
+
+    assert len(prompt_responses) == 1
+    assert generation_responses == []
+    assert model.calls == [([1, 2, 3, 4, 5, 6, 7, 8], True, True)]
+
+
 def test_scheduler_uses_minimax_m3_logits_sampler_for_msa_cache(monkeypatch):
     from vmlx_engine.models.minimax_m3.cache import MiniMaxM3SparseCache
     from vmlx_engine.request import SamplingParams
@@ -731,29 +772,32 @@ def test_minimax_m3_reasoning_on_off_auto_map_to_template_modes(monkeypatch):
 
 
 def test_minimax_m3_vl_preprocess_maps_reasoning_to_thinking_mode(monkeypatch):
-    import numpy as np
+    import mlx.core as mx
 
     from vmlx_engine.models.minimax_m3 import m3_vl_preprocess
 
     seen_kwargs = []
+    seen_texts = []
 
     class _Tokenizer:
         def apply_chat_template(self, messages, **kwargs):
             seen_kwargs.append(dict(kwargs))
-            return "<image> describe"
+            return "]<]image[>[ describe"
 
-    class _Processor:
-        tokenizer = _Tokenizer()
+        def __call__(self, text, return_tensors=None):
+            seen_texts.extend(text)
+            return {"input_ids": [[1, 200025, 2]]}
 
-        def __call__(self, *, text, images, return_tensors):
-            return {
-                "input_ids": np.array([[1, 200025, 2]], dtype=np.int64),
-                "pixel_values": np.zeros((1, 1, 1), dtype=np.float32),
-                "image_grid_thw": np.array([[1, 1, 1]], dtype=np.int32),
-            }
-
-    monkeypatch.setattr(m3_vl_preprocess, "_get_processor", lambda _path: _Processor())
+    monkeypatch.setattr(m3_vl_preprocess, "_get_tokenizer", lambda _path: _Tokenizer())
     monkeypatch.setattr(m3_vl_preprocess, "_load_pil_images", lambda _images: [object()])
+    monkeypatch.setattr(
+        m3_vl_preprocess,
+        "_preprocess_images_native",
+        lambda _images: (
+            mx.zeros((1, 1), dtype=mx.bfloat16),
+            mx.array([[1, 2, 2]], dtype=mx.int32),
+        ),
+    )
 
     messages = [
         {
@@ -778,6 +822,7 @@ def test_minimax_m3_vl_preprocess_maps_reasoning_to_thinking_mode(monkeypatch):
         )
         assert seen_kwargs[-1]["thinking_mode"] == expected
         assert "enable_thinking" not in seen_kwargs[-1]
+        assert seen_texts[-1].count("]<]image[>[") == 1
 
 
 def test_minimax_m3_reasoning_parser_accepts_fallback_think_tags():

--- a/tests/test_minimax_m3_vl_processor_parity.py
+++ b/tests/test_minimax_m3_vl_processor_parity.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in parity checks for MiniMax-M3 VL native image preprocessing.
+
+The reference MiniMax processor imports torch, so this test is intentionally
+guarded out of the default suite. Run it before changing the native
+preprocessor:
+
+    VMLINUX_RUN_M3_VL_PROCESSOR_PARITY=1 \
+    VMLINUX_M3_VL_PARITY_MODEL=/path/to/MiniMax-M3-VL \
+    pytest tests/test_minimax_m3_vl_processor_parity.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("VMLINUX_RUN_M3_VL_PROCESSOR_PARITY") != "1",
+    reason=(
+        "MiniMax-M3 VL processor parity imports the HF torch image processor; "
+        "set VMLINUX_RUN_M3_VL_PROCESSOR_PARITY=1 and "
+        "VMLINUX_M3_VL_PARITY_MODEL to run it."
+    ),
+)
+
+
+def _synthetic_image(width: int, height: int):
+    from PIL import Image, ImageDraw
+
+    image = Image.new("RGB", (width, height), (21, 36, 57))
+    draw = ImageDraw.Draw(image)
+    draw.ellipse(
+        (
+            max(0, width // 12),
+            max(0, height // 8),
+            min(width - 1, width // 12 + max(10, width // 4)),
+            min(height - 1, height // 8 + max(10, height // 4)),
+        ),
+        fill=(230, 20, 20),
+    )
+    draw.rectangle(
+        (
+            max(0, width // 2),
+            max(0, height // 3),
+            min(width - 1, width // 2 + max(10, width // 5)),
+            min(height - 1, height // 3 + max(10, height // 5)),
+        ),
+        fill=(20, 50, 230),
+    )
+    draw.text((max(0, width // 8), max(0, height - 28)), "M3", fill=(245, 245, 245))
+    return image
+
+
+@pytest.mark.parametrize(
+    ("width", "height"),
+    [
+        (112, 112),
+        (113, 251),
+        (640, 360),
+        (896, 512),
+        (47, 999),
+    ],
+)
+def test_native_minimax_m3_vl_image_preprocess_matches_hf_processor(width, height):
+    import numpy as np
+    from transformers import AutoImageProcessor
+
+    from vmlx_engine.models.minimax_m3.minimax_m3_vl import preprocess_image
+
+    model_path = os.environ.get("VMLINUX_M3_VL_PARITY_MODEL")
+    if not model_path:
+        pytest.skip("VMLINUX_M3_VL_PARITY_MODEL is required")
+
+    image = _synthetic_image(width, height)
+    native_pixels, native_grid = preprocess_image(image)
+    processor = AutoImageProcessor.from_pretrained(model_path, trust_remote_code=True)
+    hf = processor(images=[image], return_tensors="np")
+
+    native_pixels_np = np.asarray(native_pixels.tolist(), dtype=np.float32)
+    native_grid_np = np.asarray(native_grid.tolist(), dtype=np.int64)
+    hf_pixels_np = np.asarray(hf["pixel_values"], dtype=np.float32)
+    hf_grid_np = np.asarray(hf["image_grid_thw"], dtype=np.int64)
+
+    assert np.array_equal(native_grid_np, hf_grid_np)
+    np.testing.assert_allclose(native_pixels_np, hf_pixels_np, rtol=1e-5, atol=1e-5)

--- a/tests/test_minimax_m3_vl_processor_parity.py
+++ b/tests/test_minimax_m3_vl_processor_parity.py
@@ -1,17 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """Opt-in parity checks for MiniMax-M3 VL native image preprocessing.
 
-The reference MiniMax processor imports torch, so this test is intentionally
-guarded out of the default suite. Run it before changing the native
-preprocessor:
+The reference MiniMax processor's resize/patchify math uses torch, so this test
+is intentionally guarded out of the default suite. Run it before changing the
+native preprocessor:
 
     VMLINUX_RUN_M3_VL_PROCESSOR_PARITY=1 \
-    VMLINUX_M3_VL_PARITY_MODEL=/path/to/MiniMax-M3-VL \
     pytest tests/test_minimax_m3_vl_processor_parity.py
 """
 
 from __future__ import annotations
 
+import math
 import os
 
 import pytest
@@ -20,11 +20,48 @@ import pytest
 pytestmark = pytest.mark.skipif(
     os.environ.get("VMLINUX_RUN_M3_VL_PROCESSOR_PARITY") != "1",
     reason=(
-        "MiniMax-M3 VL processor parity imports the HF torch image processor; "
-        "set VMLINUX_RUN_M3_VL_PROCESSOR_PARITY=1 and "
-        "VMLINUX_M3_VL_PARITY_MODEL to run it."
+        "MiniMax-M3 VL processor parity imports torch; set "
+        "VMLINUX_RUN_M3_VL_PROCESSOR_PARITY=1 to run it."
     ),
 )
+
+MAX_RATIO = 200
+IMAGE_MEAN = [0.48145466, 0.4578275, 0.40821073]
+IMAGE_STD = [0.26862954, 0.26130258, 0.27577711]
+
+
+def _round_by_factor(number: int, factor: int) -> int:
+    return round(number / factor) * factor
+
+
+def _ceil_by_factor(number: int, factor: int) -> int:
+    return math.ceil(number / factor) * factor
+
+
+def _floor_by_factor(number: int, factor: int) -> int:
+    return math.floor(number / factor) * factor
+
+
+def _smart_resize(
+    height: int,
+    width: int,
+    factor: int = 28,
+    min_pixels: int = 4 * 28 * 28,
+    max_pixels: int = 451584,
+) -> tuple[int, int]:
+    if max(height, width) / min(height, width) > MAX_RATIO:
+        raise ValueError("aspect ratio too extreme")
+    h_bar = max(factor, _round_by_factor(height, factor))
+    w_bar = max(factor, _round_by_factor(width, factor))
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = _floor_by_factor(height / beta, factor)
+        w_bar = _floor_by_factor(width / beta, factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = _ceil_by_factor(height * beta, factor)
+        w_bar = _ceil_by_factor(width * beta, factor)
+    return h_bar, w_bar
 
 
 def _synthetic_image(width: int, height: int):
@@ -54,6 +91,81 @@ def _synthetic_image(width: int, height: int):
     return image
 
 
+def _reference_preprocess_image(
+    image,
+    patch_size: int = 14,
+    temporal_patch_size: int = 2,
+    merge_size: int = 2,
+    max_pixels: int = 451584,
+):
+    """Torch reference from bundled MiniMaxM3VLImageProcessor._preprocess."""
+    import numpy as np
+    import torch
+    import torch.nn.functional as F
+
+    image = image.convert("RGB")
+    tensor = (
+        torch.from_numpy(np.array(image))
+        .contiguous()
+        .permute(2, 0, 1)
+        .contiguous()
+    )
+    height, width = tensor.shape[-2:]
+    resized_height, resized_width = _smart_resize(
+        height,
+        width,
+        factor=patch_size * merge_size,
+        max_pixels=max_pixels,
+    )
+    tensor = F.interpolate(
+        tensor.unsqueeze(0).to(dtype=torch.float32),
+        size=(resized_height, resized_width),
+        mode="bicubic",
+        align_corners=False,
+        antialias=True,
+    ).squeeze(0)
+
+    patches = tensor.to(dtype=torch.float32) * (1 / 255)
+    mean = torch.tensor(IMAGE_MEAN, dtype=patches.dtype).view(3, 1, 1)
+    std = torch.tensor(IMAGE_STD, dtype=patches.dtype).view(3, 1, 1)
+    patches = (patches - mean) / std
+    patches = patches.unsqueeze(0).unsqueeze(0)
+
+    if patches.shape[1] % temporal_patch_size != 0:
+        repeats = patches[:, -1:].repeat(
+            1,
+            temporal_patch_size - (patches.shape[1] % temporal_patch_size),
+            1,
+            1,
+            1,
+        )
+        patches = torch.cat([patches, repeats], dim=1)
+
+    batch_size, grid_t, channel = patches.shape[:3]
+    grid_t = grid_t // temporal_patch_size
+    grid_h = resized_height // patch_size
+    grid_w = resized_width // patch_size
+    patches = patches.view(
+        batch_size,
+        grid_t,
+        temporal_patch_size,
+        channel,
+        grid_h // merge_size,
+        merge_size,
+        patch_size,
+        grid_w // merge_size,
+        merge_size,
+        patch_size,
+    )
+    patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
+    flatten_patches = patches.reshape(
+        batch_size * grid_t * grid_h * grid_w,
+        channel * temporal_patch_size * patch_size * patch_size,
+    )
+    grid = np.array([[grid_t, grid_h, grid_w]], dtype=np.int64)
+    return flatten_patches.detach().cpu().numpy().astype(np.float32), grid
+
+
 @pytest.mark.parametrize(
     ("width", "height"),
     [
@@ -64,25 +176,17 @@ def _synthetic_image(width: int, height: int):
         (47, 999),
     ],
 )
-def test_native_minimax_m3_vl_image_preprocess_matches_hf_processor(width, height):
+def test_native_minimax_m3_vl_image_preprocess_matches_torch_reference(width, height):
     import numpy as np
-    from transformers import AutoImageProcessor
 
     from vmlx_engine.models.minimax_m3.minimax_m3_vl import preprocess_image
 
-    model_path = os.environ.get("VMLINUX_M3_VL_PARITY_MODEL")
-    if not model_path:
-        pytest.skip("VMLINUX_M3_VL_PARITY_MODEL is required")
-
     image = _synthetic_image(width, height)
     native_pixels, native_grid = preprocess_image(image)
-    processor = AutoImageProcessor.from_pretrained(model_path, trust_remote_code=True)
-    hf = processor(images=[image], return_tensors="np")
+    ref_pixels_np, ref_grid_np = _reference_preprocess_image(image)
 
     native_pixels_np = np.asarray(native_pixels.tolist(), dtype=np.float32)
     native_grid_np = np.asarray(native_grid.tolist(), dtype=np.int64)
-    hf_pixels_np = np.asarray(hf["pixel_values"], dtype=np.float32)
-    hf_grid_np = np.asarray(hf["image_grid_thw"], dtype=np.int64)
 
-    assert np.array_equal(native_grid_np, hf_grid_np)
-    np.testing.assert_allclose(native_pixels_np, hf_pixels_np, rtol=1e-5, atol=1e-5)
+    assert np.array_equal(native_grid_np, ref_grid_np)
+    np.testing.assert_allclose(native_pixels_np, ref_pixels_np, rtol=1e-5, atol=1e-5)

--- a/tests/test_native_mtp_autodetect.py
+++ b/tests/test_native_mtp_autodetect.py
@@ -934,6 +934,40 @@ class TestNativeMtpAutodetect:
         assert "multi_modal_projector.linear_1" in candidates
         assert "model.multi_modal_projector.linear_1" in candidates
 
+    def test_minimax_m3_vlm_quant_candidates_select_vision_linears(self):
+        import mlx.nn as nn
+
+        from vmlx_engine.utils.jang_loader import _vlm_quant_module_path_candidates
+
+        class Projector(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear_1 = nn.Linear(32, 4)
+
+        class Vision(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.multi_modal_projector = Projector()
+
+        class TinyMiniMaxM3VL(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.vision = Vision()
+
+        model = TinyMiniMaxM3VL()
+        quantized_suffixes = {"multi_modal_projector.linear_1"}
+
+        def class_predicate(path, module):
+            return bool(
+                hasattr(module, "to_quantized")
+                and _vlm_quant_module_path_candidates(path, "minimax_m3_vl")
+                & quantized_suffixes
+            )
+
+        nn.quantize(model, group_size=32, bits=4, class_predicate=class_predicate)
+
+        assert isinstance(model.vision.multi_modal_projector.linear_1, nn.QuantizedLinear)
+
     def test_pre_load_activation_patches_mlx_vlm_qwen36_language_runtime(
         self, tmp_path
     ):

--- a/tests/test_native_mtp_autodetect.py
+++ b/tests/test_native_mtp_autodetect.py
@@ -923,6 +923,17 @@ class TestNativeMtpAutodetect:
         assert "mtp.fc" in candidates
         assert "model.language_model.mtp.fc" in candidates
 
+    def test_vlm_quant_candidates_map_minimax_m3_vision_wrapper(self):
+        from vmlx_engine.utils.jang_loader import _vlm_quant_module_path_candidates
+
+        candidates = _vlm_quant_module_path_candidates(
+            "vision.multi_modal_projector.linear_1",
+            "minimax_m3_vl",
+        )
+
+        assert "multi_modal_projector.linear_1" in candidates
+        assert "model.multi_modal_projector.linear_1" in candidates
+
     def test_pre_load_activation_patches_mlx_vlm_qwen36_language_runtime(
         self, tmp_path
     ):

--- a/vmlx_engine/models/minimax_m3/m3_vl_preprocess.py
+++ b/vmlx_engine/models/minimax_m3/m3_vl_preprocess.py
@@ -80,7 +80,7 @@ def _preprocess_images_native(pil_images: List[Any]):
     """Run vMLX's native MiniMax-M3 image preprocessor.
 
     Returns MLX ``pixel_values`` and ``image_grid_thw`` matching MiniMax's HF
-    processor layout, but without importing torch/torchvision.
+    processor layout, but without importing the HF AutoProcessor/torchvision.
     """
     import mlx.core as mx
 

--- a/vmlx_engine/models/minimax_m3/m3_vl_preprocess.py
+++ b/vmlx_engine/models/minimax_m3/m3_vl_preprocess.py
@@ -9,10 +9,10 @@ The standalone diagnostics (``diag_m3_vl_integrated.py``) proved that
 
     model(input_ids, cache=cache, pixel_values=pv, image_grid_thw=grid)
 
-produces a coherent image description. The job of this module is to reproduce the
-*exact* preprocessing those diagnostics used (MiniMax ``AutoProcessor``,
-trust_remote_code), so the engine feeds the model identical
-``input_ids`` / ``pixel_values`` / ``image_grid_thw`` tensors.
+produces a coherent image description. This module keeps the same token contract
+without importing MiniMax's HuggingFace ``AutoProcessor`` at request time. That
+processor depends on torch/torchvision/video validation, which is unnecessary for
+the text-routed vMLX image path and can block server requests on Apple Silicon.
 """
 
 from __future__ import annotations
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
 
 _TRUE = {"1", "true", "on", "yes"}
 
-# Process-wide processor cache, keyed by model path. AutoProcessor.from_pretrained
-# is expensive; the processor is stateless across requests so caching is safe.
-_PROCESSOR_CACHE: dict[str, Any] = {}
+# Process-wide tokenizer cache, keyed by model path. Tokenizers are stateless
+# across requests and much cheaper/safer than loading the full AutoProcessor.
+_TOKENIZER_CACHE: dict[str, Any] = {}
 
 
 def m3_vl_enabled() -> bool:
@@ -52,15 +52,15 @@ def is_m3_vl_model(model: Any) -> bool:
         return False
 
 
-def _get_processor(model_path: str):
-    proc = _PROCESSOR_CACHE.get(model_path)
-    if proc is not None:
-        return proc
-    from transformers import AutoProcessor
+def _get_tokenizer(model_path: str):
+    tok = _TOKENIZER_CACHE.get(model_path)
+    if tok is not None:
+        return tok
+    from transformers import AutoTokenizer
 
-    proc = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
-    _PROCESSOR_CACHE[model_path] = proc
-    return proc
+    tok = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    _TOKENIZER_CACHE[model_path] = tok
+    return tok
 
 
 def _load_pil_images(images: List[Any]):
@@ -74,6 +74,65 @@ def _load_pil_images(images: List[Any]):
         path = process_image_input(img)
         out.append(Image.open(path).convert("RGB"))
     return out
+
+
+def _preprocess_images_native(pil_images: List[Any]):
+    """Run vMLX's native MiniMax-M3 image preprocessor.
+
+    Returns MLX ``pixel_values`` and ``image_grid_thw`` matching MiniMax's HF
+    processor layout, but without importing torch/torchvision.
+    """
+    import mlx.core as mx
+
+    from .minimax_m3_vl import preprocess_image
+
+    pixel_chunks = []
+    grid_chunks = []
+    for image in pil_images:
+        pv, grid = preprocess_image(image)
+        pixel_chunks.append(pv)
+        grid_chunks.append(grid)
+    if not pixel_chunks:
+        raise ValueError("M3 VL: all image inputs failed to preprocess")
+    pixel_values = mx.concatenate(pixel_chunks, axis=0).astype(mx.bfloat16)
+    grid = mx.concatenate(grid_chunks, axis=0).astype(mx.int32)
+    mx.eval(pixel_values, grid)
+    return pixel_values, grid
+
+
+def _expand_image_tokens(text: str, image_grid_thw: Any, merge_size: int = 2) -> str:
+    """Expand each MiniMax image marker to one token per merged image patch."""
+    image_token = "]<]image[>["
+    vision_start = "]<]start of image[>["
+    vision_end = "]<]end of image[>["
+    placeholder = "]<]placeholder[>["
+    merge_length = merge_size**2
+    grids = image_grid_thw.tolist()
+    index = 0
+    while image_token in text:
+        if index >= len(grids):
+            raise ValueError(
+                "M3 VL: prompt contains more image placeholders than images"
+            )
+        gt, gh, gw = (int(v) for v in grids[index])
+        num_tokens = (gt * gh * gw) // merge_length
+        text = text.replace(
+            image_token,
+            vision_start + placeholder * num_tokens + vision_end,
+            1,
+        )
+        index += 1
+    if index != len(grids):
+        raise ValueError(
+            "M3 VL: image count does not match chat-template placeholders"
+        )
+    return text.replace(placeholder, image_token)
+
+
+def _tokenize_text(tok: Any, text: str) -> List[int]:
+    encoded = tok([text], return_tensors=None)
+    ids = encoded["input_ids"][0]
+    return [int(x) for x in ids]
 
 
 def _normalize_messages_for_template(messages: List[dict]) -> Tuple[List[dict], List[Any]]:
@@ -128,18 +187,14 @@ def preprocess_m3_vl_messages(
     add_generation_prompt: bool = True,
     enable_thinking: Optional[bool] = None,
 ) -> Optional[Tuple[List[int], Any, Any]]:
-    """Template `messages` + run the MiniMax processor -> (input_ids, pv, grid).
+    """Template `messages` + native image preprocess -> (input_ids, pv, grid).
 
-    Mirrors the proven diag preprocessing exactly: normalize image items to
-    ``{"type": "image"}``, ``apply_chat_template`` via the processor's tokenizer,
-    then call the processor with the raw PIL images. Returns ``None`` when there
-    are no images.
+    Mirrors MiniMax processor semantics without importing HF AutoProcessor:
+    normalize image items to ``{"type": "image"}``, render the chat template,
+    preprocess images with the vMLX native MiniMax image path, expand image
+    markers to patch-token placeholders, then tokenize.
     """
-    import mlx.core as mx
-    import numpy as np
-
-    proc = _get_processor(model_path)
-    tok = getattr(proc, "tokenizer", proc)
+    tok = _get_tokenizer(model_path)
 
     norm_msgs, raw_images = _normalize_messages_for_template(messages)
     if not raw_images and extra_images:
@@ -198,18 +253,11 @@ def preprocess_m3_vl_messages(
     if not pil_images:
         raise ValueError("M3 VL: all image inputs failed to load")
 
-    out = proc(text=[txt], images=pil_images, return_tensors="np")
-    ids = np.asarray(out["input_ids"][0]).astype(np.int64)
-    input_ids = [int(x) for x in ids.tolist()]
-    pixel_values = mx.array(out["pixel_values"]).astype(mx.bfloat16)
-    grid = mx.array(np.asarray(out["image_grid_thw"]).astype(np.int32))
-    # Materialize NOW so no lazy graph crosses threads. Preprocessing runs on the
-    # server event loop thread; the forward runs on the scheduler worker thread.
-    # A lazy astype bound to this thread's default stream would otherwise fail to
-    # resolve there (P0 VL stream bug: "no Stream(gpu,0) in current thread").
-    mx.eval(pixel_values, grid)
+    pixel_values, grid = _preprocess_images_native(pil_images)
+    txt = _expand_image_tokens(txt, grid)
+    input_ids = _tokenize_text(tok, txt)
 
-    n_img = int((ids == 200025).sum())
+    n_img = sum(1 for token in input_ids if token == 200025)
     logger.info(
         "M3 VL preprocess: %d tokens, %d image tokens, pixel_values=%s grid=%s",
         len(input_ids),
@@ -246,29 +294,19 @@ def preprocess_m3_vl(
     template renders an ``<image>`` placeholder per image item; the processor
     expands each into the configured number of image tokens.
     """
-    import mlx.core as mx
-    import numpy as np
-
     if not images:
         return None
 
-    proc = _get_processor(model_path)
+    tok = _get_tokenizer(model_path)
     pil_images = _load_pil_images(images)
     if not pil_images:
         raise ValueError("M3 VL: all image inputs failed to load")
 
-    out = proc(text=[prompt], images=pil_images, return_tensors="np")
-    ids = np.asarray(out["input_ids"][0]).astype(np.int64)
-    input_ids = [int(x) for x in ids.tolist()]
-    pixel_values = mx.array(out["pixel_values"]).astype(mx.bfloat16)
-    grid = mx.array(np.asarray(out["image_grid_thw"]).astype(np.int32))
-    # Materialize NOW so no lazy graph crosses threads. Preprocessing runs on the
-    # server event loop thread; the forward runs on the scheduler worker thread.
-    # A lazy astype bound to this thread's default stream would otherwise fail to
-    # resolve there (P0 VL stream bug: "no Stream(gpu,0) in current thread").
-    mx.eval(pixel_values, grid)
+    pixel_values, grid = _preprocess_images_native(pil_images)
+    prompt = _expand_image_tokens(prompt, grid)
+    input_ids = _tokenize_text(tok, prompt)
 
-    n_img = int((ids == 200025).sum())
+    n_img = sum(1 for token in input_ids if token == 200025)
     logger.info(
         "M3 VL preprocess: %d tokens, %d image tokens, pixel_values=%s grid=%s",
         len(input_ids),

--- a/vmlx_engine/models/minimax_m3/minimax_m3_vl.py
+++ b/vmlx_engine/models/minimax_m3/minimax_m3_vl.py
@@ -76,13 +76,26 @@ def preprocess_image(pil_img, patch_size=14, temporal_patch_size=2, merge_size=2
     """PIL image -> (pixel_values[num_patches, 1176], grid_thw[1,3]). Mirrors the
     bundled MiniMaxM3VLImageProcessor (Qwen2-VL layout)."""
     import numpy as np
-    from PIL import Image
+    import torch
+    import torch.nn.functional as F
+
     img = pil_img.convert("RGB")
     w0, h0 = img.size
     factor = patch_size * merge_size
     rh, rw = smart_resize(h0, w0, factor=factor, max_pixels=max_pixels)
-    img = img.resize((rw, rh), Image.BICUBIC)
-    arr = np.asarray(img).astype(np.float32) / 255.0          # [H,W,3]
+    arr = np.asarray(img).astype(np.float32)                 # [H,W,3]
+    # Match MiniMaxM3VLImageProcessor.resize exactly: torch bicubic,
+    # align_corners=False, antialias=True. PIL bicubic is close but not
+    # numerically equivalent after resizing.
+    tensor = torch.from_numpy(arr).contiguous().permute(2, 0, 1).unsqueeze(0)
+    tensor = F.interpolate(
+        tensor,
+        size=(rh, rw),
+        mode="bicubic",
+        align_corners=False,
+        antialias=True,
+    ).squeeze(0)
+    arr = tensor.permute(1, 2, 0).detach().cpu().numpy().astype(np.float32) / 255.0
     arr = np.transpose(arr, (2, 0, 1))                        # [3,H,W]
     x = mx.array(arr)
     x = (x - IMAGE_MEAN) / IMAGE_STD                          # normalize

--- a/vmlx_engine/models/minimax_m3/minimax_m3_vl.py
+++ b/vmlx_engine/models/minimax_m3/minimax_m3_vl.py
@@ -10,7 +10,7 @@ tower as the structural template.
 
 Confirmed architecture (see docs BUILD-STATUS):
   pixel_values[N, 1176] --3D-conv patch_embed--> [N, 1280]
-    + 3D-RoPE (h,w; head_dim 80, rope on 40 dims)
+    + 3D-RoPE (t,h,w; head_dim 80, rope on 78 dims, tail pass-through)
     --> pre_layrnorm --> 32 CLIP-style encoder layers
         (LayerNorm; separate q/k/v/out_proj with bias; mlp fc1 1280->5120 gelu fc2;
          FULL attention per image, no window)
@@ -105,45 +105,52 @@ def preprocess_image(pil_img, patch_size=14, temporal_patch_size=2, merge_size=2
     return pixel_values, grid_thw
 
 
-# ── 3D-RoPE (h,w spatial; t=1 for images) ──
+# ── 3D-RoPE (t,h,w; matches transformers.models.minimax_m3_vl) ──
 def rotate_half(x):
     x1 = x[..., : x.shape[-1] // 2]
     x2 = x[..., x.shape[-1] // 2:]
     return mx.concatenate([-x2, x1], axis=-1)
 
 
-def apply_rope_vision(t, freqs):
-    cos = mx.expand_dims(mx.tile(mx.expand_dims(mx.cos(freqs), 1), (1, 1, 2)), 0)
-    sin = mx.expand_dims(mx.tile(mx.expand_dims(mx.sin(freqs), 1), (1, 1, 2)), 0)
-    return (t * cos) + (rotate_half(t) * sin)
+def apply_rope_vision(q, k, cos, sin):
+    rot_dim = cos.shape[-1]
+    cos = mx.expand_dims(mx.expand_dims(cos, 0), 2)  # [1, L, 1, rot_dim]
+    sin = mx.expand_dims(mx.expand_dims(sin, 0), 2)
+    q_rot, q_pass = q[..., :rot_dim], q[..., rot_dim:]
+    k_rot, k_pass = k[..., :rot_dim], k[..., rot_dim:]
+    q_rot = (q_rot * cos) + (rotate_half(q_rot) * sin)
+    k_rot = (k_rot * cos) + (rotate_half(k_rot) * sin)
+    return mx.concatenate([q_rot, q_pass], axis=-1), mx.concatenate([k_rot, k_pass], axis=-1)
 
 
-class VisionRoPE(nn.Module):
-    def __init__(self, dim, theta=10000.0):
+class VisionRoPE3D(nn.Module):
+    def __init__(self, head_dim, theta=10000.0, spatial_merge_size=1):
         super().__init__()
-        self.dim, self.theta = dim, theta
+        rope_dims = 2 * (head_dim // 2)
+        self.axis_dim = 2 * ((rope_dims // 3) // 2)
+        self.theta = theta
+        self.spatial_merge_size = spatial_merge_size
 
-    def __call__(self, seqlen):
-        inv = 1.0 / (self.theta ** (mx.arange(0, self.dim, 2, dtype=mx.float32) / self.dim))
-        seq = mx.arange(int(seqlen), dtype=inv.dtype)
-        return mx.outer(seq, inv)
+    def __call__(self, grid_thw, dtype=mx.float32):
+        m = self.spatial_merge_size
+        coords = []
+        for t, h, w in grid_thw.tolist():
+            hi = mx.repeat(mx.expand_dims(mx.arange(h), 1), w, axis=1)
+            hi = hi.reshape(h // m, m, w // m, m)
+            hi = mx.transpose(hi, (0, 2, 1, 3)).flatten()
+            wi = mx.repeat(mx.expand_dims(mx.arange(w), 0), h, axis=0)
+            wi = wi.reshape(h // m, m, w // m, m)
+            wi = mx.transpose(wi, (0, 2, 1, 3)).flatten()
+            ti = mx.repeat(mx.arange(t), h * w)
+            coords.append(mx.stack([ti, mx.tile(hi, t), mx.tile(wi, t)], axis=-1))
+        coords = mx.concatenate(coords, axis=0).astype(mx.float32)
 
-
-def rot_pos_emb(grid_thw, merge_size, rope):
-    pos_ids = []
-    for t, h, w in grid_thw.tolist():
-        hp = mx.repeat(mx.expand_dims(mx.arange(h), 1), w, axis=1)
-        hp = hp.reshape(h // merge_size, merge_size, w // merge_size, merge_size)
-        hp = mx.transpose(hp, (0, 2, 1, 3)).flatten()
-        wp = mx.repeat(mx.expand_dims(mx.arange(w), 0), h, axis=0)
-        wp = wp.reshape(h // merge_size, merge_size, w // merge_size, merge_size)
-        wp = mx.transpose(wp, (0, 2, 1, 3)).flatten()
-        pos_ids.append(mx.tile(mx.stack([hp, wp], axis=-1), (t, 1)))
-    pos_ids = mx.concatenate(pos_ids, axis=0)
-    max_grid = int(mx.max(grid_thw[:, 1:]))
-    full = rope(max_grid)
-    emb = full[pos_ids]
-    return emb.reshape(pos_ids.shape[0], -1)
+        inv = 1.0 / (
+            self.theta ** (mx.arange(0, self.axis_dim, 2, dtype=mx.float32) / self.axis_dim)
+        )
+        freqs = mx.concatenate([coords[:, i:i + 1] * inv for i in range(3)], axis=-1)
+        emb = mx.concatenate([freqs, freqs], axis=-1)
+        return mx.cos(emb).astype(dtype), mx.sin(emb).astype(dtype)
 
 
 # ── CLIP-style encoder layer (LayerNorm, separate q/k/v/out, gelu mlp) ──
@@ -158,26 +165,19 @@ class M3VisionAttention(nn.Module):
         self.v_proj = nn.Linear(dim, dim, bias=True)
         self.out_proj = nn.Linear(dim, dim, bias=True)
 
-    def __call__(self, x, cu_seqlens, rope_emb):
+    def __call__(self, x, cu_seqlens, position_embeddings):
         L = x.shape[0]
         q = self.q_proj(x).reshape(L, self.num_heads, self.head_dim)
         k = self.k_proj(x).reshape(L, self.num_heads, self.head_dim)
         v = self.v_proj(x).reshape(L, self.num_heads, self.head_dim)
-        q = apply_rope_vision(mx.expand_dims(q, 0), rope_emb)[0]
-        k = apply_rope_vision(mx.expand_dims(k, 0), rope_emb)[0]
+        cos, sin = position_embeddings
+        q, k = apply_rope_vision(mx.expand_dims(q, 0), mx.expand_dims(k, 0), cos, sin)
+        q, k = q[0], k[0]
         q = mx.expand_dims(q.transpose(1, 0, 2), 0)  # [1,H,L,d]
         k = mx.expand_dims(k.transpose(1, 0, 2), 0)
         v = mx.expand_dims(v.transpose(1, 0, 2), 0)
-        cs = cu_seqlens.tolist()
-        outs = []
-        for i in range(len(cs) - 1):
-            a, b = cs[i], cs[i + 1]
-            if b <= a:
-                continue
-            o = mx.fast.scaled_dot_product_attention(
-                q[:, :, a:b], k[:, :, a:b], v[:, :, a:b], scale=self.scale, mask=None)
-            outs.append(o)
-        out = mx.concatenate(outs, axis=2)[0].transpose(1, 0, 2).reshape(L, -1)
+        out = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=self.scale, mask=None)[0].transpose(1, 0, 2).reshape(L, -1)
         return self.out_proj(out)
 
 
@@ -229,18 +229,18 @@ class MiniMaxM3VisionModel(nn.Module):
         self.pre_layrnorm = nn.LayerNorm(dim, eps=vc.get("layer_norm_eps", 1e-5))
         self.encoder = _Encoder(vc)
         head_dim = dim // self.num_heads
-        self.rope = VisionRoPE(head_dim // 2, theta=vc.get("rope_theta", 10000.0))
+        self.rope = VisionRoPE3D(
+            head_dim, theta=vc.get("rope_theta", 10000.0), spatial_merge_size=self.merge_size)
 
     def __call__(self, pixel_values, grid_thw):
         x = self.embeddings(pixel_values)                  # [N, dim]
         x = self.pre_layrnorm(x)
-        rope_emb = rot_pos_emb(grid_thw, self.merge_size, self.rope)
-        # full attention per image: cu_seqlens at image boundaries
+        position_embeddings = self.rope(grid_thw, dtype=x.dtype)
         cu = [0]
         for t, h, w in grid_thw.tolist():
             cu.append(cu[-1] + t * h * w)
         cu_seqlens = mx.array(cu, dtype=mx.int32)
-        x = self.encoder(x, cu_seqlens, rope_emb)
+        x = self.encoder(x, cu_seqlens, position_embeddings)
         return x
 
 

--- a/vmlx_engine/utils/jang_loader.py
+++ b/vmlx_engine/utils/jang_loader.py
@@ -579,6 +579,18 @@ def _vlm_quant_module_path_candidates(module_path: str, model_type: str = "") ->
     if module_path.endswith("lm_head") or "language_model.lm_head" in module_path:
         candidates.add("lm_head")
 
+    if str(model_type or "").lower() in {"minimax_m3", "minimax_m3_vl"}:
+        # The vendored MiniMax-M3 runtime hangs the VL stack under
+        # ``model.vision`` while JANG bundles store those weights at top-level
+        # paths such as ``vision_tower.*``, ``multi_modal_projector.*`` and
+        # ``patch_merge_mlp.*``.  Let nn.quantize() see through that runtime
+        # wrapper; otherwise quantized vision linears stay plain nn.Linear and
+        # their uint32 sidecars are skipped by strict=False load.
+        if module_path.startswith("vision."):
+            raw = module_path[len("vision.") :]
+            candidates.add(raw)
+            candidates.add(f"model.{raw}")
+
     if str(model_type or "").lower() == "zaya1_vl":
         if module_path.startswith("language_model.model."):
             raw = module_path.replace("language_model.model.", "model.", 1)
@@ -3538,16 +3550,17 @@ def _load_jang_v2_vlm(
         return None
 
     def get_class_predicate(p, m):
-        if skip_multimodal_module(p):
+        candidates = _vlm_quant_module_path_candidates(
+            p,
+            str(config.get("model_type", "")),
+        )
+        if skip_multimodal_module(p) and not (candidates & quantized_suffixes):
             return False
         if not hasattr(m, "to_quantized"):
             return False
         # Path matches: same logic as before for "should this module be quantized?"
         _matched = False
-        if _vlm_quant_module_path_candidates(
-            p,
-            str(config.get("model_type", "")),
-        ) & quantized_suffixes:
+        if candidates & quantized_suffixes:
             _matched = True
         if not _matched:
             return False

--- a/vmlx_engine/utils/single_batch_generator.py
+++ b/vmlx_engine/utils/single_batch_generator.py
@@ -617,7 +617,15 @@ class SingleBatchGenerator:
         image-token positions must co-occur for the vision splice.
         """
         tokens = list(req.prompt_tokens)
-        step = max(1, int(self.prefill_step_size or len(tokens) or 1))
+        if req.pixel_values is not None:
+            # VL splice correctness requires image-token positions and
+            # pixel_values to be present in the same forward.  _model_call()
+            # intentionally clears pixel_values after the first forward so
+            # decode stays text-only; therefore image prompts cannot be split
+            # by prefill_step_size.
+            step = max(1, len(tokens))
+        else:
+            step = max(1, int(self.prefill_step_size or len(tokens) or 1))
         pos = 0
         _prefill_keep_alloc = os.environ.get(
             "VMLINUX_PREFILL_KEEP_ALLOC",


### PR DESCRIPTION
## Summary
- avoid MiniMax-M3 VL request-time AutoProcessor imports by using the native vMLX image preprocessor plus tokenizer image-token expansion
- align the MiniMax-M3 vision tower with the official 3D RoPE contract and full vision attention path
- quantize MiniMax-M3 VL JANG vision/projector modules by mapping runtime vision.* paths back to bundle-side names
- keep M3 VL image prompts in a single prefill forward so pixel_values and image-token positions co-occur

## Validation
- py_compile on touched runtime and test files
- direct MiniMax-M3 VL checks for native preprocessing/token expansion, quant path mapping, single-forward VL prefill, and 3D RoPE shapes
- local server smoke tested text and image requests back-to-back on MiniMax-M3-REAP22-Coder via vMLX