### PR TITLE
Polish vMLX chat UI overlays and controls

### DIFF
--- a/panel/src/renderer/src/components/chat/InputBox.tsx
+++ b/panel/src/renderer/src/components/chat/InputBox.tsx
@@ -79,6 +79,7 @@ export function InputBox({ onSend, onAbort, disabled, loading, sessionEndpoint, 
     const el = textareaRef.current
     if (!el) return
     el.style.height = 'auto'
+    el.style.overflowY = el.scrollHeight > 200 ? 'auto' : 'hidden'
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`
   }, [message])
 

--- a/panel/src/renderer/src/components/layout/TitleBar.tsx
+++ b/panel/src/renderer/src/components/layout/TitleBar.tsx
@@ -30,13 +30,13 @@ export function TitleBar() {
     >
       {/* macOS traffic light spacer + sidebar toggle */}
       <div
-        className="flex items-center gap-1 pl-[72px] pr-2"
+        className="flex w-[102px] shrink-0 items-center gap-1 pl-[72px] pr-2"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         {state.mode === "chat" && (
           <button
             onClick={() => dispatch({ type: "TOGGLE_SIDEBAR" })}
-            className="p-1 text-muted-foreground hover:text-foreground rounded hover:bg-accent transition-colors"
+            className="p-1 translate-y-[3px] text-muted-foreground hover:text-foreground rounded hover:bg-accent transition-colors focus:outline-none focus-visible:outline-none"
             title={
               state.sidebarCollapsed
                 ? t("app.sidebar.show")

--- a/panel/src/renderer/src/components/sessions/SessionView.tsx
+++ b/panel/src/renderer/src/components/sessions/SessionView.tsx
@@ -244,7 +244,7 @@ export function SessionView({ sessionId, onBack }: SessionViewProps) {
   const isImageEdit = isImage && sessionConfig.imageMode === 'edit'
 
   return (
-    <div className="flex flex-col h-full min-h-0">
+    <div className="relative flex flex-col h-full min-h-0">
       {/* Session Header */}
       <div className="flex items-center gap-3 px-4 py-2 border-b border-border bg-card/50 flex-shrink-0 overflow-x-auto [scrollbar-width:thin]">
         <button onClick={onBack} className="text-muted-foreground hover:text-foreground text-sm flex items-center gap-1 flex-shrink-0">
@@ -449,7 +449,7 @@ export function SessionView({ sessionId, onBack }: SessionViewProps) {
 
       {/* Chat List Overlay */}
       {showChatList && (
-        <div className="fixed inset-0 bg-background/50 z-10" onClick={() => setShowChatList(false)}>
+        <div className="absolute inset-0 bg-background/50 z-10" onClick={() => setShowChatList(false)}>
           <div className="w-80 h-full bg-card border-r border-border" onClick={e => e.stopPropagation()}>
             <ChatList
               currentChatId={currentChatId}

--- a/panel/tests/layout-shell.test.ts
+++ b/panel/tests/layout-shell.test.ts
@@ -14,6 +14,7 @@
  *   - No hardcoded values verification
  */
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
 
 // ─── AppState Types (from types/app-state.ts) ────────────────────────────────
 
@@ -433,6 +434,16 @@ describe('AppState Reducer', () => {
       const result = appReducer(initialState, { type: 'NONEXISTENT' } as any)
       expect(result).toEqual(initialState)
     })
+  })
+})
+
+describe('SessionView chat list overlay', () => {
+  const sessionViewSource = readFileSync('src/renderer/src/components/sessions/SessionView.tsx', 'utf8')
+
+  it('positions the chat list overlay inside the session view, below the app titlebar', () => {
+    expect(sessionViewSource).toContain('className="relative flex flex-col h-full min-h-0"')
+    expect(sessionViewSource).toContain('className="absolute inset-0 bg-background/50 z-10"')
+    expect(sessionViewSource).not.toContain('className="fixed inset-0 bg-background/50 z-10"')
   })
 })
 


### PR DESCRIPTION
## Summary

Consolidates four small chat UI polish fixes into one end-of-day PR:

- Server tab chat clipping / session chat-list overlay titlebar collision
- Empty chat input scrollbar
- Hide-sidebar button alignment in the Chat tab titlebar
- Navigation tab alignment when switching into the Chat tab

## Fixes Included

### Keep session chat-list overlay below the titlebar

Problem: opening the session chat list from the three-line menu next to `+ Chat` could draw the overlay over the macOS traffic-light controls.

Root Cause: `panel/src/renderer/src/components/sessions/SessionView.tsx` used `fixed inset-0` for the overlay, anchoring it to the full Electron viewport, including the hidden/inset titlebar area.

Fix: make the session view a relative positioning boundary, switch the overlay to `absolute inset-0`, and add layout regression coverage.

Visual proof:

Before:

<img width="312" height="500" alt="Session chat list overlay covering titlebar controls" src="https://github.com/user-attachments/assets/e8fa5729-e32d-4ffa-9dac-6f9f45e6df11" />

After:

<img width="312" height="500" alt="Session chat list overlay contained below titlebar controls" src="https://github.com/user-attachments/assets/40b407e8-724b-41c8-9e92-3bc3c5131a5b" />

### Hide empty chat composer scrollbar

Problem: the chat message text input could show a vertical scrollbar even when empty.

Root Cause: `panel/src/renderer/src/components/chat/InputBox.tsx` autosized the textarea height but left vertical overflow to native textarea behavior, which made the globally styled WebKit scrollbar visible in the empty/minimum-height state.

Fix: hide vertical overflow until the textarea content exceeds the 200px cap, then restore `auto` scrolling for long prompts.

Visual proof:

Before:
<img width="693" height="267" alt="Empty chat composer showing scrollbar before fix" src="https://github.com/user-attachments/assets/dde8787e-a97e-4402-a574-f2d2c18efb83" />

After:
<img width="693" height="267" alt="Empty chat composer without scrollbar after fix" src="https://github.com/user-attachments/assets/4e6ea7ed-7f49-4130-bbf5-cd49c991c176" />

### Align the Chat tab hide-sidebar button

Problem: the Chat tab's hide/show sidebar control sat slightly high relative to the native macOS traffic-light controls, and the hover/focus treatment made the mismatch more visible.

Root Cause: `panel/src/renderer/src/components/layout/TitleBar.tsx` rendered the sidebar toggle as a regular padded icon button in the titlebar row, while the apparent centerline did not match the native traffic-light row.

Fix: move the toggle and hover background down together with `translate-y-[3px]`, and suppress the titlebar control's default focus outline.

Visual proof:

Verified manually in the patched dev app.

### Keep navigation tabs aligned in Chat mode

Problem: switching into the Chat tab shifted the central navigation tab group to the right.

Root Cause: the left titlebar rail grew only in Chat mode because the sidebar toggle was conditionally rendered there, and the mode switcher centers itself in the remaining flex space.

Fix: reserve the left titlebar rail width in every mode so the central navigation tabs stay stationary when Chat mode is selected.

Visual proof:

Verified manually in the patched dev app.

## Proven Live on the Dev App

- Session chat-list overlay: verified with before/after screenshots above.
- Empty chat composer scrollbar: verified with before/after screenshots above and manually in the patched dev app.
- Hide-sidebar button alignment: verified manually in the patched dev app.
- Navigation tab alignment: verified manually in the patched dev app.

## Tests

- `npm run typecheck`
- `npx vitest run tests/layout-shell.test.ts tests/chat-ui.test.ts`

Result: 2 test files passed, 328 tests passed.

## Notes

No engine, model launch, cache, parser, or runtime behavior is intended to change.
