### PR TITLE
Accept single-sequence TurboQuant cache with unset idx

### DIFF
--- a/tests/test_cache_record_validator.py
+++ b/tests/test_cache_record_validator.py
@@ -435,6 +435,50 @@ def test_live_cache_rejects_tq_encoded_huge_shape_when_keys_cleared():
     assert "shape" in reason.lower() or "dim" in reason.lower()
 
 
+def test_live_cache_accepts_real_single_sequence_turboquant_with_unset_idx():
+    """TurboQuantKVCache leaves _idx=None until it enters batched mode."""
+    pytest.importorskip("jang_tools.turboquant.cache")
+    from jang_tools.turboquant.cache import TurboQuantKVCache
+    from vmlx_engine.cache_record_validator import validate_live_cache
+
+    layer = TurboQuantKVCache(key_dim=128, value_dim=128)
+    layer.keys = _stub_tensor((1, 8, 16, 128))
+    layer.values = _stub_tensor((1, 8, 16, 128))
+    layer.offset = 16
+    layer._idx = None
+    layer.key_bits = 3
+    layer.value_bits = 3
+    layer.sink_tokens = 0
+    layer._compressed_tokens = 0
+
+    ok, reason, nbytes = validate_live_cache([layer], source="test:live-tq-single")
+
+    assert ok, reason
+    assert nbytes > 0
+
+
+def test_live_cache_rejects_fake_turboquant_with_unset_idx():
+    from vmlx_engine.cache_record_validator import validate_live_cache
+
+    TurboQuantKVCache = type("TurboQuantKVCache", (), {})
+    layer = TurboQuantKVCache()
+    layer.keys = _stub_tensor((1, 8, 16, 128))
+    layer.values = _stub_tensor((1, 8, 16, 128))
+    layer.offset = 16
+    layer._idx = None
+    layer.key_dim = 128
+    layer.value_dim = 128
+    layer.key_bits = 3
+    layer.value_bits = 3
+    layer.sink_tokens = 0
+    layer._compressed_tokens = 0
+
+    ok, reason, _ = validate_live_cache([layer], source="test:live-fake-tq")
+
+    assert not ok
+    assert "_idx" in reason
+
+
 def test_live_cache_accepts_clean_kv_layer():
     from vmlx_engine.cache_record_validator import validate_live_cache
 

--- a/vmlx_engine/cache_record_validator.py
+++ b/vmlx_engine/cache_record_validator.py
@@ -658,6 +658,13 @@ def _validate_live_single_cache(layer_cache: Any, *, layer_idx: int) -> Tuple[bo
     if layer_cache is None:
         return False, f"layer {layer_idx}: None cache layer", 0
 
+    def _is_turboquant_kv_cache(value: Any) -> bool:
+        cls = type(value)
+        return (
+            cls.__name__ == "TurboQuantKVCache"
+            and cls.__module__.startswith("jang_tools.turboquant")
+        )
+
     def _m3_seq_len(value: Any) -> Optional[int]:
         shape = getattr(value, "shape", None)
         if not isinstance(shape, (list, tuple)) or len(shape) < 3:
@@ -729,6 +736,10 @@ def _validate_live_single_cache(layer_cache: Any, *, layer_idx: int) -> Tuple[bo
         if not hasattr(layer_cache, attr):
             return True, ""
         value = getattr(layer_cache, attr)
+        if attr == "_idx" and value is None and _is_turboquant_kv_cache(layer_cache):
+            # TurboQuantKVCache leaves _idx unset for clean single-sequence
+            # cache state until the cache is prepared for batched use.
+            return True, ""
         if type(value).__module__.startswith("unittest.mock"):
             # Unit-test mocks claim every attribute exists. Ignore synthetic
             # mock scalars so cache-validation contract tests can use duck


### PR DESCRIPTION
## Summary

Accept valid single-sequence `TurboQuantKVCache` live-cache state where
`offset` is set but `_idx` is still unset. The change is code-audited and
covered by focused validator tests; full pytest execution is blocked locally by
test-environment dependency setup.

## Problem

`TurboQuantKVCache` does not populate `_idx` until it enters batched mode via
`prepare()`. Clean single-sequence prompt-cache/live-cache state can therefore
have a valid integer `offset` and `_idx=None`.

## Root Cause

The live-cache validator treated any present `_idx` as an integer for every
cache class. That made valid single-sequence TurboQuant state look corrupt.

## Fix

- Scope the `_idx=None` allowance to `TurboQuantKVCache` from the
  `jang_tools.turboquant` module path.
- Preserve the existing integer validation for other cache classes and for
  fake/local classes merely named `TurboQuantKVCache`.
- Add focused tests for real-class acceptance and fake-class rejection.

## Why This Shape

The exception is deliberately narrow. It does not relax `_idx` validation for
rotating/native cache classes, fake same-name test classes, or invalid
TurboQuant `_idx` values other than the valid single-sequence unset state.

## Live Proof

| Interface / Harness | Model / Config | Result |
|---|---|---|
| Code audit + direct validator exercise | Live-cache validator, TurboQuant-shaped single-sequence state | PASS: fake same-name cache rejected; TurboQuant-module-shaped cache accepted |

Evidence captured:

- spawn args: N/A
- startup logs: N/A
- `/health`: N/A
- streaming chunks/tool calls/reasoning: N/A
- memory/RAM soak: N/A

## Regression / Adjacent Coverage

- Real-class regression test added with `pytest.importorskip("jang_tools.turboquant.cache")`.
- Fake same-name class regression test added to prevent class-name-only acceptance.

## Follow-up / Out of Scope

- Full pytest execution was not completed locally because the available Python
  environment does not have `pytest`, and the worktree preflight reports the
  existing lockfile is stale relative to `pyproject.toml`.
- No UI or live model validation was run because this PR only changes live-cache
  validator acceptance for an already-identified object-state contract.

## Tests

- `python3 -m py_compile vmlx_engine/cache_record_validator.py tests/test_cache_record_validator.py`
- `git diff --check`
- Direct validator exercise: fake same-name cache rejected; TurboQuant-module-shaped cache accepted
