### PR TITLE
Fix Qwen Smelt JANG norm shift

### DIFF
--- a/tests/test_smelt_loader.py
+++ b/tests/test_smelt_loader.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+
+
+def test_smelt_load_applies_internal_jang_norm_shift(monkeypatch, tmp_path):
+    import jang_tools.loader as jt_loader
+    import vmlx_engine.utils.jang_loader as internal_jang_loader
+    import vmlx_engine.utils.smelt_loader as smelt_loader
+
+    calls = []
+
+    class FakeModel:
+        def __init__(self):
+            self.model = SimpleNamespace(layers=[])
+
+        def parameters(self):
+            return {}
+
+    fake_model = FakeModel()
+    fake_tokenizer = object()
+
+    monkeypatch.setattr(
+        jt_loader,
+        "load_jang_model",
+        lambda path: (fake_model, fake_tokenizer),
+    )
+    monkeypatch.setattr(
+        jt_loader,
+        "_fix_quantized_bits",
+        lambda model, overrides: calls.append(("fix_bits", model, overrides)),
+    )
+    monkeypatch.setattr(
+        internal_jang_loader,
+        "apply_jang_norm_shift",
+        lambda model: calls.append(("norm_shift", model)),
+    )
+    monkeypatch.setattr(
+        smelt_loader.ExpertIndex,
+        "build",
+        staticmethod(lambda path: SimpleNamespace(num_experts=8, layers={})),
+    )
+    monkeypatch.setattr(smelt_loader.mx, "eval", lambda *args, **kwargs: None)
+    monkeypatch.setattr(smelt_loader.mx, "clear_cache", lambda: None)
+
+    model, tokenizer = smelt_loader.smelt_load(str(tmp_path), expert_percent=50)
+
+    assert model is fake_model
+    assert tokenizer is fake_tokenizer
+    assert ("fix_bits", fake_model, {}) in calls
+    assert ("norm_shift", fake_model) in calls

--- a/vmlx_engine/utils/smelt_loader.py
+++ b/vmlx_engine/utils/smelt_loader.py
@@ -777,6 +777,11 @@ def smelt_load(
     import struct as _struct
     from jang_tools.loader import load_jang_model as _jt_load
     from jang_tools.loader import _fix_quantized_bits
+    try:
+        from ..utils.jang_loader import apply_jang_norm_shift as _apply_jang_norm_shift
+    except Exception as exc:
+        _apply_jang_norm_shift = None
+        logger.debug("Could not import JANG norm shift helper: %s", exc)
 
     # Gemma 4 (model_type=gemma4, text_config.model_type=gemma4_text):
     # jang_tools text-only loader does NOT sanitize Gemma 4's SwitchGLU +
@@ -1064,6 +1069,8 @@ def smelt_load(
     # After filling experts, fix quantization bits again (expert modules
     # may have different bits than the backbone defaults)
     _fix_quantized_bits(model, {})
+    if _apply_jang_norm_shift is not None:
+        _apply_jang_norm_shift(model)
 
     logger.info("  Wrapped %d MoE layers", patched)
 


### PR DESCRIPTION
## Summary

Fixes Qwen/Ornith JANG Smelt loads by applying the existing internal JANG norm-shift correction after Smelt refills expert weights. Live API checks showed the affected Smelt path returned coherent `OK` and `4` responses after the bridge, while the pre-bridge path emitted repeated junk tokens.

## Problem

Smelt loads JANG MoE models through an external JANG backbone path, filters expert tensors during the initial load, then fills the selected expert subset afterward. For Qwen/Ornith-style JANG artifacts, that path skipped the internal vMLX norm correction that the standard non-Smelt JANG loader applies.

The failing symptom was coherent startup and expert loading, followed by incoherent generation: short deterministic prompts emitted repeated garbage tokens and stopped by length instead of producing the expected answer.

## Root Cause

The existing internal JANG loader has a detector-gated `+1` scale-shift correction for low-norm Qwen/Ornith JANG artifacts. Smelt bypassed that internal step by loading its backbone through the external JANG loader, then did expert fill and bit-fixing without reapplying the norm correction.

Because the correction must happen after the Smelt model and experts are present, the Smelt loader needs to call the same helper after expert fill and quantized-bit repair.

## Fix

- Import the internal JANG norm-shift helper inside Smelt loading.
- Apply it after Smelt fills selected experts and reapplies per-module quantization bits.
- Keep the call defensive: if the helper import is unavailable, Smelt logs at debug level and continues.
- Add a focused unit test proving `smelt_load` invokes the internal norm-shift helper.

## Why This Shape

This reuses the existing detector-gated norm-shift implementation instead of duplicating Qwen-family detection or adding a Smelt-specific heuristic. Models that do not match the low-norm Qwen/Ornith pattern should pass through unchanged.

## Live Proof

| Interface / Harness | Model / Config | Result |
|---|---|---|
| CLI/API negative-control repro | Qwen-family MoE JANG Smelt50 with norm shift disabled | Loaded, but deterministic prompts emitted junk and stopped by length. |
| CLI/API fixed path | Same Qwen-family MoE JANG Smelt50 with this bridge active | Deterministic probes returned `OK` and `4` with stop finish reasons. |
| Unit test | Smelt loader fake-model path | Proves Smelt calls the internal JANG norm-shift helper after bit-fix. |

Evidence captured:

- spawn args: yes
- startup logs: yes
- `/health`: yes
- streaming chunks/tool calls/reasoning: not applicable for this narrow load/coherence fix
- memory/RAM soak: memory snapshots captured; long soak not run

## Regression / Adjacent Coverage

- The fix is intentionally limited to the Smelt JANG load path.
- A separate Gemma MoE investigation found a different Smelt issue in Gemma expert indexing and selection quality; that is out of scope for this Qwen/Ornith norm-shift PR.

## Follow-up / Out of Scope

- UI-created session proof was not part of this PR packet.
- Streaming/tool-call adapter coverage was not rerun because this change only affects model load-time weight correction.
- Gemma Smelt expert-index and Smelt50 quality work should be handled separately.

## Tests

- `uv run --python 3.13 --with pytest pytest tests/test_smelt_loader.py -q`
- `uv run --python 3.13 python -m py_compile vmlx_engine/utils/smelt_loader.py tests/test_smelt_loader.py`

Full runtime matrix was not run for this branch; prior live CLI/API evidence covers the failing and fixed Qwen Smelt path.
