### PR TITLE
Fix session chat list overlay titlebar collision

### DIFF
--- a/panel/src/renderer/src/components/sessions/SessionView.tsx
+++ b/panel/src/renderer/src/components/sessions/SessionView.tsx
@@ -244,7 +244,7 @@ export function SessionView({ sessionId, onBack }: SessionViewProps) {
   const isImageEdit = isImage && sessionConfig.imageMode === 'edit'
 
   return (
-    <div className="flex flex-col h-full min-h-0">
+    <div className="relative flex flex-col h-full min-h-0">
       {/* Session Header */}
       <div className="flex items-center gap-3 px-4 py-2 border-b border-border bg-card/50 flex-shrink-0 overflow-x-auto [scrollbar-width:thin]">
         <button onClick={onBack} className="text-muted-foreground hover:text-foreground text-sm flex items-center gap-1 flex-shrink-0">
@@ -449,7 +449,7 @@ export function SessionView({ sessionId, onBack }: SessionViewProps) {
 
       {/* Chat List Overlay */}
       {showChatList && (
-        <div className="fixed inset-0 bg-background/50 z-10" onClick={() => setShowChatList(false)}>
+        <div className="absolute inset-0 bg-background/50 z-10" onClick={() => setShowChatList(false)}>
           <div className="w-80 h-full bg-card border-r border-border" onClick={e => e.stopPropagation()}>
             <ChatList
               currentChatId={currentChatId}

--- a/panel/tests/layout-shell.test.ts
+++ b/panel/tests/layout-shell.test.ts
@@ -14,6 +14,7 @@
  *   - No hardcoded values verification
  */
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
 
 // ─── AppState Types (from types/app-state.ts) ────────────────────────────────
 
@@ -433,6 +434,16 @@ describe('AppState Reducer', () => {
       const result = appReducer(initialState, { type: 'NONEXISTENT' } as any)
       expect(result).toEqual(initialState)
     })
+  })
+})
+
+describe('SessionView chat list overlay', () => {
+  const sessionViewSource = readFileSync('src/renderer/src/components/sessions/SessionView.tsx', 'utf8')
+
+  it('positions the chat list overlay inside the session view, below the app titlebar', () => {
+    expect(sessionViewSource).toContain('className="relative flex flex-col h-full min-h-0"')
+    expect(sessionViewSource).toContain('className="absolute inset-0 bg-background/50 z-10"')
+    expect(sessionViewSource).not.toContain('className="fixed inset-0 bg-background/50 z-10"')
   })
 })
 


### PR DESCRIPTION
## Problem

In the session view, opening the chat list from the three-line menu next to `+ Chat` caused the left-side overlay to cover the macOS titlebar traffic-light controls.

This made the close/minimize/maximize buttons visually clip through the menu overlay.

## Root Cause

The session chat-list overlay was positioned with `fixed inset-0`, so it was anchored to the full Electron window viewport.

Because the app uses a hidden/inset macOS titlebar, that viewport includes the titlebar/traffic-light region. The overlay therefore drew over controls that live outside the session content area.

## This PR

Changes the session view to be the overlay positioning boundary:

- Makes `SessionView` root `relative`
- Changes the chat-list overlay from `fixed inset-0` to `absolute inset-0`
- Adds a layout regression test so the overlay does not accidentally return to viewport-fixed positioning

No engine, model launch, cache, parser, or runtime behavior changes.

## Before / After

### Before

<img width="312" height="500" alt="Screenshot 2026-06-29 at 1 02 49 pm" src="https://github.com/user-attachments/assets/e8fa5729-e32d-4ffa-9dac-6f9f45e6df11" />


### After

<img width="312" height="500" alt="Screenshot 2026-06-29 at 1 02 22 pm" src="https://github.com/user-attachments/assets/40b407e8-724b-41c8-9e92-3bc3c5131a5b" />

## Proven Live on the Dev App

Verified on the patched Electron dev app from branch `ui/fix-chat-sidebar-titlebar`.

| Case | Result |
|---|---|
| Server tab -> launch model -> open session chat | Session view opens normally |
| Click menu next to `+ Chat` | Chat list opens on the left |
| Inspect macOS traffic-light controls | Close/minimize/maximize remain unobstructed |

Tested with a Gemma4 session launch path using the bundled vMLX engine.

## Tests

- `npm run typecheck`
- `npx vitest run tests/layout-shell.test.ts`

Full `npm test` was attempted, but the suite has unrelated existing failures in:

- `tests/i18n-consistency.test.ts`
- `tests/settings-flow.test.ts`
