### PR TITLE
DSV4: fail-closed affine decode integration and native stability paths

### DIFF
--- a/bench/affine_moe_decode_bench.py
+++ b/bench/affine_moe_decode_bench.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Affine MoE decode kernel microbench.
+
+Synthetic benchmark — does NOT load a model. Exercises the fused
+dequant+matvec kernels from vmlx_engine.metal.affine_moe_decode against
+MLX's stock gather_qmm baseline, using DeepSeek-V4-Flash JANG shapes.
+
+Usage:
+    python bench/affine_moe_decode_bench.py [--experts 256] [--k 6] [--iters 200]
+
+Reports per-projection latency and total MoE-layer estimate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Any, Callable
+
+import mlx.core as mx
+
+from vmlx_engine.metal.affine_moe_decode import AffineMoEDecodeManager
+
+
+def _sync(*values: Any) -> None:
+    mx.eval(*values)
+    mx.synchronize()
+
+
+def _time_ms(fn: Callable[[], Any], *, warmup: int, iters: int) -> float:
+    for _ in range(warmup):
+        _sync(fn())
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        _sync(fn())
+    return (time.perf_counter() - t0) * 1000.0 / max(1, iters)
+
+
+def _make_affine_weights(
+    n_experts: int, out_dim: int, in_dim: int, bits: int, group_size: int
+) -> tuple[mx.array, mx.array, mx.array]:
+    """Create synthetic affine-quantized weights matching MLX layout."""
+    n_groups = in_dim // group_size
+    vals_per_u32 = 32 // bits
+    packed_cols = in_dim // vals_per_u32
+    code_mask = (1 << bits) - 1
+
+    weights = mx.random.uniform(
+        shape=(n_experts, out_dim, packed_cols), low=0, high=2**32 - 1
+    ).astype(mx.uint32)
+    # Mask to valid code range
+    weights = weights & code_mask
+    scales = mx.random.uniform(shape=(n_experts, out_dim, n_groups), low=0.001, high=0.1)
+    biases = mx.random.uniform(shape=(n_experts, out_dim, n_groups), low=-0.05, high=0.05)
+    return weights.astype(mx.float16).astype(mx.uint32), scales.astype(mx.float16), biases.astype(mx.float16)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--experts", type=int, default=256)
+    parser.add_argument("--k", type=int, default=6, help="Top-k experts per token")
+    parser.add_argument("--hidden", type=int, default=4096)
+    parser.add_argument("--inter", type=int, default=2048)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=200)
+    args = parser.parse_args()
+
+    E, k, hidden, inter = args.experts, args.k, args.hidden, args.inter
+
+    print(f"Affine MoE decode microbench")
+    print(f"  experts={E}  k={k}  hidden={hidden}  inter={inter}")
+    print(f"  warmup={args.warmup}  iters={args.iters}")
+    print()
+
+    mgr = AffineMoEDecodeManager(n_chunks=2, threadgroup_y=128)
+
+    # DSV4-Flash shapes: gate/up are hidden→inter (2-bit g64 or 3-bit g64),
+    # down is inter→hidden (2-bit g32)
+    gate_w, gate_s, gate_b = _make_affine_weights(E, inter, hidden, 3, 64)
+    up_w, up_s, up_b = _make_affine_weights(E, inter, hidden, 2, 64)
+    down_w, down_s, down_b = _make_affine_weights(E, hidden, inter, 2, 32)
+
+    x = mx.random.normal(shape=(hidden,)).astype(mx.float16)
+    expert_ids = mx.arange(k).astype(mx.uint16)
+
+    # Warm up kernel compilation
+    _ = mgr.run_projection(x, gate_w, gate_s, gate_b, expert_ids, hidden, inter, hidden // 64, k, 3, 64)
+    _sync(_)
+
+    # Benchmark each projection
+    def bench_gate():
+        return mgr.run_projection(x, gate_w, gate_s, gate_b, expert_ids, hidden, inter, hidden // 64, k, 3, 64)
+
+    def bench_up():
+        return mgr.run_projection(x, up_w, up_s, up_b, expert_ids, hidden, inter, hidden // 64, k, 2, 64)
+
+    def bench_down():
+        act = mx.random.normal(shape=(k, inter)).astype(mx.float16)
+        return mgr.run_projection(act, down_w, down_s, down_b, expert_ids, inter, hidden, inter // 32, k, 2, 32)
+
+    gate_ms = _time_ms(bench_gate, warmup=args.warmup, iters=args.iters)
+    up_ms = _time_ms(bench_up, warmup=args.warmup, iters=args.iters)
+    down_ms = _time_ms(bench_down, warmup=args.warmup, iters=args.iters)
+
+    total = gate_ms + up_ms + down_ms
+    print(f"  gate_proj (3-bit g64): {gate_ms:7.3f} ms")
+    print(f"  up_proj   (2-bit g64): {up_ms:7.3f} ms")
+    print(f"  down_proj (2-bit g32): {down_ms:7.3f} ms")
+    print(f"  ─────────────────────────────────")
+    print(f"  total MoE layer:       {total:7.3f} ms")
+    print()
+
+    # Estimate full model throughput (43 layers, MoE ~62% of decode time)
+    est_moe_per_token = total * 43
+    est_total_per_token = est_moe_per_token / 0.62
+    est_tps = 1000.0 / est_total_per_token
+    print(f"  Estimated (43 layers, MoE=62% of decode):")
+    print(f"    MoE per token:  {est_moe_per_token:.1f} ms")
+    print(f"    Total per token: {est_total_per_token:.1f} ms")
+    print(f"    Throughput:      {est_tps:.1f} tok/s")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/dsv4_longrun_harness.py
+++ b/bench/dsv4_longrun_harness.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Long-run DSV4 decode and prefill harness.
+
+This complements the 30-token target gate with an exact 1,000-token stream
+length check. The persistent generator excludes its one-time warmup from the
+reported prefill/decode timings and records the output-token hash for repeat
+comparison. Pass ``--expected-token-hash`` to make the run an exact-reference
+gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import statistics
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from dsv4_target_harness import _parse_targets, _PersistentRunner, _prompt
+
+DEFAULT_OUTPUT = Path("dsv4-longrun-report.json")
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_suffix(path.suffix + ".tmp")
+    temp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    temp.replace(path)
+
+
+def _request(runner: _PersistentRunner, prompt: Any, max_tokens: int) -> dict[str, Any]:
+    prompt_ids = [int(value) for value in prompt.tolist()]
+    uid = runner.generator.insert(
+        [prompt_ids],
+        max_tokens=[max_tokens],
+        capture_prompt_snapshots=[False],
+    )[0]
+    started = time.perf_counter()
+    first_token_at: float | None = None
+    output_tokens: list[int] = []
+    try:
+        while len(output_tokens) < max_tokens:
+            prompt_responses, generated_responses = runner.generator.next()
+            responses = list(prompt_responses) + list(generated_responses)
+            if not responses:
+                break
+            if first_token_at is None:
+                first_token_at = time.perf_counter()
+            output_tokens.extend(int(response.token) for response in responses)
+            if any(response.finish_reason is not None for response in responses):
+                break
+    finally:
+        runner.generator.remove([uid])
+    finished = time.perf_counter()
+    decode_seconds = finished - first_token_at if first_token_at is not None else None
+    return {
+        "prompt_tokens": len(prompt_ids),
+        "new_tokens": len(output_tokens),
+        "ttft_s": (first_token_at - started if first_token_at is not None else None),
+        "prefill_tok_s": (
+            len(prompt_ids) / (first_token_at - started)
+            if first_token_at is not None and first_token_at > started
+            else None
+        ),
+        "decode_tok_s": (
+            (len(output_tokens) - 1) / decode_seconds
+            if decode_seconds and len(output_tokens) > 1
+            else None
+        ),
+        "token_ids_sha256": hashlib.sha256(
+            ",".join(map(str, output_tokens)).encode()
+        ).hexdigest(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--prompt-targets", default="256")
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--max-tokens", type=int, default=1000)
+    parser.add_argument("--warmup-tokens", type=int, default=4)
+    parser.add_argument("--prefill-step-size", type=int, default=2048)
+    parser.add_argument("--expected-token-hash")
+    args = parser.parse_args()
+    if not args.model.is_dir():
+        parser.error(f"model directory does not exist: {args.model}")
+    if args.max_tokens < 1000:
+        parser.error("this long-run harness requires at least 1000 output tokens")
+    if args.repeats <= 0 or args.warmup_tokens <= 0:
+        parser.error("repeats and warmup tokens must be positive")
+    try:
+        targets = _parse_targets(args.prompt_targets)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    os.environ.setdefault("VMLX_DSV4_AFFINE_MOE_FASTPATH", "0")
+    import mlx.core as mx
+
+    import vmlx_engine
+    from vmlx_engine.loaders.load_jangtq_dsv4 import load_jangtq_dsv4_model
+
+    model, tokenizer = load_jangtq_dsv4_model(str(args.model))
+    from jang_tools.dsv4.mlx_model import MoE as _Dsv4MoE
+
+    compiled_moe_installed = bool(getattr(_Dsv4MoE, "_vmlx_dsv4_compiled_moe", False))
+    prompts = {target: _prompt(tokenizer, target, mx) for target in targets}
+    mx.eval(*prompts.values())
+    runner = _PersistentRunner(
+        model,
+        step_size=args.prefill_step_size,
+        max_tokens=args.max_tokens,
+        mx=mx,
+    )
+    first_prompt = next(iter(prompts.values()))
+    runner.request(first_prompt, max_tokens=args.warmup_tokens)
+
+    results: dict[str, Any] = {}
+    for target, prompt in prompts.items():
+        rows = [_request(runner, prompt, args.max_tokens) for _ in range(args.repeats)]
+        hashes = {row["token_ids_sha256"] for row in rows}
+        results[str(target)] = {
+            "passed": bool(rows)
+            and all(row["new_tokens"] == args.max_tokens for row in rows)
+            and len(hashes) == 1
+            and (
+                args.expected_token_hash is None
+                or all(
+                    row["token_ids_sha256"] == args.expected_token_hash for row in rows
+                )
+            ),
+            "stable_token_stream": len(hashes) == 1,
+            "reference_token_hash": args.expected_token_hash,
+            "reference_token_hash_matches": args.expected_token_hash is None
+            or all(row["token_ids_sha256"] == args.expected_token_hash for row in rows),
+            "median_prefill_tok_s": (
+                statistics.median(
+                    float(row["prefill_tok_s"])
+                    for row in rows
+                    if row.get("prefill_tok_s") is not None
+                )
+                if any(row.get("prefill_tok_s") is not None for row in rows)
+                else None
+            ),
+            "median_decode_tok_s": (
+                statistics.median(
+                    float(row["decode_tok_s"])
+                    for row in rows
+                    if row.get("decode_tok_s") is not None
+                )
+                if any(row.get("decode_tok_s") is not None for row in rows)
+                else None
+            ),
+            "samples": rows,
+        }
+
+    report = {
+        "schema": "dsv4_longrun_harness.v1",
+        "finished_at": _now(),
+        "model": str(args.model),
+        "runtime": "vmlx_dsv4_batch_generator",
+        "vmlx_engine": vmlx_engine.__version__,
+        "jang": importlib.metadata.version("jang"),
+        "mlx": importlib.metadata.version("mlx"),
+        "mlx_lm": importlib.metadata.version("mlx-lm"),
+        "lm_head_mode": os.environ.get("VMLX_DSV4_LM_HEAD_MODE", "quantized")
+        .strip()
+        .lower(),
+        "lm_head_fastpath_installed": bool(
+            getattr(type(model), "_vmlx_dsv4_lm_head_cache_installed", False)
+        ),
+        "compiled_moe_installed": compiled_moe_installed,
+        "max_tokens": args.max_tokens,
+        "repeats": args.repeats,
+        "prefill_step_size": args.prefill_step_size,
+        "expected_token_hash": args.expected_token_hash,
+        "results": results,
+        "passed": bool(results) and all(row["passed"] for row in results.values()),
+    }
+    _atomic_write(args.out, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(f"Report: {args.out}")
+    return 0 if report["passed"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/dsv4_target_harness.py
+++ b/bench/dsv4_target_harness.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Stable DSV4 target harness for 30-token output and cold prefill.
+
+The generator is intentionally reused across requests. DSV4BatchGenerator
+performs a one-time kernel warmup on its first request; constructing a fresh
+generator for every sample would charge that fixed cost to every prefill
+measurement and under-report the production path.
+
+The default gate requires every measured sample to produce exactly 30 tokens,
+the greedy token stream to remain stable, and the measured prefill rate to be
+at least 200 tokens/s. Pass ``--expected-token-hash`` when the run is being
+used as an exact-reference gate rather than a repeatability probe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import statistics
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "dsv4_target_harness.v1"
+DEFAULT_OUTPUT = Path("dsv4-target-report.json")
+DEFAULT_PROMPT_TARGETS = (256,)
+
+PROMPT = (
+    "We are reviewing a production Apple-Silicon inference service. A recent "
+    "optimization changed the request loop to reuse a mutable KV cache and to "
+    "batch prompt tokens in chunks. Users report slow first answers and "
+    "occasional repetition from a previous request. Review this simplified "
+    "code: cache = shared_cache; for request in requests: prompt = "
+    "tokenizer.encode(request.text); for start in range(0, len(prompt), 2048): "
+    "logits = model(prompt[start:start + 2048], cache=cache); token = "
+    "sample(logits[:, -1, :]); while token not in stop_tokens: logits = "
+    "model(token, cache=cache); token = sample(logits[:, -1, :]); yield "
+    "tokenizer.decode(token). Give a concise diagnosis, corrected pseudocode, "
+    "and three tests. State assumptions."
+)
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _parse_targets(raw: str) -> tuple[int, ...]:
+    values = tuple(
+        dict.fromkeys(int(item.strip()) for item in raw.split(",") if item.strip())
+    )
+    if not values or any(value <= 0 for value in values):
+        raise ValueError("prompt targets must contain positive integers")
+    return values
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_suffix(path.suffix + ".tmp")
+    temp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    temp.replace(path)
+
+
+def _prompt(tokenizer: Any, target_tokens: int, mx: Any) -> Any:
+    body = PROMPT
+    while len(tokenizer.encode(body)) < target_tokens:
+        body += " Preserve request isolation and exact timing receipts."
+    rendered = tokenizer.apply_chat_template(
+        [{"role": "user", "content": body}],
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+    return mx.array(tokenizer.encode(rendered), dtype=mx.uint32)
+
+
+class _PersistentRunner:
+    def __init__(self, model: Any, *, step_size: int, max_tokens: int, mx: Any):
+        # Use vMLX's production sampler wrapper. Its greedy sampler is marked
+        # as accepting raw logits, which lets DSV4BatchGenerator skip an
+        # unnecessary full-vocabulary log-softmax on every decode token.
+        from vmlx_engine.sampling import make_sampler
+        from vmlx_engine.utils.dsv4_batch_generator import DSV4BatchGenerator
+
+        os.environ["DSV4_PREFILL_STEP_SIZE"] = str(step_size)
+        self.generator = DSV4BatchGenerator(
+            model,
+            max_tokens=max_tokens,
+            sampler=make_sampler(temp=0.0, top_p=0.0),
+            prefill_step_size=step_size,
+            capture_prompt_snapshot=False,
+        )
+        self.max_tokens = max_tokens
+        self.mx = mx
+
+    def request(self, prompt: Any, *, max_tokens: int | None = None) -> dict[str, Any]:
+        token_limit = max_tokens or self.max_tokens
+        prompt_ids = [int(value) for value in prompt.tolist()]
+        uid = self.generator.insert(
+            [prompt_ids],
+            max_tokens=[token_limit],
+            capture_prompt_snapshots=[False],
+        )[0]
+        started = time.perf_counter()
+        first_token_at: float | None = None
+        output_tokens: list[int] = []
+        try:
+            while len(output_tokens) < token_limit:
+                prompt_responses, generated_responses = self.generator.next()
+                responses = list(prompt_responses) + list(generated_responses)
+                if not responses:
+                    break
+                if first_token_at is None:
+                    first_token_at = time.perf_counter()
+                output_tokens.extend(int(response.token) for response in responses)
+                if any(response.finish_reason is not None for response in responses):
+                    break
+        finally:
+            self.generator.remove([uid])
+        finished = time.perf_counter()
+        ttft = first_token_at - started if first_token_at is not None else None
+        decode_seconds = (
+            finished - first_token_at if first_token_at is not None else None
+        )
+        return {
+            "prompt_tokens": len(prompt_ids),
+            "new_tokens": len(output_tokens),
+            "ttft_s": ttft,
+            "prefill_tok_s": len(prompt_ids) / ttft if ttft else None,
+            "decode_tok_s": (
+                max(len(output_tokens) - 1, 0) / decode_seconds
+                if decode_seconds and len(output_tokens) > 1
+                else None
+            ),
+            "token_ids_sha256": hashlib.sha256(
+                ",".join(map(str, output_tokens)).encode()
+            ).hexdigest(),
+        }
+
+
+def _summarize(
+    rows: list[dict[str, Any]],
+    minimum_prefill: float,
+    expected_token_hash: str | None,
+) -> dict[str, Any]:
+    hashes = {row["token_ids_sha256"] for row in rows}
+    prefill = [
+        float(row["prefill_tok_s"])
+        for row in rows
+        if row.get("prefill_tok_s") is not None
+    ]
+    decode = [float(row["decode_tok_s"]) for row in rows if row.get("decode_tok_s")]
+    reference_matches = expected_token_hash is None or all(
+        row["token_ids_sha256"] == expected_token_hash for row in rows
+    )
+    passed = bool(
+        rows
+        and all(row["new_tokens"] == 30 for row in rows)
+        and len(hashes) == 1
+        and bool(prefill)
+        and min(prefill) >= minimum_prefill
+        and reference_matches
+    )
+    return {
+        "passed": passed,
+        "stable_30_tokens": bool(rows) and all(row["new_tokens"] == 30 for row in rows),
+        "stable_token_stream": len(hashes) == 1,
+        "reference_token_hash": expected_token_hash,
+        "reference_token_hash_matches": reference_matches,
+        "min_prefill_tok_s": min(prefill) if prefill else None,
+        "median_prefill_tok_s": statistics.median(prefill) if prefill else None,
+        "median_decode_tok_s": statistics.median(decode) if decode else None,
+        "samples": rows,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--prompt-targets", default="256")
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--max-tokens", type=int, default=30)
+    parser.add_argument("--warmup-tokens", type=int, default=4)
+    parser.add_argument("--prefill-step-size", type=int, default=2048)
+    parser.add_argument("--min-prefill-tok-s", type=float, default=200.0)
+    parser.add_argument("--expected-token-hash")
+    parser.add_argument(
+        "--affine",
+        action="store_true",
+        help="opt into upstream's guarded affine decode path for comparison",
+    )
+    args = parser.parse_args()
+    if args.max_tokens != 30:
+        parser.error("this target harness requires --max-tokens 30")
+    if args.repeats <= 0 or args.warmup_tokens <= 0:
+        parser.error("repeats and warmup tokens must be positive")
+    if args.prefill_step_size <= 0 or args.min_prefill_tok_s <= 0:
+        parser.error("prefill step and minimum throughput must be positive")
+    try:
+        targets = _parse_targets(args.prompt_targets)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if not args.model.is_dir():
+        parser.error(f"model directory does not exist: {args.model}")
+
+    os.environ["VMLX_DSV4_AFFINE_MOE_FASTPATH"] = "1" if args.affine else "0"
+    import mlx.core as mx
+
+    import vmlx_engine
+    from vmlx_engine.loaders.load_jangtq_dsv4 import load_jangtq_dsv4_model
+
+    model, tokenizer = load_jangtq_dsv4_model(str(args.model))
+    lm_head_cache_installed = bool(
+        getattr(type(model), "_vmlx_dsv4_lm_head_cache_installed", False)
+    )
+    from jang_tools.dsv4.mlx_model import MoE as _Dsv4MoE
+
+    compiled_moe_installed = bool(getattr(_Dsv4MoE, "_vmlx_dsv4_compiled_moe", False))
+    prompts = {target: _prompt(tokenizer, target, mx) for target in targets}
+    mx.eval(*prompts.values())
+    runner = _PersistentRunner(
+        model,
+        step_size=args.prefill_step_size,
+        max_tokens=args.max_tokens,
+        mx=mx,
+    )
+    results: dict[str, Any] = {}
+    for target, prompt in prompts.items():
+        runner.request(prompt, max_tokens=args.warmup_tokens)
+        rows = [runner.request(prompt) for _ in range(args.repeats)]
+        results[str(target)] = _summarize(
+            rows,
+            args.min_prefill_tok_s,
+            args.expected_token_hash,
+        )
+
+    report = {
+        "schema": SCHEMA,
+        "finished_at": _now(),
+        "model": str(args.model),
+        "runtime": "vmlx_dsv4_batch_generator",
+        "vmlx_engine": vmlx_engine.__version__,
+        "jang": importlib.metadata.version("jang"),
+        "mlx": importlib.metadata.version("mlx"),
+        "mlx_lm": importlib.metadata.version("mlx-lm"),
+        "affine_opt_in": args.affine,
+        "lm_head_mode": os.environ.get("VMLX_DSV4_LM_HEAD_MODE", "quantized")
+        .strip()
+        .lower(),
+        "lm_head_fastpath_installed": lm_head_cache_installed,
+        "compiled_moe_installed": compiled_moe_installed,
+        "max_tokens": args.max_tokens,
+        "repeats": args.repeats,
+        "prefill_step_size": args.prefill_step_size,
+        "minimum_prefill_tok_s": args.min_prefill_tok_s,
+        "expected_token_hash": args.expected_token_hash,
+        "results": results,
+        "passed": bool(results) and all(row["passed"] for row in results.values()),
+    }
+    _atomic_write(args.out, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(f"Report: {args.out}")
+    return 0 if report["passed"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/development/dsv4-decode-acceptance.md
+++ b/docs/development/dsv4-decode-acceptance.md
@@ -1,0 +1,79 @@
+# DeepSeek-V4 decode integration acceptance
+
+The DSV4 optimizations are guarded by model-shape, dtype, cache-shape, and
+request-length checks. Unsupported layouts and runtime failures must remain on
+the native JANG/MLX implementation. A faster short run is not sufficient for
+promotion: the output stream must remain stable through the long-run gate.
+
+## Runtime policy
+
+- The compiled native-gather MoE path is enabled by default for exact DSV4
+  weighted-route layouts and accepts only single-token decode shapes.
+- The quantized affine vocabulary-head path is enabled by default when the
+  loaded head exposes the native MLX quantization contract.
+- The exact RoPE table cache is enabled by default and is bounded. Native RoPE
+  remains an explicit experiment with `VMLX_DSV4_ROPE_NATIVE=1`.
+- The indexer bypass is request-bounded and applies only to fresh, short
+  requests. Prefill and prefix-cache-hit paths retain the native indexer.
+- The custom affine Metal path remains opt-in with
+  `VMLX_DSV4_AFFINE_MOE_FASTPATH=1`.
+
+Every optional path must be safe to disable through its environment control,
+and a failed optimized dispatch must fall back to the original implementation
+for the remainder of the process or request as appropriate.
+
+## Required checks
+
+Run the source checks first:
+
+```text
+git diff --check
+python -m py_compile \
+  vmlx_engine/loaders/load_jangtq_dsv4.py \
+  vmlx_engine/utils/dsv4_batch_generator.py \
+  vmlx_engine/models/dsv4_compiled_moe.py \
+  vmlx_engine/models/dsv4_indexer_skip.py \
+  vmlx_engine/models/dsv4_lm_head_cache.py \
+  vmlx_engine/models/dsv4_rope_cache.py
+python -m pip check
+```
+
+Run the no-model contract suite:
+
+```text
+python -m pytest -q \
+  tests/test_dsv4_stability_fastpaths.py \
+  tests/test_dsv4_affine_moe_fastpath.py \
+  tests/test_dsv4_batch_generator_speed.py \
+  tests/test_dsv4_contract_hardening.py \
+  tests/test_dsv4_route_mode_code_exactness.py \
+  tests/test_dsv4_bundle_integrity.py
+```
+
+Run the target harness with a real DSV4 bundle. Without
+`--expected-token-hash`, the report is a repeatability result only:
+
+```text
+python bench/dsv4_target_harness.py \
+  --model /path/to/DeepSeek-V4-Flash-JANG \
+  --out dsv4-target-report.json \
+  --repeats 3 \
+  --prompt-targets 256
+```
+
+For an exact-reference gate, pass the known-good 30-token stream hash. The
+same distinction applies to the 1,000-token harness:
+
+```text
+python bench/dsv4_longrun_harness.py \
+  --model /path/to/DeepSeek-V4-Flash-JANG \
+  --out dsv4-longrun-report.json \
+  --repeats 1 \
+  --prompt-targets 256 \
+  --max-tokens 1000 \
+  --expected-token-hash <reference-sha256>
+```
+
+Keep the raw JSON reports with the review artifacts. Report decode and prefill
+as separate measurements, and do not promote a candidate that is exact but
+slower or that only passes the short stream gate.

--- a/tests/test_dsv4_affine_moe_fastpath.py
+++ b/tests/test_dsv4_affine_moe_fastpath.py
@@ -1,0 +1,546 @@
+"""Focused contracts for the guarded DSV4 affine PR #248 integration."""
+
+from __future__ import annotations
+
+import weakref
+from contextlib import suppress
+
+import pytest
+
+
+class _FakeArray:
+    def __init__(self, shape=(), dtype="float16"):
+        self.shape = tuple(shape)
+        self.dtype = dtype
+        self.ndim = len(self.shape)
+        size = 1
+        for value in self.shape:
+            size *= value
+        self.size = size
+
+    def reshape(self, *_shape):
+        return self
+
+    def astype(self, _dtype):
+        return self
+
+
+class _FakeMx:
+    uint32 = "uint32"
+    uint16 = "uint16"
+    float16 = "float16"
+    float32 = "float32"
+
+    @staticmethod
+    def array(_value, dtype=None):
+        return _FakeArray((), dtype=dtype)
+
+    @staticmethod
+    def eval(*_values):
+        return None
+
+
+class _FakeQuantizedSwitchLinear:
+    def __init__(self, input_dims, output_dims, experts, bits, group_size):
+        self.input_dims = input_dims
+        self.output_dims = output_dims
+        self.bits = bits
+        self.group_size = group_size
+        self.mode = "affine"
+        groups = input_dims // group_size
+        packed = input_dims * bits // 32
+        self.weight = _FakeArray((experts, output_dims, packed), "uint32")
+        self.scales = _FakeArray((experts, output_dims, groups), "float16")
+        self.biases = _FakeArray((experts, output_dims, groups), "float16")
+
+    def __contains__(self, key):
+        return False
+
+
+class _FakeActivation:
+    swiglu_limit = 10.0
+
+    def __call__(self, up, gate):
+        return up
+
+
+class _FakeSwitchGLU:
+    def __init__(self, *, gate_bits=3, up_bits=2, down_groups=32, hidden=128, inter=64):
+        self.gate_proj = _FakeQuantizedSwitchLinear(hidden, inter, 4, gate_bits, 64)
+        self.up_proj = _FakeQuantizedSwitchLinear(hidden, inter, 4, up_bits, 64)
+        self.down_proj = _FakeQuantizedSwitchLinear(inter, hidden, 4, 2, down_groups)
+        self.activation = _FakeActivation()
+
+    def __call__(self, x, indices):
+        return ("stock", x, indices)
+
+
+_FAKE_STOCK_CALL = _FakeSwitchGLU.__call__
+
+
+class _FakeModel:
+    config = {"model_type": "deepseek_v4"}
+
+    def __init__(self, switch):
+        self.switch = switch
+
+    def named_modules(self):
+        return [("layers.0.ffn.switch_mlp", self.switch)]
+
+
+class _FakeWeightedMoE:
+    def __init__(self, switch):
+        self.switch_mlp = switch
+
+    def _weighted_routed_experts(self, x, indices, scores):
+        return ("stock-weighted", x, indices, scores)
+
+
+_FAKE_STOCK_WEIGHTED_CALL = _FakeWeightedMoE._weighted_routed_experts
+
+
+class _FakeWeightedModel(_FakeModel):
+    def __init__(self, switch):
+        super().__init__(switch)
+        self.moe = _FakeWeightedMoE(switch)
+
+    def named_modules(self):
+        return [
+            ("layers.0.ffn", self.moe),
+            ("layers.0.ffn.switch_mlp", self.switch),
+        ]
+
+
+@pytest.fixture
+def fake_runtime(monkeypatch):
+    import mlx_lm.models.switch_layers as switch_layers
+
+    import vmlx_engine.metal.affine_moe_decode as fastpath
+
+    monkeypatch.setattr(fastpath, "mx", _FakeMx)
+    monkeypatch.setattr(fastpath, "_CONFIGS", fastpath._WeakIdentityMap())
+    monkeypatch.setattr(fastpath, "_PATCHED_CLASS", None)
+    monkeypatch.setattr(fastpath, "_ORIGINAL_CALL", None)
+    monkeypatch.setattr(fastpath, "_WRAPPER", None)
+    monkeypatch.setattr(fastpath, "_PATCHED_WEIGHTED_CLASS", None)
+    monkeypatch.setattr(fastpath, "_ORIGINAL_WEIGHTED_CALL", None)
+    monkeypatch.setattr(fastpath, "_WEIGHTED_WRAPPER", None)
+    monkeypatch.setattr(fastpath, "_FIRST_FAST_CALL_LOGGED", False)
+    monkeypatch.setattr(fastpath, "_FIRST_REGISTERED_FALLBACK_LOGGED", False)
+    monkeypatch.setattr(switch_layers, "SwitchGLU", _FakeSwitchGLU)
+    monkeypatch.setattr(
+        switch_layers,
+        "QuantizedSwitchLinear",
+        _FakeQuantizedSwitchLinear,
+    )
+    monkeypatch.setenv("VMLX_DSV4_AFFINE_MOE_FASTPATH", "1")
+    _FakeSwitchGLU.__call__ = _FAKE_STOCK_CALL
+    _FakeWeightedMoE._weighted_routed_experts = _FAKE_STOCK_WEIGHTED_CALL
+    yield fastpath
+    _FakeSwitchGLU.__call__ = _FAKE_STOCK_CALL
+    _FakeWeightedMoE._weighted_routed_experts = _FAKE_STOCK_WEIGHTED_CALL
+
+
+def test_dsv4_affine_installer_is_weak_scoped_and_idempotent(fake_runtime):
+    switch = _FakeSwitchGLU()
+    model = _FakeModel(switch)
+
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(model) == 1
+    wrapper = _FakeSwitchGLU.__call__
+    first_config = fake_runtime._CONFIGS[switch]
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(model) == 1
+
+    assert _FakeSwitchGLU.__call__ is wrapper
+    assert fake_runtime._CONFIGS[switch] is not first_config
+    assert weakref.ref(switch)() is switch
+    assert switch in fake_runtime._CONFIGS
+
+
+def test_dsv4_affine_weak_identity_map_accepts_unhashable_modules(fake_runtime):
+    class _UnhashableSwitch(_FakeSwitchGLU):
+        __hash__ = None
+
+    switch = _UnhashableSwitch()
+    model = _FakeModel(switch)
+
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(model) == 1
+    assert fake_runtime._CONFIGS.get(switch) is not None
+
+
+def test_dsv4_affine_opt_out_precedes_install(fake_runtime, monkeypatch):
+    monkeypatch.setenv("VMLX_DSV4_AFFINE_MOE_FASTPATH", "0")
+    switch = _FakeSwitchGLU()
+
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_FakeModel(switch)) == 0
+    assert switch not in fake_runtime._CONFIGS
+
+
+def test_dsv4_affine_default_is_native_stock(fake_runtime, monkeypatch):
+    monkeypatch.delenv("VMLX_DSV4_AFFINE_MOE_FASTPATH")
+    switch = _FakeSwitchGLU()
+
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_FakeModel(switch)) == 0
+    assert switch not in fake_runtime._CONFIGS
+
+
+def test_dsv4_affine_rejects_unsupported_and_remainder_layouts(fake_runtime):
+    unsupported = _FakeSwitchGLU(up_bits=3)
+    remainder = _FakeSwitchGLU(hidden=192, inter=96)
+
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_FakeModel(unsupported)) == 0
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_FakeModel(remainder)) == 0
+    assert unsupported not in fake_runtime._CONFIGS
+    assert remainder not in fake_runtime._CONFIGS
+
+
+def test_dsv4_affine_install_is_atomic_when_any_switchglu_rejects(fake_runtime):
+    compatible = _FakeSwitchGLU()
+    incompatible = _FakeSwitchGLU(up_bits=3)
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_FakeModel(compatible)) == 1
+    wrapper = _FakeSwitchGLU.__call__
+    assert compatible in fake_runtime._CONFIGS
+
+    class _MixedModel:
+        config = {"model_type": "deepseek_v4"}
+
+        def named_modules(self):
+            return [
+                ("layers.0.ffn.switch_mlp", compatible),
+                ("layers.1.ffn.switch_mlp", incompatible),
+            ]
+
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_MixedModel()) == 0
+    assert compatible not in fake_runtime._CONFIGS
+    assert incompatible not in fake_runtime._CONFIGS
+    assert _FakeSwitchGLU.__call__ is wrapper
+    x = _FakeArray((1, 1, 128), "float16")
+    indices = _FakeArray((1, 1, 2), "uint32")
+    assert compatible(x, indices) == ("stock", x, indices)
+
+
+def test_dsv4_affine_runtime_exception_disables_only_eligible_module(
+    fake_runtime,
+    monkeypatch,
+):
+    class _BrokenManager:
+        def run_projection(self, *_args, **_kwargs):
+            raise RuntimeError("synthetic compile failure")
+
+    monkeypatch.setattr(fake_runtime, "_MANAGER", _BrokenManager())
+    switch = _FakeSwitchGLU()
+    other = _FakeSwitchGLU()
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_FakeModel(switch)) == 1
+    x = _FakeArray((1, 1, 128), "float16")
+    indices = _FakeArray((1, 1, 2), "uint32")
+
+    result = switch(x, indices)
+    untouched = other(x, indices)
+
+    assert result[0] == "stock"
+    assert untouched[0] == "stock"
+    assert "synthetic compile failure" in fake_runtime._CONFIGS[switch].disabled_reason
+
+
+def test_dsv4_affine_training_uses_stock_without_disabling_decode(fake_runtime, monkeypatch):
+    class _DecodeOnlyManager:
+        def run_projection(self, *_args, **_kwargs):
+            raise AssertionError("training must remain on stock SwitchGLU")
+
+    monkeypatch.setattr(fake_runtime, "_MANAGER", _DecodeOnlyManager())
+    switch = _FakeSwitchGLU()
+    switch.training = True
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_FakeModel(switch)) == 1
+    x = _FakeArray((1, 1, 128), "float16")
+    indices = _FakeArray((1, 1, 2), "uint32")
+
+    assert switch(x, indices) == ("stock", x, indices)
+    assert fake_runtime._CONFIGS[switch].disabled_reason is None
+
+
+def test_dsv4_affine_current_dsv4_weighted_route_owns_decode(
+    fake_runtime,
+    monkeypatch,
+):
+    switch = _FakeSwitchGLU()
+    model = _FakeWeightedModel(switch)
+    expected = object()
+    calls = []
+
+    def _fake_weighted_decode(owner, config, x, indices, scores):
+        calls.append((owner, config, x, indices, scores))
+        return expected
+
+    monkeypatch.setattr(fake_runtime, "_weighted_decode", _fake_weighted_decode)
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(model) == 1
+    assert _FakeSwitchGLU.__call__ is _FAKE_STOCK_CALL
+    x = _FakeArray((1, 1, 128), "float16")
+    indices = _FakeArray((1, 1, 2), "uint32")
+    scores = _FakeArray((1, 1, 2), "float32")
+
+    assert model.moe._weighted_routed_experts(x, indices, scores) is expected
+    assert calls and calls[0][0] is switch
+
+
+def test_dsv4_affine_current_dsv4_weighted_route_preserves_prefill(
+    fake_runtime,
+    monkeypatch,
+):
+    switch = _FakeSwitchGLU()
+    model = _FakeWeightedModel(switch)
+
+    def _unexpected_weighted_decode(*_args, **_kwargs):
+        raise AssertionError("decode kernel must not own weighted prefill")
+
+    monkeypatch.setattr(
+        fake_runtime,
+        "_weighted_decode",
+        _unexpected_weighted_decode,
+    )
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(model) == 1
+    x = _FakeArray((1, 2, 128), "float16")
+    indices = _FakeArray((1, 2, 2), "uint32")
+    scores = _FakeArray((1, 2, 2), "float32")
+
+    result = model.moe._weighted_routed_experts(x, indices, scores)
+    assert result == ("stock-weighted", x, indices, scores)
+
+
+def test_dsv4_affine_rejects_partial_weighted_owner_topology(fake_runtime):
+    first = _FakeSwitchGLU()
+    second = _FakeSwitchGLU()
+    owner = _FakeWeightedMoE(first)
+
+    class _PartialOwnerModel:
+        config = {"model_type": "deepseek_v4"}
+
+        def named_modules(self):
+            return [
+                ("layers.0.ffn", owner),
+                ("layers.0.ffn.switch_mlp", first),
+                ("layers.1.ffn.switch_mlp", second),
+            ]
+
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_PartialOwnerModel()) == 0
+    assert first not in fake_runtime._CONFIGS
+    assert second not in fake_runtime._CONFIGS
+    assert _FakeWeightedMoE._weighted_routed_experts is _FAKE_STOCK_WEIGHTED_CALL
+
+
+@pytest.mark.parametrize(
+    ("x_shape", "indices_shape"),
+    [
+        ((1, 2, 128), (1, 2, 2)),
+        ((2, 128), (2, 2)),
+    ],
+)
+def test_dsv4_affine_multitoken_prefill_stays_on_stock_switchglu(
+    fake_runtime,
+    monkeypatch,
+    x_shape,
+    indices_shape,
+):
+    class _DecodeOnlyManager:
+        def run_projection(self, *_args, **_kwargs):
+            raise AssertionError("decode kernel must not own multi-token prefill")
+
+    monkeypatch.setattr(fake_runtime, "_MANAGER", _DecodeOnlyManager())
+    switch = _FakeSwitchGLU()
+    assert fake_runtime.install_dsv4_affine_moe_fastpath(_FakeModel(switch)) == 1
+    x = _FakeArray(x_shape, "float16")
+    indices = _FakeArray(indices_shape, "uint32")
+
+    result = switch(x, indices)
+
+    assert result == ("stock", x, indices)
+
+
+def test_dsv4_affine_populated_packed_weights_match_stock_and_preserve_rank(monkeypatch):
+    """Metal numeric gate; run on the designated DSV4 compute Mac."""
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.models.switch_layers import SwitchGLU, SwitchLinear
+
+    import vmlx_engine.metal.affine_moe_decode as fastpath
+
+    monkeypatch.setenv("VMLX_DSV4_AFFINE_MOE_FASTPATH", "1")
+
+    try:
+        if mx.default_device() != mx.gpu or not mx.metal.is_available():
+            pytest.skip("requires MLX Metal")
+    except Exception:
+        pytest.skip("requires MLX Metal")
+
+    class _Activation(nn.Module):
+        swiglu_limit = 10.0
+
+        def __call__(self, x_up, x_gate):
+            return x_gate * mx.sigmoid(x_gate) * x_up
+
+    mx.random.seed(248)
+    switch = SwitchGLU(128, 64, 8, activation=_Activation(), bias=False)
+    switch.gate_proj = SwitchLinear(128, 64, 8, bias=False).to_quantized(64, 3)
+    switch.up_proj = SwitchLinear(128, 64, 8, bias=False).to_quantized(64, 2)
+    switch.down_proj = SwitchLinear(64, 128, 8, bias=False).to_quantized(32, 2)
+    for projection in (switch.gate_proj, switch.up_proj, switch.down_proj):
+        projection.scales = projection.scales.astype(mx.float16)
+        projection.biases = projection.biases.astype(mx.float16)
+    model = _FakeModel(switch)
+    x = mx.random.normal((1, 1, 128)).astype(mx.float16)
+    indices = mx.array([[[1, 3, 0, 2, 4, 7]]], dtype=mx.uint32)
+    original = getattr(
+        SwitchGLU,
+        "_vmlx_dsv4_affine_original_call",
+        SwitchGLU.__call__,
+    )
+    expected = original(switch, x, indices)
+    mx.eval(expected)
+
+    saved_call = SwitchGLU.__call__
+    saved_configs = fastpath._CONFIGS
+    saved_patched_class = fastpath._PATCHED_CLASS
+    saved_original_call = fastpath._ORIGINAL_CALL
+    saved_wrapper = fastpath._WRAPPER
+    saved_attrs = {
+        name: getattr(SwitchGLU, name, None)
+        for name in (
+            "_vmlx_dsv4_affine_original_call",
+            "_vmlx_dsv4_affine_decode_fastpath",
+        )
+    }
+    try:
+        fastpath._CONFIGS = fastpath._WeakIdentityMap()
+        fastpath._PATCHED_CLASS = None
+        fastpath._ORIGINAL_CALL = None
+        fastpath._WRAPPER = None
+        assert fastpath.install_dsv4_affine_moe_fastpath(model) == 1
+        actual = switch(x, indices)
+        mx.eval(actual)
+
+        assert actual.shape == expected.shape == (1, 1, 6, 128)
+        delta = actual.astype(mx.float32) - expected.astype(mx.float32)
+        rel_rms = mx.sqrt(mx.mean(mx.square(delta))) / mx.maximum(
+            mx.sqrt(mx.mean(mx.square(expected.astype(mx.float32)))),
+            mx.array(1e-8),
+        )
+        assert float(rel_rms.item()) < 0.02
+        assert float(mx.max(mx.abs(delta)).item()) < 0.25
+
+        # Multi-token prefill must remain byte-for-byte owned by stock SwitchGLU.
+        prefill_x = mx.random.normal((1, 2, 128)).astype(mx.float16)
+        prefill_indices = mx.array(
+            [[[0, 2, 4, 6, 1, 3], [1, 3, 5, 7, 0, 2]]],
+            dtype=mx.uint32,
+        )
+        prefill_expected = original(switch, prefill_x, prefill_indices)
+        prefill_actual = switch(prefill_x, prefill_indices)
+        mx.eval(prefill_expected, prefill_actual)
+        assert prefill_actual.shape == prefill_expected.shape == (1, 2, 6, 128)
+        assert bool(mx.array_equal(prefill_actual, prefill_expected).item())
+    finally:
+        SwitchGLU.__call__ = saved_call
+        fastpath._CONFIGS = saved_configs
+        fastpath._PATCHED_CLASS = saved_patched_class
+        fastpath._ORIGINAL_CALL = saved_original_call
+        fastpath._WRAPPER = saved_wrapper
+        for name, value in saved_attrs.items():
+            if value is None:
+                with suppress(AttributeError):
+                    delattr(SwitchGLU, name)
+            else:
+                setattr(SwitchGLU, name, value)
+
+
+def test_dsv4_affine_weighted_owner_matches_current_dsv4_stock_order(monkeypatch):
+    """Metal numeric gate for score-before-down current DSV4 packages."""
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.models.switch_layers import SwitchGLU, SwitchLinear
+
+    import vmlx_engine.metal.affine_moe_decode as fastpath
+
+    monkeypatch.setenv("VMLX_DSV4_AFFINE_MOE_FASTPATH", "1")
+
+    try:
+        if mx.default_device() != mx.gpu or not mx.metal.is_available():
+            pytest.skip("requires MLX Metal")
+    except Exception:
+        pytest.skip("requires MLX Metal")
+
+    class _Activation(nn.Module):
+        swiglu_limit = 10.0
+
+        def __call__(self, x_up, x_gate):
+            gate = mx.clip(x_gate.astype(mx.float32), a_min=None, a_max=10.0)
+            up = mx.clip(x_up.astype(mx.float32), a_min=-10.0, a_max=10.0)
+            return (mx.sigmoid(gate) * gate * up).astype(x_gate.dtype)
+
+    class _CurrentWeightedOwner:
+        def __init__(self, switch):
+            self.switch_mlp = switch
+
+        def _weighted_routed_experts(self, x, inds, scores):
+            switch = self.switch_mlp
+            dtype = x.dtype
+            expanded = mx.expand_dims(x, (-2, -3))
+            x_up = switch.up_proj(expanded, inds, sorted_indices=False)
+            x_gate = switch.gate_proj(expanded, inds, sorted_indices=False)
+            gate = mx.clip(x_gate.astype(mx.float32), a_min=None, a_max=10.0)
+            up = mx.clip(x_up.astype(mx.float32), a_min=-10.0, a_max=10.0)
+            activated = mx.sigmoid(gate) * gate * up
+            activated = (activated * scores[..., None, None]).astype(dtype)
+            return switch.down_proj(
+                activated,
+                inds,
+                sorted_indices=False,
+            ).squeeze(-2)
+
+    mx.random.seed(249)
+    switch = SwitchGLU(128, 64, 8, activation=_Activation(), bias=False)
+    switch.gate_proj = SwitchLinear(128, 64, 8, bias=False).to_quantized(64, 3)
+    switch.up_proj = SwitchLinear(128, 64, 8, bias=False).to_quantized(64, 2)
+    switch.down_proj = SwitchLinear(64, 128, 8, bias=False).to_quantized(32, 2)
+    for projection in (switch.gate_proj, switch.up_proj, switch.down_proj):
+        projection.scales = projection.scales.astype(mx.float16)
+        projection.biases = projection.biases.astype(mx.float16)
+    owner = _CurrentWeightedOwner(switch)
+
+    class _CurrentWeightedModel:
+        config = {"model_type": "deepseek_v4"}
+
+        def named_modules(self):
+            return [("layers.0.ffn", owner), ("layers.0.ffn.switch_mlp", switch)]
+
+    x = mx.random.normal((1, 1, 128)).astype(mx.float16)
+    indices = mx.array([[[1, 3, 0, 2, 4, 7]]], dtype=mx.uint32)
+    scores = mx.array([[[0.31, 0.24, 0.18, 0.12, 0.09, 0.06]]], dtype=mx.float32)
+    original = _CurrentWeightedOwner._weighted_routed_experts
+    expected = original(owner, x, indices, scores)
+    mx.eval(expected)
+
+    saved_weighted_class = fastpath._PATCHED_WEIGHTED_CLASS
+    saved_original = fastpath._ORIGINAL_WEIGHTED_CALL
+    saved_wrapper = fastpath._WEIGHTED_WRAPPER
+    saved_configs = fastpath._CONFIGS
+    try:
+        fastpath._PATCHED_WEIGHTED_CLASS = None
+        fastpath._ORIGINAL_WEIGHTED_CALL = None
+        fastpath._WEIGHTED_WRAPPER = None
+        fastpath._CONFIGS = fastpath._WeakIdentityMap()
+        assert fastpath.install_dsv4_affine_moe_fastpath(_CurrentWeightedModel()) == 1
+        actual = owner._weighted_routed_experts(x, indices, scores)
+        mx.eval(actual)
+
+        assert actual.shape == expected.shape == (1, 1, 6, 128)
+        delta = actual.astype(mx.float32) - expected.astype(mx.float32)
+        rel_rms = mx.sqrt(mx.mean(mx.square(delta))) / mx.maximum(
+            mx.sqrt(mx.mean(mx.square(expected.astype(mx.float32)))),
+            mx.array(1e-8),
+        )
+        assert float(rel_rms.item()) < 0.02
+        assert float(mx.max(mx.abs(delta)).item()) < 0.25
+    finally:
+        _CurrentWeightedOwner._weighted_routed_experts = original
+        fastpath._PATCHED_WEIGHTED_CLASS = saved_weighted_class
+        fastpath._ORIGINAL_WEIGHTED_CALL = saved_original
+        fastpath._WEIGHTED_WRAPPER = saved_wrapper
+        fastpath._CONFIGS = saved_configs

--- a/tests/test_dsv4_bundle_integrity.py
+++ b/tests/test_dsv4_bundle_integrity.py
@@ -231,8 +231,9 @@ def test_dsv4_hydration_mode_separates_affine_from_jangtq(tmp_path):
     assert _dsv4_uses_jangtq_hydration(tq) is True
 
 
-def test_dsv4_affine_loader_uses_generic_jang_hydration(monkeypatch, tmp_path):
+def test_dsv4_affine_loader_uses_generic_jang_hydration(monkeypatch, tmp_path, caplog):
     import vmlx_engine.loaders.load_jangtq_dsv4 as loader
+    import vmlx_engine.metal.affine_moe_decode as affine_fastpath
     import vmlx_engine.utils.jang_loader as jang_loader
 
     bundle = tmp_path / "DeepSeek-V4-Flash-JANG_2L-MTP"
@@ -245,6 +246,8 @@ def test_dsv4_affine_loader_uses_generic_jang_hydration(monkeypatch, tmp_path):
     )
     expected = (object(), SimpleNamespace(apply_chat_template=lambda *a, **k: []))
     calls = []
+    fastpath_calls = []
+    caplog.set_level("INFO", logger=loader.__name__)
 
     monkeypatch.setattr(loader, "_validate_dsv4_control_tensors", lambda path: None)
     monkeypatch.setattr(loader, "_verify_dsv4_attention_contract", lambda: None)
@@ -257,12 +260,20 @@ def test_dsv4_affine_loader_uses_generic_jang_hydration(monkeypatch, tmp_path):
         "load_jang_model",
         lambda path, **kwargs: calls.append((path, kwargs)) or expected,
     )
+    monkeypatch.setattr(
+        affine_fastpath,
+        "install_dsv4_affine_moe_fastpath",
+        lambda model, **kwargs: fastpath_calls.append((model, kwargs)) or 0,
+    )
 
     loaded = loader.load_jangtq_dsv4_model(str(bundle), skip_params_eval=True)
 
     assert loaded[0] is expected[0]
     assert loaded[1] is expected[1]
     assert calls == [(str(bundle), {"skip_eval": True})]
+    assert fastpath_calls == [(expected[0], {"model_type": "deepseek_v4"})]
+    assert "fast path not installed; using stock SwitchGLU" in caplog.text
+    assert "fast path installed for 0 modules" not in caplog.text
 
 
 def test_dsv4_artifact_bit_plan_audit_reads_actual_tq_bits_and_sidecar(tmp_path):

--- a/tests/test_dsv4_stability_fastpaths.py
+++ b/tests/test_dsv4_stability_fastpaths.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed contracts for the optional DSV4 stability fast paths."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _projection(
+    *, bits: int = 2, group_size: int = 64, input_dims: int = 128, output_dims: int = 64
+):
+    return SimpleNamespace(
+        bits=bits,
+        group_size=group_size,
+        mode="affine",
+        scales=object(),
+        biases=object(),
+        weight=object(),
+        input_dims=input_dims,
+        output_dims=output_dims,
+    )
+
+
+def _switch(*, gate_bits: int = 3):
+    return SimpleNamespace(
+        gate_proj=_projection(bits=gate_bits),
+        up_proj=_projection(bits=2),
+        down_proj=_projection(bits=2, group_size=32, input_dims=64, output_dims=128),
+        activation=SimpleNamespace(swiglu_limit=10.0),
+    )
+
+
+def test_compiled_moe_installer_rejects_malformed_layout_without_raising(monkeypatch):
+    import vmlx_engine.models.dsv4_compiled_moe as mod
+
+    class Owner:
+        def __init__(self, switch):
+            self.switch_mlp = switch
+
+        def _weighted_routed_experts(self, *_args):
+            return "stock"
+
+    class Model:
+        def named_modules(self):
+            return [("layer.0", Owner(_switch(gate_bits="broken")))]
+
+    monkeypatch.setattr(mod, "mx", object())
+    monkeypatch.setenv("VMLX_DSV4_COMPILED_MOE", "1")
+    mod._SUPPORTED_MOES.clear()
+    mod._DISABLED_MOES.clear()
+
+    assert mod.install_dsv4_compiled_moe(Model()) == 0
+    assert not mod._SUPPORTED_MOES
+
+
+def test_compiled_moe_installation_replaces_stale_module_selection(monkeypatch):
+    import vmlx_engine.models.dsv4_compiled_moe as mod
+
+    class Owner:
+        def __init__(self, switch):
+            self.switch_mlp = switch
+
+        def _weighted_routed_experts(self, *_args):
+            return "stock"
+
+    class Model:
+        def __init__(self, owner):
+            self.owner = owner
+
+        def named_modules(self):
+            return [("layer.0", self.owner)]
+
+    first = Owner(_switch())
+    second = Owner(_switch())
+    monkeypatch.setattr(mod, "mx", object())
+    monkeypatch.setenv("VMLX_DSV4_COMPILED_MOE", "1")
+    mod._PATCHED_CLASS = None
+    mod._SUPPORTED_MOES.clear()
+    mod._DISABLED_MOES.clear()
+
+    assert mod.install_dsv4_compiled_moe(Model(first)) == 1
+    assert mod.install_dsv4_compiled_moe(Model(second)) == 1
+    assert id(second) in mod._SUPPORTED_MOES
+    assert id(first) not in mod._SUPPORTED_MOES
+    mod._DISABLED_MOES.add(id(second))
+    assert mod.install_dsv4_compiled_moe(Model(second)) == 1
+    assert id(second) in mod._DISABLED_MOES
+
+    monkeypatch.setenv("VMLX_DSV4_COMPILED_MOE", "0")
+    assert first._weighted_routed_experts(None, None, None) == "stock"
+    assert second._weighted_routed_experts(None, None, None) == "stock"
+
+
+def test_indexer_bypass_falls_back_for_short_or_malformed_state(monkeypatch):
+    import vmlx_engine.models.dsv4_indexer_skip as mod
+
+    class FakeMx:
+        @staticmethod
+        def zeros(shape, dtype=None):
+            return ("zeros", tuple(shape), dtype)
+
+    class Indexer:
+        def __init__(self):
+            self.head_dim = 4
+            self.index_topk = 4
+            self.compressor = object()
+
+        def update_pool(self, _x, _rope, _cache, start_pos):
+            return ("stock", start_pos)
+
+    class Model:
+        def __init__(self, indexer):
+            self.indexer = indexer
+
+        def named_modules(self):
+            return [("layer.0.indexer", self.indexer)]
+
+    class Cache:
+        _vmlx_dsv4_indexer_skip_decode = True
+
+        def __init__(self, malformed=False):
+            self.states = {
+                "compressor_state": {
+                    "pooled": SimpleNamespace(ndim=3, shape=(1, 3, 4))
+                },
+                "indexer_state": {},
+            }
+            if malformed:
+                self.states["compressor_state"] = {"pooled": object()}
+
+        def _branch_state(self, name):
+            return self.states[name]
+
+    monkeypatch.setattr(mod, "mx", FakeMx)
+    monkeypatch.setattr(mod, "_PATCHED_CLASS", None)
+    monkeypatch.setenv("VMLX_DSV4_SKIP_UNUSED_INDEXER", "1")
+    indexer = Indexer()
+    assert mod.install_dsv4_indexer_skip(Model(indexer)) == 1
+
+    short_x = SimpleNamespace(ndim=1, shape=(4,), dtype="float16")
+    assert indexer.update_pool(short_x, None, Cache(), 1) == ("stock", 1)
+
+    decode_x = SimpleNamespace(ndim=2, shape=(1, 1), dtype="float16")
+    bypassed = indexer.update_pool(decode_x, None, Cache(), 2)
+    assert bypassed == ("zeros", (1, 3, 4), "float16")
+
+    fallback = indexer.update_pool(decode_x, None, Cache(malformed=True), 3)
+    assert fallback == ("stock", 3)
+
+
+def test_lm_head_fastpath_falls_back_once_after_runtime_failure(monkeypatch):
+    import vmlx_engine.models.dsv4_lm_head_cache as mod
+
+    class FakeMx:
+        @staticmethod
+        def quantized_matmul(*_args, **_kwargs):
+            raise RuntimeError("synthetic quantized matmul failure")
+
+    class Head:
+        weight = SimpleNamespace(ndim=2, shape=(16, 4))
+        scales = object()
+        bits = 8
+        group_size = 64
+        mode = "affine"
+
+    class Model:
+        def __init__(self):
+            self.lm_head = Head()
+            self.model = lambda input_ids, cache=None, mask=None: "hidden"
+
+        def __call__(self, input_ids, cache=None, mask=None):
+            return ("stock", input_ids, cache, mask)
+
+    monkeypatch.setattr(mod, "mx", FakeMx)
+    monkeypatch.setenv("VMLX_DSV4_LM_HEAD_MODE", "quantized")
+    model = Model()
+    assert mod.install_dsv4_lm_head_cache(model)
+
+    first = model("ids", cache="cache", mask="mask")
+    second = model("ids2")
+    assert first[0] == second[0] == "stock"
+    assert model._vmlx_dsv4_lm_head_fastpath_disabled is True
+
+
+def test_rope_table_cache_is_bounded(monkeypatch):
+    import mlx.core as mx
+    from jang_tools.dsv4.mlx_model import DeepseekV4RoPE
+
+    import vmlx_engine.models.dsv4_rope_cache as mod
+
+    original_call = DeepseekV4RoPE.__call__
+    original_cache_flag = getattr(DeepseekV4RoPE, "_vmlx_dsv4_rope_cache", None)
+    original_original_call = getattr(
+        DeepseekV4RoPE, "_vmlx_dsv4_rope_original_call", None
+    )
+    mod._TABLES.clear()
+    mod._PATCHED_CLASS = None
+    monkeypatch.setenv("VMLX_DSV4_ROPE_CACHE_MAX_ENTRIES", "1")
+
+    rope = DeepseekV4RoPE(4, 10_000)
+
+    class Model:
+        def named_modules(self):
+            return [("rope", rope)]
+
+    try:
+        assert mod.install_dsv4_rope_cache(Model())
+        x = mx.ones((1, 2, 4), dtype=mx.float16)
+        mx.eval(rope(x, offset=0), rope(x, offset=2))
+        assert len(mod._TABLES) <= 1
+    finally:
+        DeepseekV4RoPE.__call__ = original_call
+        if original_cache_flag is None:
+            with __import__("contextlib").suppress(AttributeError):
+                delattr(DeepseekV4RoPE, "_vmlx_dsv4_rope_cache")
+        else:
+            DeepseekV4RoPE._vmlx_dsv4_rope_cache = original_cache_flag
+        if original_original_call is None:
+            with __import__("contextlib").suppress(AttributeError):
+                delattr(DeepseekV4RoPE, "_vmlx_dsv4_rope_original_call")
+        else:
+            DeepseekV4RoPE._vmlx_dsv4_rope_original_call = original_original_call
+        mod._TABLES.clear()
+        mod._PATCHED_CLASS = None
+
+
+def test_target_harness_requires_reference_match_when_supplied():
+    path = Path(__file__).parents[1] / "bench" / "dsv4_target_harness.py"
+    spec = importlib.util.spec_from_file_location("dsv4_target_harness", path)
+    assert spec is not None and spec.loader is not None
+    harness = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(harness)
+
+    rows = [
+        {
+            "new_tokens": 30,
+            "token_ids_sha256": "actual",
+            "prefill_tok_s": 250.0,
+            "decode_tok_s": 27.0,
+        }
+    ]
+    assert harness._summarize(rows, 200.0, "actual")["passed"] is True
+    mismatch = harness._summarize(rows, 200.0, "reference")
+    assert mismatch["passed"] is False
+    assert mismatch["reference_token_hash_matches"] is False
+    assert Path("dsv4-target-report.json") == harness.DEFAULT_OUTPUT

--- a/vmlx_engine/loaders/load_jangtq_dsv4.py
+++ b/vmlx_engine/loaders/load_jangtq_dsv4.py
@@ -1432,6 +1432,31 @@ def load_jangtq_dsv4_model(model_path: str, *, skip_params_eval: bool = True) ->
                 model_path,
                 skip_eval=skip_params_eval,
             )
+        # PR #248 by Andrew Hornsby (@Hornsan1) supplies substantially faster
+        # affine routed-expert decode kernels. Keep installation inside this
+        # exact DSV4 affine branch; the installer validates every projection
+        # and leaves stock SwitchGLU untouched for unsupported modules.
+        try:
+            from ..metal.affine_moe_decode import install_dsv4_affine_moe_fastpath
+
+            installed = install_dsv4_affine_moe_fastpath(
+                model,
+                model_type="deepseek_v4",
+            )
+            if installed > 0:
+                _log.info(
+                    "DSV4 affine MoE decode fast path installed for %d modules",
+                    installed,
+                )
+            else:
+                _log.info(
+                    "DSV4 affine MoE decode fast path not installed; using stock SwitchGLU"
+                )
+        except Exception as _affine_fastpath_err:
+            _log.warning(
+                "DSV4 affine MoE decode fast path unavailable (%s); using stock SwitchGLU",
+                _affine_fastpath_err,
+            )
 
     # 2026-05-03 (F17): install canonical-encoder shim on
     # tokenizer.apply_chat_template. The bundle ships a Jinja chat_template

--- a/vmlx_engine/loaders/load_jangtq_dsv4.py
+++ b/vmlx_engine/loaders/load_jangtq_dsv4.py
@@ -32,9 +32,10 @@ Runtime contract implemented by the underlying loader:
   this loader verifies the installed JANG attention path has the symmetric
   mask-width fix and per-query compressed-pool mask. Older JANG builds now
   fail loudly instead of being patched in-process.
-- ``swiglu_limit=10`` SwiGLU activation, fp32 lm_head matmul (4096
-  contraction in bf16 drifts logits enough to flip arithmetic answers —
-  see research/DSV-EXHAUSTIVE-VARIABLES-GUIDE.md).
+- ``swiglu_limit=10`` SwiGLU activation, native affine quantized ``lm_head``
+  by default (with an opt-in exact FP32 dequantized fallback; the historical
+  BF16 contraction can drift logits enough to flip arithmetic answers — see
+  research/DSV-EXHAUSTIVE-VARIABLES-GUIDE.md).
 
 The function returns ``(model, tokenizer)`` just like the sibling loaders.
 """
@@ -1398,6 +1399,12 @@ def load_jangtq_dsv4_model(model_path: str, *, skip_params_eval: bool = True) ->
     pool_quant = _configure_dsv4_pool_quant_default(model_path)
     _log.info("DSV4 runtime defaults: DSV4_LONG_CTX=1, DSV4_POOL_QUANT=%s", pool_quant)
     _install_dsv4_memory_defaults()
+    # JANG's layerwise prefill materialization is needed for genuinely long
+    # prompts, but evaluating all 43 layers for a 267-token request adds
+    # avoidable synchronization. Keep the operator's explicit override and
+    # defer the safety boundary to 512 tokens, which is live-verified on the
+    # target model and leaves long-context prefill protected.
+    os.environ.setdefault("DSV4_LAYERWISE_PREFILL_MIN_TOKENS", "512")
 
     # Eagerly register mlx_lm.models.deepseek_v4 so the underlying loader
     # can resolve the model_type. Safe to call multiple times (idempotent).
@@ -1457,6 +1464,46 @@ def load_jangtq_dsv4_model(model_path: str, *, skip_params_eval: bool = True) ->
                 "DSV4 affine MoE decode fast path unavailable (%s); using stock SwitchGLU",
                 _affine_fastpath_err,
             )
+
+    # The JANG DSV4 model class dequantizes its quantized vocabulary head on
+    # every forward call. Install the selected native quantized-head or exact
+    # FP32-cache fast path; this is independent of the experimental routed-
+    # expert kernels above.
+    try:
+        from ..models.dsv4_lm_head_cache import install_dsv4_lm_head_cache
+
+        if install_dsv4_lm_head_cache(model):
+            _log.info("DSV4 lm_head fast path installed")
+        else:
+            _log.info("DSV4 lm_head fast path not installed")
+    except Exception as _lm_head_cache_err:
+        _log.warning("DSV4 lm_head fast path unavailable: %s", _lm_head_cache_err)
+
+    try:
+        from ..models.dsv4_compiled_moe import install_dsv4_compiled_moe
+
+        compiled_moe = install_dsv4_compiled_moe(model)
+        if compiled_moe:
+            _log.info("DSV4 compiled native-gather MoE path installed for %d modules", compiled_moe)
+    except Exception as _compiled_moe_err:
+        _log.warning("DSV4 compiled MoE path unavailable: %s", _compiled_moe_err)
+
+    try:
+        from ..models.dsv4_rope_cache import install_dsv4_rope_cache
+
+        if install_dsv4_rope_cache(model):
+            _log.info("DSV4 exact RoPE table cache installed")
+    except Exception as _rope_cache_err:
+        _log.warning("DSV4 exact RoPE table cache unavailable: %s", _rope_cache_err)
+
+    try:
+        from ..models.dsv4_indexer_skip import install_dsv4_indexer_skip
+
+        indexer_skip = install_dsv4_indexer_skip(model)
+        if indexer_skip:
+            _log.info("DSV4 unused-indexer bypass candidate installed for %d modules", indexer_skip)
+    except Exception as _indexer_skip_err:
+        _log.warning("DSV4 unused-indexer bypass candidate unavailable: %s", _indexer_skip_err)
 
     # 2026-05-03 (F17): install canonical-encoder shim on
     # tokenizer.apply_chat_template. The bundle ships a Jinja chat_template

--- a/vmlx_engine/metal/__init__.py
+++ b/vmlx_engine/metal/__init__.py
@@ -1,6 +1,13 @@
 """Metal kernels package."""
 
+from .affine_moe_decode import (
+    AffineMoEDecodeManager,
+    install_dsv4_affine_moe_fastpath,
+)
 from .kernel_manager import CodebookKernelManager
-from .affine_moe_decode import AffineMoEDecodeManager, install_affine_moe_fastpath
 
-__all__ = ["CodebookKernelManager", "AffineMoEDecodeManager", "install_affine_moe_fastpath"]
+__all__ = [
+    "CodebookKernelManager",
+    "AffineMoEDecodeManager",
+    "install_dsv4_affine_moe_fastpath",
+]

--- a/vmlx_engine/metal/__init__.py
+++ b/vmlx_engine/metal/__init__.py
@@ -1,5 +1,6 @@
 """Metal kernels package."""
 
 from .kernel_manager import CodebookKernelManager
+from .affine_moe_decode import AffineMoEDecodeManager, install_affine_moe_fastpath
 
-__all__ = ["CodebookKernelManager"]
+__all__ = ["CodebookKernelManager", "AffineMoEDecodeManager", "install_affine_moe_fastpath"]

--- a/vmlx_engine/metal/affine_moe_decode.metal
+++ b/vmlx_engine/metal/affine_moe_decode.metal
@@ -1,79 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
 //
-// affine_moe_decode.metal
-// Fused affine-dequant + matvec kernels for MoE decode at batch=1.
-//
-// Problem: MLX's gather_qmm achieves ~2% of peak bandwidth at batch=1/k=6
-// because each expert matvec is too small to saturate the GPU. These kernels
-// fuse gather + dequant + dot-product into a single pass with no
-// intermediate materialization.
-//
-// Architecture: two-pass split reduction.
-//   Pass 1 (these kernels): each thread computes a partial dot-product over
-//     a chunk of groups. Grid = (k, out_dim, n_chunks). Output is fp32
-//     partial sums of shape [k, out_dim, n_chunks].
-//   Pass 2 (host-side mx.sum): reduce partial sums across chunks to [k, out_dim].
-//
-//   Splitting the group loop across chunks increases GPU occupancy by
-//   launching more threadgroups. n_chunks=2 with threadgroup=(1,128,1)
-//   gives the best throughput on M4 Max (17.1 tok/s vs 4.9 baseline).
-//
-// Data layout (matches MLX affine quantization):
-//   x:          [hidden]           float16   (single decode token)
-//   weights:    [E, out, packed]   uint32    (packed N-bit codes)
-//   scales:     [E, out, n_groups] float16   (per-group scale)
-//   biases:     [E, out, n_groups] float16   (per-group bias)
-//   expert_ids: [k]                uint16    (selected expert indices)
-//   partial:    [k, out, n_chunks] float32   (partial sums per chunk)
-//
-// Variants:
-//   b2_g64 — 2-bit codes, group_size=64 (gate_proj, up_proj)
-//   b3_g64 — 3-bit codes, group_size=64 (gate_proj on some layers)
-//   b2_g32 — 2-bit codes, group_size=32 (down_proj)
-//
-// Kernel parameters (via mx.fast.metal_kernel):
-//   inputs:  x, weights, scales, biases, expert_ids,
-//            hidden, out_dim, n_groups, k, n_chunks
-//   outputs: partial [k, out_dim, n_chunks] float32
-//   grid:    (k, out_dim, n_chunks)
-//   threadgroup: (1, 128, 1)  — tuned for M4 Max
-//
+// Fused affine MoE decode kernels contributed by Andrew Hornsby (@Hornsan1)
+// in jjang-ai/vmlx PR #248. The executable copies live in
+// affine_moe_decode.py because mx.fast.metal_kernel accepts kernel bodies.
+// Production installation is guarded to the exact DSV4 affine layout there.
 
 #include <metal_stdlib>
 using namespace metal;
 
-// ---------------------------------------------------------------------------
-// b2_g64: 2-bit codes, group_size=64
-// Packing: 64 elements × 2 bits = 128 bits = 4 uint32 per group.
-// Each uint32 holds 16 × 2-bit codes.
-// ---------------------------------------------------------------------------
 kernel void affine_moe_decode_b2_g64(
-    device const half*   x          [[buffer(0)]],
-    device const uint*   weights    [[buffer(1)]],
-    device const half*   scales     [[buffer(2)]],
-    device const half*   biases     [[buffer(3)]],
+    device const half* x [[buffer(0)]],
+    device const uint* weights [[buffer(1)]],
+    device const half* scales [[buffer(2)]],
+    device const half* biases [[buffer(3)]],
     device const ushort* expert_ids [[buffer(4)]],
-    constant uint&       hidden     [[buffer(5)]],
-    constant uint&       out_dim    [[buffer(6)]],
-    constant uint&       n_groups   [[buffer(7)]],
-    constant uint&       k          [[buffer(8)]],
-    constant uint&       n_chunks   [[buffer(9)]],
-    device float*        partial    [[buffer(10)]],
+    constant uint& hidden [[buffer(5)]],
+    constant uint& out_dim [[buffer(6)]],
+    constant uint& n_groups [[buffer(7)]],
+    constant uint& k [[buffer(8)]],
+    constant uint& n_chunks [[buffer(9)]],
+    device float* partial [[buffer(10)]],
     uint3 tpig [[thread_position_in_grid]]
 ) {
     uint expert_local = tpig.x;
     uint out_d = tpig.y;
     uint chunk_id = tpig.z;
     if (expert_local >= k || out_d >= out_dim) return;
-
     uint expert_id = (uint)expert_ids[expert_local];
     uint packed_per_row = n_groups * 4u;
     uint w_row_base = expert_id * out_dim * packed_per_row + out_d * packed_per_row;
     uint s_row_base = expert_id * out_dim * n_groups + out_d * n_groups;
-
     uint groups_per_chunk = n_groups / n_chunks;
     uint g_start = chunk_id * groups_per_chunk;
     uint g_end = g_start + groups_per_chunk;
-
     float sum = 0.0f;
     for (uint g = g_start; g < g_end; g++) {
         float scale = (float)scales[s_row_base + g];
@@ -92,39 +51,31 @@ kernel void affine_moe_decode_b2_g64(
     partial[expert_local * out_dim * n_chunks + out_d * n_chunks + chunk_id] = sum;
 }
 
-// ---------------------------------------------------------------------------
-// b3_g64: 3-bit codes, group_size=64
-// Packing: 64 elements × 3 bits = 192 bits = 6 uint32 per group.
-// Codes may span uint32 boundaries (bit_off > 29).
-// ---------------------------------------------------------------------------
 kernel void affine_moe_decode_b3_g64(
-    device const half*   x          [[buffer(0)]],
-    device const uint*   weights    [[buffer(1)]],
-    device const half*   scales     [[buffer(2)]],
-    device const half*   biases     [[buffer(3)]],
+    device const half* x [[buffer(0)]],
+    device const uint* weights [[buffer(1)]],
+    device const half* scales [[buffer(2)]],
+    device const half* biases [[buffer(3)]],
     device const ushort* expert_ids [[buffer(4)]],
-    constant uint&       hidden     [[buffer(5)]],
-    constant uint&       out_dim    [[buffer(6)]],
-    constant uint&       n_groups   [[buffer(7)]],
-    constant uint&       k          [[buffer(8)]],
-    constant uint&       n_chunks   [[buffer(9)]],
-    device float*        partial    [[buffer(10)]],
+    constant uint& hidden [[buffer(5)]],
+    constant uint& out_dim [[buffer(6)]],
+    constant uint& n_groups [[buffer(7)]],
+    constant uint& k [[buffer(8)]],
+    constant uint& n_chunks [[buffer(9)]],
+    device float* partial [[buffer(10)]],
     uint3 tpig [[thread_position_in_grid]]
 ) {
     uint expert_local = tpig.x;
     uint out_d = tpig.y;
     uint chunk_id = tpig.z;
     if (expert_local >= k || out_d >= out_dim) return;
-
     uint expert_id = (uint)expert_ids[expert_local];
     uint packed_per_row = n_groups * 6u;
     uint w_row_base = expert_id * out_dim * packed_per_row + out_d * packed_per_row;
     uint s_row_base = expert_id * out_dim * n_groups + out_d * n_groups;
-
     uint groups_per_chunk = n_groups / n_chunks;
     uint g_start = chunk_id * groups_per_chunk;
     uint g_end = g_start + groups_per_chunk;
-
     float sum = 0.0f;
     for (uint g = g_start; g < g_end; g++) {
         float scale = (float)scales[s_row_base + g];
@@ -150,41 +101,32 @@ kernel void affine_moe_decode_b3_g64(
     partial[expert_local * out_dim * n_chunks + out_d * n_chunks + chunk_id] = sum;
 }
 
-// ---------------------------------------------------------------------------
-// b2_g32: 2-bit codes, group_size=32
-// Packing: 32 elements × 2 bits = 64 bits = 2 uint32 per group.
-// Used by down_proj (inter=2048, group_size=32).
-// x is indexed per-expert: x_row_base = expert_local * hidden.
-// ---------------------------------------------------------------------------
 kernel void affine_moe_decode_b2_g32(
-    device const half*   x          [[buffer(0)]],
-    device const uint*   weights    [[buffer(1)]],
-    device const half*   scales     [[buffer(2)]],
-    device const half*   biases     [[buffer(3)]],
+    device const half* x [[buffer(0)]],
+    device const uint* weights [[buffer(1)]],
+    device const half* scales [[buffer(2)]],
+    device const half* biases [[buffer(3)]],
     device const ushort* expert_ids [[buffer(4)]],
-    constant uint&       hidden     [[buffer(5)]],
-    constant uint&       out_dim    [[buffer(6)]],
-    constant uint&       n_groups   [[buffer(7)]],
-    constant uint&       k          [[buffer(8)]],
-    constant uint&       n_chunks   [[buffer(9)]],
-    device float*        partial    [[buffer(10)]],
+    constant uint& hidden [[buffer(5)]],
+    constant uint& out_dim [[buffer(6)]],
+    constant uint& n_groups [[buffer(7)]],
+    constant uint& k [[buffer(8)]],
+    constant uint& n_chunks [[buffer(9)]],
+    device float* partial [[buffer(10)]],
     uint3 tpig [[thread_position_in_grid]]
 ) {
     uint expert_local = tpig.x;
     uint out_d = tpig.y;
     uint chunk_id = tpig.z;
     if (expert_local >= k || out_d >= out_dim) return;
-
     uint expert_id = (uint)expert_ids[expert_local];
     uint packed_per_row = n_groups * 2u;
     uint w_row_base = expert_id * out_dim * packed_per_row + out_d * packed_per_row;
     uint s_row_base = expert_id * out_dim * n_groups + out_d * n_groups;
     uint x_row_base = expert_local * hidden;
-
     uint groups_per_chunk = n_groups / n_chunks;
     uint g_start = chunk_id * groups_per_chunk;
     uint g_end = g_start + groups_per_chunk;
-
     float sum = 0.0f;
     for (uint g = g_start; g < g_end; g++) {
         float scale = (float)scales[s_row_base + g];

--- a/vmlx_engine/metal/affine_moe_decode.metal
+++ b/vmlx_engine/metal/affine_moe_decode.metal
@@ -1,0 +1,204 @@
+//
+// affine_moe_decode.metal
+// Fused affine-dequant + matvec kernels for MoE decode at batch=1.
+//
+// Problem: MLX's gather_qmm achieves ~2% of peak bandwidth at batch=1/k=6
+// because each expert matvec is too small to saturate the GPU. These kernels
+// fuse gather + dequant + dot-product into a single pass with no
+// intermediate materialization.
+//
+// Architecture: two-pass split reduction.
+//   Pass 1 (these kernels): each thread computes a partial dot-product over
+//     a chunk of groups. Grid = (k, out_dim, n_chunks). Output is fp32
+//     partial sums of shape [k, out_dim, n_chunks].
+//   Pass 2 (host-side mx.sum): reduce partial sums across chunks to [k, out_dim].
+//
+//   Splitting the group loop across chunks increases GPU occupancy by
+//   launching more threadgroups. n_chunks=2 with threadgroup=(1,128,1)
+//   gives the best throughput on M4 Max (17.1 tok/s vs 4.9 baseline).
+//
+// Data layout (matches MLX affine quantization):
+//   x:          [hidden]           float16   (single decode token)
+//   weights:    [E, out, packed]   uint32    (packed N-bit codes)
+//   scales:     [E, out, n_groups] float16   (per-group scale)
+//   biases:     [E, out, n_groups] float16   (per-group bias)
+//   expert_ids: [k]                uint16    (selected expert indices)
+//   partial:    [k, out, n_chunks] float32   (partial sums per chunk)
+//
+// Variants:
+//   b2_g64 — 2-bit codes, group_size=64 (gate_proj, up_proj)
+//   b3_g64 — 3-bit codes, group_size=64 (gate_proj on some layers)
+//   b2_g32 — 2-bit codes, group_size=32 (down_proj)
+//
+// Kernel parameters (via mx.fast.metal_kernel):
+//   inputs:  x, weights, scales, biases, expert_ids,
+//            hidden, out_dim, n_groups, k, n_chunks
+//   outputs: partial [k, out_dim, n_chunks] float32
+//   grid:    (k, out_dim, n_chunks)
+//   threadgroup: (1, 128, 1)  — tuned for M4 Max
+//
+
+#include <metal_stdlib>
+using namespace metal;
+
+// ---------------------------------------------------------------------------
+// b2_g64: 2-bit codes, group_size=64
+// Packing: 64 elements × 2 bits = 128 bits = 4 uint32 per group.
+// Each uint32 holds 16 × 2-bit codes.
+// ---------------------------------------------------------------------------
+kernel void affine_moe_decode_b2_g64(
+    device const half*   x          [[buffer(0)]],
+    device const uint*   weights    [[buffer(1)]],
+    device const half*   scales     [[buffer(2)]],
+    device const half*   biases     [[buffer(3)]],
+    device const ushort* expert_ids [[buffer(4)]],
+    constant uint&       hidden     [[buffer(5)]],
+    constant uint&       out_dim    [[buffer(6)]],
+    constant uint&       n_groups   [[buffer(7)]],
+    constant uint&       k          [[buffer(8)]],
+    constant uint&       n_chunks   [[buffer(9)]],
+    device float*        partial    [[buffer(10)]],
+    uint3 tpig [[thread_position_in_grid]]
+) {
+    uint expert_local = tpig.x;
+    uint out_d = tpig.y;
+    uint chunk_id = tpig.z;
+    if (expert_local >= k || out_d >= out_dim) return;
+
+    uint expert_id = (uint)expert_ids[expert_local];
+    uint packed_per_row = n_groups * 4u;
+    uint w_row_base = expert_id * out_dim * packed_per_row + out_d * packed_per_row;
+    uint s_row_base = expert_id * out_dim * n_groups + out_d * n_groups;
+
+    uint groups_per_chunk = n_groups / n_chunks;
+    uint g_start = chunk_id * groups_per_chunk;
+    uint g_end = g_start + groups_per_chunk;
+
+    float sum = 0.0f;
+    for (uint g = g_start; g < g_end; g++) {
+        float scale = (float)scales[s_row_base + g];
+        float bias = (float)biases[s_row_base + g];
+        uint x_base = g * 64u;
+        uint w_base = w_row_base + g * 4u;
+        for (uint w = 0; w < 4u; w++) {
+            uint packed = weights[w_base + w];
+            uint x_off = x_base + w * 16u;
+            for (uint i = 0; i < 16u; i++) {
+                uint code = (packed >> (i * 2u)) & 0x3u;
+                sum += (float)x[x_off + i] * ((float)code * scale + bias);
+            }
+        }
+    }
+    partial[expert_local * out_dim * n_chunks + out_d * n_chunks + chunk_id] = sum;
+}
+
+// ---------------------------------------------------------------------------
+// b3_g64: 3-bit codes, group_size=64
+// Packing: 64 elements × 3 bits = 192 bits = 6 uint32 per group.
+// Codes may span uint32 boundaries (bit_off > 29).
+// ---------------------------------------------------------------------------
+kernel void affine_moe_decode_b3_g64(
+    device const half*   x          [[buffer(0)]],
+    device const uint*   weights    [[buffer(1)]],
+    device const half*   scales     [[buffer(2)]],
+    device const half*   biases     [[buffer(3)]],
+    device const ushort* expert_ids [[buffer(4)]],
+    constant uint&       hidden     [[buffer(5)]],
+    constant uint&       out_dim    [[buffer(6)]],
+    constant uint&       n_groups   [[buffer(7)]],
+    constant uint&       k          [[buffer(8)]],
+    constant uint&       n_chunks   [[buffer(9)]],
+    device float*        partial    [[buffer(10)]],
+    uint3 tpig [[thread_position_in_grid]]
+) {
+    uint expert_local = tpig.x;
+    uint out_d = tpig.y;
+    uint chunk_id = tpig.z;
+    if (expert_local >= k || out_d >= out_dim) return;
+
+    uint expert_id = (uint)expert_ids[expert_local];
+    uint packed_per_row = n_groups * 6u;
+    uint w_row_base = expert_id * out_dim * packed_per_row + out_d * packed_per_row;
+    uint s_row_base = expert_id * out_dim * n_groups + out_d * n_groups;
+
+    uint groups_per_chunk = n_groups / n_chunks;
+    uint g_start = chunk_id * groups_per_chunk;
+    uint g_end = g_start + groups_per_chunk;
+
+    float sum = 0.0f;
+    for (uint g = g_start; g < g_end; g++) {
+        float scale = (float)scales[s_row_base + g];
+        float bias = (float)biases[s_row_base + g];
+        uint x_base = g * 64u;
+        uint w_base = w_row_base + g * 6u;
+        for (uint i = 0; i < 64u; i++) {
+            uint bit_start = i * 3u;
+            uint uint_idx = bit_start / 32u;
+            uint bit_off = bit_start % 32u;
+            uint packed = weights[w_base + uint_idx];
+            uint code;
+            if (bit_off <= 29u) {
+                code = (packed >> bit_off) & 0x7u;
+            } else {
+                uint lo = packed >> bit_off;
+                uint hi = weights[w_base + uint_idx + 1u];
+                code = (lo | (hi << (32u - bit_off))) & 0x7u;
+            }
+            sum += (float)x[x_base + i] * ((float)code * scale + bias);
+        }
+    }
+    partial[expert_local * out_dim * n_chunks + out_d * n_chunks + chunk_id] = sum;
+}
+
+// ---------------------------------------------------------------------------
+// b2_g32: 2-bit codes, group_size=32
+// Packing: 32 elements × 2 bits = 64 bits = 2 uint32 per group.
+// Used by down_proj (inter=2048, group_size=32).
+// x is indexed per-expert: x_row_base = expert_local * hidden.
+// ---------------------------------------------------------------------------
+kernel void affine_moe_decode_b2_g32(
+    device const half*   x          [[buffer(0)]],
+    device const uint*   weights    [[buffer(1)]],
+    device const half*   scales     [[buffer(2)]],
+    device const half*   biases     [[buffer(3)]],
+    device const ushort* expert_ids [[buffer(4)]],
+    constant uint&       hidden     [[buffer(5)]],
+    constant uint&       out_dim    [[buffer(6)]],
+    constant uint&       n_groups   [[buffer(7)]],
+    constant uint&       k          [[buffer(8)]],
+    constant uint&       n_chunks   [[buffer(9)]],
+    device float*        partial    [[buffer(10)]],
+    uint3 tpig [[thread_position_in_grid]]
+) {
+    uint expert_local = tpig.x;
+    uint out_d = tpig.y;
+    uint chunk_id = tpig.z;
+    if (expert_local >= k || out_d >= out_dim) return;
+
+    uint expert_id = (uint)expert_ids[expert_local];
+    uint packed_per_row = n_groups * 2u;
+    uint w_row_base = expert_id * out_dim * packed_per_row + out_d * packed_per_row;
+    uint s_row_base = expert_id * out_dim * n_groups + out_d * n_groups;
+    uint x_row_base = expert_local * hidden;
+
+    uint groups_per_chunk = n_groups / n_chunks;
+    uint g_start = chunk_id * groups_per_chunk;
+    uint g_end = g_start + groups_per_chunk;
+
+    float sum = 0.0f;
+    for (uint g = g_start; g < g_end; g++) {
+        float scale = (float)scales[s_row_base + g];
+        float bias = (float)biases[s_row_base + g];
+        uint x_base = x_row_base + g * 32u;
+        uint w_base = w_row_base + g * 2u;
+        for (uint w = 0; w < 2u; w++) {
+            uint packed = weights[w_base + w];
+            uint x_off = x_base + w * 16u;
+            for (uint i = 0; i < 16u; i++) {
+                uint code = (packed >> (i * 2u)) & 0x3u;
+                sum += (float)x[x_off + i] * ((float)code * scale + bias);
+            }
+        }
+    }
+    partial[expert_local * out_dim * n_chunks + out_d * n_chunks + chunk_id] = sum;
+}

--- a/vmlx_engine/metal/affine_moe_decode.py
+++ b/vmlx_engine/metal/affine_moe_decode.py
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Affine MoE decode fast-path — fused dequant+matvec Metal kernels.
+
+Replaces stock SwitchGLU gather_qmm for batch=1 decode on affine-quantized
+JANG models (2-bit and 3-bit weights with per-group scale/bias).  The stock
+path achieves ~2% of peak bandwidth at k=6 because each expert matvec is too
+small to saturate the GPU.  These kernels fuse gather + dequant + dot-product
+into a single pass with no intermediate materialization.
+
+Architecture: two-pass split reduction.
+  Pass 1 (Metal): each thread computes a partial dot-product over a chunk of
+    groups.  Grid = (k, out_dim, n_chunks).  Output: fp32 partial sums
+    [k, out_dim, n_chunks].
+  Pass 2 (host): mx.sum across chunks → [k, out_dim] fp16.
+
+  Splitting the group loop across chunks increases GPU occupancy.
+  n_chunks=2, threadgroup=(1, 128, 1) is optimal on M4 Max.
+
+Measured: 4.9 → 17.1 tok/s (3.46×) on DeepSeek-V4-Flash JANG, M4 Max 128 GB.
+
+Usage::
+
+    from vmlx_engine.metal.affine_moe_decode import install_affine_moe_fastpath
+    install_affine_moe_fastpath(model)
+
+The patch is scoped to batch=1 decode (indices.size < 64).  Prefill and
+large-batch calls fall through to the original SwitchGLU.__call__.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    import mlx.core as mx
+
+    _MLX_AVAILABLE = True
+except ImportError:
+    _MLX_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Kernel source strings — must stay in sync with affine_moe_decode.metal
+# ---------------------------------------------------------------------------
+
+_KERNEL_B2_G64 = """
+    uint expert_local = thread_position_in_grid.x;
+    uint out_d = thread_position_in_grid.y;
+    uint chunk_id = thread_position_in_grid.z;
+    if (expert_local >= (uint)k || out_d >= (uint)out_dim) return;
+    uint expert_id = (uint)expert_ids[expert_local];
+    uint packed_per_row = (uint)n_groups * 4u;
+    uint w_row_base = expert_id * (uint)out_dim * packed_per_row + out_d * packed_per_row;
+    uint s_row_base = expert_id * (uint)out_dim * (uint)n_groups + out_d * (uint)n_groups;
+    uint groups_per_chunk = (uint)n_groups / (uint)n_chunks;
+    uint g_start = chunk_id * groups_per_chunk;
+    uint g_end = g_start + groups_per_chunk;
+    float sum = 0.0f;
+    for (uint g = g_start; g < g_end; g++) {
+        float scale = (float)scales[s_row_base + g];
+        float bias = (float)biases[s_row_base + g];
+        uint x_base = g * 64u;
+        uint w_base = w_row_base + g * 4u;
+        for (uint w = 0; w < 4u; w++) {
+            uint packed = weights[w_base + w];
+            uint x_off = x_base + w * 16u;
+            for (uint i = 0; i < 16u; i++) {
+                uint code = (packed >> (i * 2u)) & 0x3u;
+                sum += (float)x[x_off + i] * ((float)code * scale + bias);
+            }
+        }
+    }
+    partial[expert_local * (uint)out_dim * (uint)n_chunks + out_d * (uint)n_chunks + chunk_id] = sum;
+"""
+
+_KERNEL_B3_G64 = """
+    uint expert_local = thread_position_in_grid.x;
+    uint out_d = thread_position_in_grid.y;
+    uint chunk_id = thread_position_in_grid.z;
+    if (expert_local >= (uint)k || out_d >= (uint)out_dim) return;
+    uint expert_id = (uint)expert_ids[expert_local];
+    uint packed_per_row = (uint)n_groups * 6u;
+    uint w_row_base = expert_id * (uint)out_dim * packed_per_row + out_d * packed_per_row;
+    uint s_row_base = expert_id * (uint)out_dim * (uint)n_groups + out_d * (uint)n_groups;
+    uint groups_per_chunk = (uint)n_groups / (uint)n_chunks;
+    uint g_start = chunk_id * groups_per_chunk;
+    uint g_end = g_start + groups_per_chunk;
+    float sum = 0.0f;
+    for (uint g = g_start; g < g_end; g++) {
+        float scale = (float)scales[s_row_base + g];
+        float bias = (float)biases[s_row_base + g];
+        uint x_base = g * 64u;
+        uint w_base = w_row_base + g * 6u;
+        for (uint i = 0; i < 64u; i++) {
+            uint bit_start = i * 3u;
+            uint uint_idx = bit_start / 32u;
+            uint bit_off = bit_start % 32u;
+            uint packed = weights[w_base + uint_idx];
+            uint code;
+            if (bit_off <= 29u) { code = (packed >> bit_off) & 0x7u; }
+            else {
+                uint lo = packed >> bit_off;
+                uint hi = weights[w_base + uint_idx + 1u];
+                code = (lo | (hi << (32u - bit_off))) & 0x7u;
+            }
+            sum += (float)x[x_base + i] * ((float)code * scale + bias);
+        }
+    }
+    partial[expert_local * (uint)out_dim * (uint)n_chunks + out_d * (uint)n_chunks + chunk_id] = sum;
+"""
+
+_KERNEL_B2_G32 = """
+    uint expert_local = thread_position_in_grid.x;
+    uint out_d = thread_position_in_grid.y;
+    uint chunk_id = thread_position_in_grid.z;
+    if (expert_local >= (uint)k || out_d >= (uint)out_dim) return;
+    uint expert_id = (uint)expert_ids[expert_local];
+    uint packed_per_row = (uint)n_groups * 2u;
+    uint w_row_base = expert_id * (uint)out_dim * packed_per_row + out_d * packed_per_row;
+    uint s_row_base = expert_id * (uint)out_dim * (uint)n_groups + out_d * (uint)n_groups;
+    uint x_row_base = expert_local * (uint)hidden;
+    uint groups_per_chunk = (uint)n_groups / (uint)n_chunks;
+    uint g_start = chunk_id * groups_per_chunk;
+    uint g_end = g_start + groups_per_chunk;
+    float sum = 0.0f;
+    for (uint g = g_start; g < g_end; g++) {
+        float scale = (float)scales[s_row_base + g];
+        float bias = (float)biases[s_row_base + g];
+        uint x_base = x_row_base + g * 32u;
+        uint w_base = w_row_base + g * 2u;
+        for (uint w = 0; w < 2u; w++) {
+            uint packed = weights[w_base + w];
+            uint x_off = x_base + w * 16u;
+            for (uint i = 0; i < 16u; i++) {
+                uint code = (packed >> (i * 2u)) & 0x3u;
+                sum += (float)x[x_off + i] * ((float)code * scale + bias);
+            }
+        }
+    }
+    partial[expert_local * (uint)out_dim * (uint)n_chunks + out_d * (uint)n_chunks + chunk_id] = sum;
+"""
+
+# ---------------------------------------------------------------------------
+# Tunables — M4 Max optimal
+# ---------------------------------------------------------------------------
+N_CHUNKS = 2
+THREADGROUP_Y = 128
+
+
+class AffineMoEDecodeManager:
+    """Compiles and caches affine MoE decode kernels.
+
+    One instance per process is sufficient; kernels are compiled lazily
+    on first use and cached for the lifetime of the manager.
+    """
+
+    def __init__(self, n_chunks: int = N_CHUNKS, threadgroup_y: int = THREADGROUP_Y):
+        self.n_chunks = n_chunks
+        self.threadgroup_y = threadgroup_y
+        self._kernels: dict[str, Any] = {}
+        self._compiled = False
+
+    def _compile(self) -> None:
+        if self._compiled:
+            return
+        if not _MLX_AVAILABLE:
+            raise RuntimeError("MLX is not available")
+        specs = [
+            ("b2_g64", _KERNEL_B2_G64),
+            ("b3_g64", _KERNEL_B3_G64),
+            ("b2_g32", _KERNEL_B2_G32),
+        ]
+        for name, src in specs:
+            self._kernels[name] = mx.fast.metal_kernel(
+                name=f"affine_moe_decode_{name}",
+                input_names=[
+                    "x", "weights", "scales", "biases", "expert_ids",
+                    "hidden", "out_dim", "n_groups", "k", "n_chunks",
+                ],
+                output_names=["partial"],
+                source=src,
+                ensure_row_contiguous=False,
+            )
+        self._compiled = True
+        logger.info(
+            "Affine MoE decode kernels compiled (n_chunks=%d, tg_y=%d)",
+            self.n_chunks, self.threadgroup_y,
+        )
+
+    def kernel_for(self, bits: int, group_size: int) -> Any:
+        """Return the compiled kernel matching the given quantization params."""
+        self._compile()
+        key = f"b{bits}_g{group_size}"
+        if key not in self._kernels:
+            raise ValueError(
+                f"No affine decode kernel for bits={bits}, group_size={group_size}. "
+                f"Available: {sorted(self._kernels)}"
+            )
+        return self._kernels[key]
+
+    def run_projection(
+        self,
+        x: "mx.array",
+        weight: "mx.array",
+        scales: "mx.array",
+        biases: "mx.array",
+        expert_ids_u16: "mx.array",
+        hidden: int,
+        out_dim: int,
+        n_groups: int,
+        k: int,
+        bits: int,
+        group_size: int,
+    ) -> "mx.array":
+        """Run one affine projection through the fused kernel.
+
+        Returns fp16 output of shape [k, out_dim].
+        """
+        kern = self.kernel_for(bits, group_size)
+        nc = self.n_chunks
+        partial = kern(
+            inputs=[
+                x, weight, scales, biases, expert_ids_u16,
+                mx.array(hidden, dtype=mx.uint32),
+                mx.array(out_dim, dtype=mx.uint32),
+                mx.array(n_groups, dtype=mx.uint32),
+                mx.array(k, dtype=mx.uint32),
+                mx.array(nc, dtype=mx.uint32),
+            ],
+            output_shapes=[(k, out_dim, nc)],
+            output_dtypes=[mx.float32],
+            grid=(k, out_dim, nc),
+            threadgroup=(1, self.threadgroup_y, 1),
+        )[0]
+        return mx.sum(partial, axis=-1).astype(mx.float16)
+
+    @property
+    def is_available(self) -> bool:
+        return _MLX_AVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+_manager: AffineMoEDecodeManager | None = None
+
+
+def get_manager() -> AffineMoEDecodeManager:
+    global _manager
+    if _manager is None:
+        _manager = AffineMoEDecodeManager()
+    return _manager
+
+
+# ---------------------------------------------------------------------------
+# SwitchGLU patch
+# ---------------------------------------------------------------------------
+
+def install_affine_moe_fastpath(model: Any) -> int:
+    """Monkey-patch SwitchGLU.__call__ for affine-quantized decode.
+
+    Only activates for batch=1 decode (indices.size < 64).  Prefill and
+    large-batch calls fall through to the original implementation.
+
+    Returns the number of SwitchGLU modules tagged for the fast path.
+    """
+    if not _MLX_AVAILABLE:
+        logger.warning("MLX not available; affine MoE fast-path skipped")
+        return 0
+
+    from mlx_lm.models.switch_layers import SwitchGLU
+
+    mgr = get_manager()
+    _orig_call = getattr(SwitchGLU, "_affine_original_call", SwitchGLU.__call__)
+    setattr(SwitchGLU, "_affine_original_call", _orig_call)
+
+    # Per-layer constant cache (avoids mx.array allocation per token)
+    _layer_cache: dict[int, dict] = {}
+
+    def _get_layer_cfg(switch: Any) -> dict:
+        sid = id(switch)
+        if sid in _layer_cache:
+            return _layer_cache[sid]
+        gp, up, dp = switch.gate_proj, switch.up_proj, switch.down_proj
+        cfg = {
+            "gate": {
+                "w": gp.weight, "s": gp.scales,
+                "b": gp.biases if gp.biases is not None else mx.zeros_like(gp.scales),
+                "out": gp.output_dims, "ng": gp.scales.shape[2],
+                "bits": gp.bits, "gs": gp.group_size,
+            },
+            "up": {
+                "w": up.weight, "s": up.scales,
+                "b": up.biases if up.biases is not None else mx.zeros_like(up.scales),
+                "out": up.output_dims, "ng": up.scales.shape[2],
+                "bits": up.bits, "gs": up.group_size,
+            },
+            "down": {
+                "w": dp.weight, "s": dp.scales,
+                "b": dp.biases if dp.biases is not None else mx.zeros_like(dp.scales),
+                "out": dp.output_dims, "ng": dp.scales.shape[2],
+                "inter": up.output_dims,
+                "bits": dp.bits, "gs": dp.group_size,
+            },
+            "hidden_u32": None,
+        }
+        _layer_cache[sid] = cfg
+        return cfg
+
+    def _affine_switchglu_call(self: Any, x: "mx.array", indices: "mx.array") -> "mx.array":
+        batch = x.shape[0] * (x.shape[1] if x.ndim > 2 else 1)
+        if batch > 1 or indices.size >= 64:
+            return _orig_call(self, x, indices)
+
+        idx = indices.reshape(-1)
+        x1 = x.reshape(-1)
+        k = idx.shape[0]
+        idx16 = idx.astype(mx.uint16)
+        c = _get_layer_cfg(self)
+
+        if c["hidden_u32"] is None:
+            c["hidden_u32"] = mx.array(x1.shape[0], dtype=mx.uint32)
+        hidden_val = c["hidden_u32"]
+
+        def _run(proj: dict, x_in: "mx.array", h_val: "mx.array") -> "mx.array":
+            return mgr.run_projection(
+                x_in, proj["w"], proj["s"], proj["b"], idx16,
+                h_val.item() if hasattr(h_val, "item") else int(h_val),
+                proj["out"], proj["ng"], k,
+                proj["bits"], proj["gs"],
+            )
+
+        g = _run(c["gate"], x1, hidden_val)
+        u = _run(c["up"], x1, hidden_val)
+        act = self.activation(u, g)
+        d = _run(c["down"], act, mx.array(c["down"]["inter"], dtype=mx.uint32))
+
+        if x.ndim == 3:
+            return d.reshape(x.shape[0], k, -1)
+        return d.reshape(1, k, -1)
+
+    SwitchGLU.__call__ = _affine_switchglu_call
+
+    # Tag affine-quantized modules
+    n_patched = 0
+    for _, m in model.named_modules():
+        if isinstance(m, SwitchGLU):
+            gp = getattr(m, "gate_proj", None)
+            if gp is not None and hasattr(gp, "bits") and hasattr(gp, "group_size"):
+                n_patched += 1
+
+    logger.info(
+        "Affine MoE decode fast-path installed (%d SwitchGLU modules, "
+        "n_chunks=%d, tg_y=%d)",
+        n_patched, mgr.n_chunks, mgr.threadgroup_y,
+    )
+    return n_patched

--- a/vmlx_engine/metal/affine_moe_decode.py
+++ b/vmlx_engine/metal/affine_moe_decode.py
@@ -1,52 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
-"""
-Affine MoE decode fast-path — fused dequant+matvec Metal kernels.
+"""Guarded affine-MoE decode kernels for DeepSeek-V4.
 
-Replaces stock SwitchGLU gather_qmm for batch=1 decode on affine-quantized
-JANG models (2-bit and 3-bit weights with per-group scale/bias).  The stock
-path achieves ~2% of peak bandwidth at k=6 because each expert matvec is too
-small to saturate the GPU.  These kernels fuse gather + dequant + dot-product
-into a single pass with no intermediate materialization.
-
-Architecture: two-pass split reduction.
-  Pass 1 (Metal): each thread computes a partial dot-product over a chunk of
-    groups.  Grid = (k, out_dim, n_chunks).  Output: fp32 partial sums
-    [k, out_dim, n_chunks].
-  Pass 2 (host): mx.sum across chunks → [k, out_dim] fp16.
-
-  Splitting the group loop across chunks increases GPU occupancy.
-  n_chunks=2, threadgroup=(1, 128, 1) is optimal on M4 Max.
-
-Measured: 4.9 → 17.1 tok/s (3.46×) on DeepSeek-V4-Flash JANG, M4 Max 128 GB.
-
-Usage::
-
-    from vmlx_engine.metal.affine_moe_decode import install_affine_moe_fastpath
-    install_affine_moe_fastpath(model)
-
-The patch is scoped to batch=1 decode (indices.size < 64).  Prefill and
-large-batch calls fall through to the original SwitchGLU.__call__.
+The fused dequantize-plus-matvec kernel design and initial implementation were
+contributed by Andrew Hornsby (@Hornsan1) in jjang-ai/vmlx PR #248.  This
+version keeps that work behind the exact DSV4 affine layout it was measured on
+and preserves the stock ``SwitchGLU`` path for every other model, shape, dtype,
+or quantization layout.
 """
 
 from __future__ import annotations
 
 import logging
+import os
+import weakref
+from dataclasses import dataclass, field
 from typing import Any
-
-logger = logging.getLogger(__name__)
 
 try:
     import mlx.core as mx
+except ImportError:  # pragma: no cover - non-Apple package inspection
+    mx = None  # type: ignore[assignment]
 
-    _MLX_AVAILABLE = True
-except ImportError:
-    _MLX_AVAILABLE = False
 
-# ---------------------------------------------------------------------------
-# Kernel source strings — must stay in sync with affine_moe_decode.metal
-# ---------------------------------------------------------------------------
+logger = logging.getLogger(__name__)
 
-_KERNEL_B2_G64 = """
+N_CHUNKS = 2
+THREADGROUP_Y = 128
+
+
+_KERNEL_B2_G64 = r"""
     uint expert_local = thread_position_in_grid.x;
     uint out_d = thread_position_in_grid.y;
     uint chunk_id = thread_position_in_grid.z;
@@ -76,7 +58,8 @@ _KERNEL_B2_G64 = """
     partial[expert_local * (uint)out_dim * (uint)n_chunks + out_d * (uint)n_chunks + chunk_id] = sum;
 """
 
-_KERNEL_B3_G64 = """
+
+_KERNEL_B3_G64 = r"""
     uint expert_local = thread_position_in_grid.x;
     uint out_d = thread_position_in_grid.y;
     uint chunk_id = thread_position_in_grid.z;
@@ -100,8 +83,9 @@ _KERNEL_B3_G64 = """
             uint bit_off = bit_start % 32u;
             uint packed = weights[w_base + uint_idx];
             uint code;
-            if (bit_off <= 29u) { code = (packed >> bit_off) & 0x7u; }
-            else {
+            if (bit_off <= 29u) {
+                code = (packed >> bit_off) & 0x7u;
+            } else {
                 uint lo = packed >> bit_off;
                 uint hi = weights[w_base + uint_idx + 1u];
                 code = (lo | (hi << (32u - bit_off))) & 0x7u;
@@ -112,7 +96,8 @@ _KERNEL_B3_G64 = """
     partial[expert_local * (uint)out_dim * (uint)n_chunks + out_d * (uint)n_chunks + chunk_id] = sum;
 """
 
-_KERNEL_B2_G32 = """
+
+_KERNEL_B2_G32 = r"""
     uint expert_local = thread_position_in_grid.x;
     uint out_d = thread_position_in_grid.y;
     uint chunk_id = thread_position_in_grid.z;
@@ -143,218 +128,571 @@ _KERNEL_B2_G32 = """
     partial[expert_local * (uint)out_dim * (uint)n_chunks + out_d * (uint)n_chunks + chunk_id] = sum;
 """
 
-# ---------------------------------------------------------------------------
-# Tunables — M4 Max optimal
-# ---------------------------------------------------------------------------
-N_CHUNKS = 2
-THREADGROUP_Y = 128
-
 
 class AffineMoEDecodeManager:
-    """Compiles and caches affine MoE decode kernels.
-
-    One instance per process is sufficient; kernels are compiled lazily
-    on first use and cached for the lifetime of the manager.
-    """
+    """Lazily compile and reuse Hornsan1's three exact affine kernels."""
 
     def __init__(self, n_chunks: int = N_CHUNKS, threadgroup_y: int = THREADGROUP_Y):
-        self.n_chunks = n_chunks
-        self.threadgroup_y = threadgroup_y
+        self.n_chunks = int(n_chunks)
+        self.threadgroup_y = int(threadgroup_y)
         self._kernels: dict[str, Any] = {}
-        self._compiled = False
 
-    def _compile(self) -> None:
-        if self._compiled:
-            return
-        if not _MLX_AVAILABLE:
-            raise RuntimeError("MLX is not available")
-        specs = [
-            ("b2_g64", _KERNEL_B2_G64),
-            ("b3_g64", _KERNEL_B3_G64),
-            ("b2_g32", _KERNEL_B2_G32),
-        ]
-        for name, src in specs:
-            self._kernels[name] = mx.fast.metal_kernel(
-                name=f"affine_moe_decode_{name}",
+    def kernel_for(self, bits: int, group_size: int):
+        if mx is None:
+            raise RuntimeError("MLX is unavailable")
+        key = f"b{int(bits)}_g{int(group_size)}"
+        sources = {
+            "b2_g64": _KERNEL_B2_G64,
+            "b3_g64": _KERNEL_B3_G64,
+            "b2_g32": _KERNEL_B2_G32,
+        }
+        if key not in sources:
+            raise ValueError(f"unsupported DSV4 affine projection {key}")
+        if key not in self._kernels:
+            self._kernels[key] = mx.fast.metal_kernel(
+                name=f"dsv4_affine_moe_decode_{key}",
                 input_names=[
                     "x", "weights", "scales", "biases", "expert_ids",
                     "hidden", "out_dim", "n_groups", "k", "n_chunks",
                 ],
                 output_names=["partial"],
-                source=src,
+                source=sources[key],
                 ensure_row_contiguous=False,
-            )
-        self._compiled = True
-        logger.info(
-            "Affine MoE decode kernels compiled (n_chunks=%d, tg_y=%d)",
-            self.n_chunks, self.threadgroup_y,
-        )
-
-    def kernel_for(self, bits: int, group_size: int) -> Any:
-        """Return the compiled kernel matching the given quantization params."""
-        self._compile()
-        key = f"b{bits}_g{group_size}"
-        if key not in self._kernels:
-            raise ValueError(
-                f"No affine decode kernel for bits={bits}, group_size={group_size}. "
-                f"Available: {sorted(self._kernels)}"
             )
         return self._kernels[key]
 
     def run_projection(
         self,
-        x: "mx.array",
-        weight: "mx.array",
-        scales: "mx.array",
-        biases: "mx.array",
-        expert_ids_u16: "mx.array",
-        hidden: int,
-        out_dim: int,
-        n_groups: int,
+        x: mx.array,
+        projection: _Projection,
+        expert_ids: mx.array,
         k: int,
-        bits: int,
-        group_size: int,
-    ) -> "mx.array":
-        """Run one affine projection through the fused kernel.
-
-        Returns fp16 output of shape [k, out_dim].
-        """
-        kern = self.kernel_for(bits, group_size)
-        nc = self.n_chunks
-        partial = kern(
+    ) -> mx.array:
+        kernel = self.kernel_for(projection.bits, projection.group_size)
+        partial = kernel(
             inputs=[
-                x, weight, scales, biases, expert_ids_u16,
-                mx.array(hidden, dtype=mx.uint32),
-                mx.array(out_dim, dtype=mx.uint32),
-                mx.array(n_groups, dtype=mx.uint32),
+                x,
+                projection.weight,
+                projection.scales,
+                projection.biases,
+                expert_ids,
+                projection.hidden_scalar,
+                projection.out_scalar,
+                projection.groups_scalar,
                 mx.array(k, dtype=mx.uint32),
-                mx.array(nc, dtype=mx.uint32),
+                projection.chunks_scalar,
             ],
-            output_shapes=[(k, out_dim, nc)],
+            output_shapes=[(k, projection.output_dims, self.n_chunks)],
             output_dtypes=[mx.float32],
-            grid=(k, out_dim, nc),
+            grid=(k, projection.output_dims, self.n_chunks),
             threadgroup=(1, self.threadgroup_y, 1),
         )[0]
         return mx.sum(partial, axis=-1).astype(mx.float16)
 
-    @property
-    def is_available(self) -> bool:
-        return _MLX_AVAILABLE
+
+@dataclass
+class _Projection:
+    weight: mx.array
+    scales: mx.array
+    biases: mx.array
+    input_dims: int
+    output_dims: int
+    bits: int
+    group_size: int
+    n_groups: int
+    hidden_scalar: mx.array = field(init=False)
+    out_scalar: mx.array = field(init=False)
+    groups_scalar: mx.array = field(init=False)
+    chunks_scalar: mx.array = field(init=False)
+
+    def __post_init__(self):
+        self.hidden_scalar = mx.array(self.input_dims, dtype=mx.uint32)
+        self.out_scalar = mx.array(self.output_dims, dtype=mx.uint32)
+        self.groups_scalar = mx.array(self.n_groups, dtype=mx.uint32)
+        self.chunks_scalar = mx.array(N_CHUNKS, dtype=mx.uint32)
 
 
-# ---------------------------------------------------------------------------
-# Module-level singleton
-# ---------------------------------------------------------------------------
-_manager: AffineMoEDecodeManager | None = None
+@dataclass
+class _SwitchConfig:
+    gate: _Projection
+    up: _Projection
+    down: _Projection
+    disabled_reason: str | None = None
+    first_call_evaluated: bool = False
 
 
-def get_manager() -> AffineMoEDecodeManager:
-    global _manager
-    if _manager is None:
-        _manager = AffineMoEDecodeManager()
-    return _manager
+_MANAGER = AffineMoEDecodeManager()
 
 
-# ---------------------------------------------------------------------------
-# SwitchGLU patch
-# ---------------------------------------------------------------------------
+class _WeakIdentityMap:
+    """Weak module lookup that also accepts unhashable ``mlx.nn.Module`` objects."""
 
-def install_affine_moe_fastpath(model: Any) -> int:
-    """Monkey-patch SwitchGLU.__call__ for affine-quantized decode.
+    def __init__(self):
+        self._items: dict[int, tuple[weakref.ReferenceType[Any], _SwitchConfig]] = {}
 
-    Only activates for batch=1 decode (indices.size < 64).  Prefill and
-    large-batch calls fall through to the original implementation.
+    def __contains__(self, owner: Any) -> bool:
+        entry = self._items.get(id(owner))
+        return entry is not None and entry[0]() is owner
 
-    Returns the number of SwitchGLU modules tagged for the fast path.
+    def __setitem__(self, owner: Any, config: _SwitchConfig) -> None:
+        identity = id(owner)
+        items = self._items
+
+        def _remove(reference: weakref.ReferenceType[Any]) -> None:
+            current = items.get(identity)
+            if current is not None and current[0] is reference:
+                items.pop(identity, None)
+
+        self._items[identity] = (weakref.ref(owner, _remove), config)
+
+    def __getitem__(self, owner: Any) -> _SwitchConfig:
+        missing = object()
+        config = self.get(owner, missing)
+        if config is missing:
+            raise KeyError(owner)
+        return config
+
+    def get(self, owner: Any, default: Any = None) -> Any:
+        entry = self._items.get(id(owner))
+        if entry is None or entry[0]() is not owner:
+            return default
+        return entry[1]
+
+    def discard(self, owner: Any) -> None:
+        identity = id(owner)
+        entry = self._items.get(identity)
+        if entry is not None and entry[0]() is owner:
+            self._items.pop(identity, None)
+
+
+_CONFIGS = _WeakIdentityMap()
+_PATCHED_CLASS: type | None = None
+_ORIGINAL_CALL: Any = None
+_WRAPPER: Any = None
+_PATCHED_WEIGHTED_CLASS: type | None = None
+_ORIGINAL_WEIGHTED_CALL: Any = None
+_WEIGHTED_WRAPPER: Any = None
+_FIRST_FAST_CALL_LOGGED = False
+_FIRST_REGISTERED_FALLBACK_LOGGED = False
+
+
+def _projection_config(module: Any, *, role: str) -> _Projection:
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+
+    if not isinstance(module, QuantizedSwitchLinear):
+        raise ValueError(f"{role} is not QuantizedSwitchLinear")
+    expected = {
+        "gate": ({2, 3}, 64),
+        "up": ({2}, 64),
+        "down": ({2}, 32),
+    }[role]
+    bits = int(module.bits)
+    group_size = int(module.group_size)
+    if bits not in expected[0] or group_size != expected[1]:
+        raise ValueError(f"unsupported {role} bits/group_size={bits}/{group_size}")
+    if getattr(module, "mode", "affine") != "affine":
+        raise ValueError(f"{role} is not affine mode")
+    if "bias" in module:
+        raise ValueError(f"{role} has an unsupported post-matmul bias")
+    weight = module.weight
+    scales = module.scales
+    biases = module.biases
+    if biases is None:
+        raise ValueError(f"{role} is missing affine biases")
+    if weight.dtype != mx.uint32 or scales.dtype != mx.float16 or biases.dtype != mx.float16:
+        raise ValueError(
+            f"{role} dtype mismatch weight/scales/biases="
+            f"{weight.dtype}/{scales.dtype}/{biases.dtype}"
+        )
+    if weight.ndim != 3 or scales.ndim != 3 or biases.shape != scales.shape:
+        raise ValueError(f"{role} has invalid affine tensor ranks")
+    input_dims = int(module.input_dims)
+    output_dims = int(module.output_dims)
+    n_groups = int(scales.shape[2])
+    if n_groups % N_CHUNKS:
+        raise ValueError(f"{role} group count {n_groups} is not divisible by {N_CHUNKS}")
+    if input_dims != n_groups * group_size:
+        raise ValueError(f"{role} input/group geometry mismatch")
+    packed_cols = input_dims * bits // 32
+    if input_dims * bits % 32 or int(weight.shape[2]) != packed_cols:
+        raise ValueError(f"{role} packed-column geometry mismatch")
+    if tuple(scales.shape[:2]) != tuple(weight.shape[:2]):
+        raise ValueError(f"{role} scale/weight geometry mismatch")
+    return _Projection(
+        weight=weight,
+        scales=scales,
+        biases=biases,
+        input_dims=input_dims,
+        output_dims=output_dims,
+        bits=bits,
+        group_size=group_size,
+        n_groups=n_groups,
+    )
+
+
+def _switch_config(module: Any) -> _SwitchConfig:
+    activation = getattr(module, "activation", None)
+    if float(getattr(activation, "swiglu_limit", -1.0)) != 10.0:
+        raise ValueError("DSV4 affine SwitchGLU requires swiglu_limit=10")
+    gate = _projection_config(module.gate_proj, role="gate")
+    up = _projection_config(module.up_proj, role="up")
+    down = _projection_config(module.down_proj, role="down")
+    if gate.input_dims != up.input_dims or gate.output_dims != up.output_dims:
+        raise ValueError("gate/up projection geometry differs")
+    if down.input_dims != up.output_dims or down.output_dims != up.input_dims:
+        raise ValueError("down projection does not invert gate/up geometry")
+    if len({int(gate.weight.shape[0]), int(up.weight.shape[0]), int(down.weight.shape[0])}) != 1:
+        raise ValueError("projection expert counts differ")
+    if int(gate.weight.shape[0]) > 65535:
+        raise ValueError("expert ids do not fit uint16")
+    return _SwitchConfig(gate=gate, up=up, down=down)
+
+
+def _infer_model_type(model: Any) -> str:
+    for owner in (model, getattr(model, "model", None)):
+        if owner is None:
+            continue
+        config = getattr(owner, "config", None)
+        if isinstance(config, dict) and config.get("model_type"):
+            return str(config["model_type"])
+        args = getattr(owner, "args", None)
+        if args is not None and getattr(args, "model_type", None):
+            return str(args.model_type)
+    return ""
+
+
+def _install_class_wrapper(switch_class: type) -> None:
+    global _PATCHED_CLASS, _ORIGINAL_CALL, _WRAPPER
+    if _PATCHED_CLASS is switch_class and switch_class.__call__ is _WRAPPER:
+        return
+    if _PATCHED_CLASS is not None:
+        raise RuntimeError("DSV4 affine fast path was already installed on a different SwitchGLU class")
+    original_call = switch_class.__call__
+
+    def _guarded_call(self: Any, x: mx.array, indices: mx.array) -> mx.array:
+        global _FIRST_FAST_CALL_LOGGED, _FIRST_REGISTERED_FALLBACK_LOGGED
+        config = _CONFIGS.get(self)
+        if (
+            config is None
+            or config.disabled_reason is not None
+            or bool(getattr(self, "training", False))
+        ):
+            return original_call(self, x, indices)
+        leading = tuple(x.shape[:-1])
+        # Keep multi-token prefill on mlx_lm's stock SwitchGLU. It sorts routed
+        # rows once and issues one sorted gather_qmm per projection. Splitting
+        # that dynamic routing into per-expert quantized_matmul calls requires a
+        # host-visible ragged partition (or large padding), adds many launches,
+        # and is not numerically identical to gather_qmm on MLX 0.31.2. This
+        # wrapper therefore owns only the exact single-token decode shape.
+        fallback_reason = None
+        if x.dtype != mx.float16:
+            fallback_reason = f"activation_dtype={x.dtype}"
+        elif x.ndim not in (2, 3):
+            fallback_reason = f"activation_rank={x.ndim}"
+        elif int(x.size) != int(x.shape[-1]):
+            fallback_reason = f"multi_token_shape={tuple(x.shape)}"
+        elif indices.ndim != x.ndim or tuple(indices.shape[:-1]) != leading:
+            fallback_reason = (
+                f"route_shape={tuple(indices.shape)} activation_shape={tuple(x.shape)}"
+            )
+        elif int(indices.shape[-1]) <= 0 or int(indices.shape[-1]) >= 64:
+            fallback_reason = f"route_top_k={int(indices.shape[-1])}"
+        if fallback_reason is not None:
+            if not _FIRST_REGISTERED_FALLBACK_LOGGED:
+                logger.info(
+                    "DSV4 affine MoE registered module used stock SwitchGLU: %s",
+                    fallback_reason,
+                )
+                _FIRST_REGISTERED_FALLBACK_LOGGED = True
+            return original_call(self, x, indices)
+        k = int(indices.shape[-1])
+        try:
+            ids = indices.reshape(-1).astype(mx.uint16)
+            token = x.reshape(-1)
+            gate = _MANAGER.run_projection(token, config.gate, ids, k)
+            up = _MANAGER.run_projection(token, config.up, ids, k)
+            activated = self.activation(up, gate)
+            down = _MANAGER.run_projection(activated, config.down, ids, k)
+            result = down.reshape(leading + (k, config.down.output_dims))
+            if not config.first_call_evaluated:
+                mx.eval(result)
+                config.first_call_evaluated = True
+            if not _FIRST_FAST_CALL_LOGGED:
+                logger.info(
+                    "DSV4 affine MoE Metal decode path active: activation_dtype=%s "
+                    "route_top_k=%d hidden=%d",
+                    x.dtype,
+                    k,
+                    config.gate.input_dims,
+                )
+                _FIRST_FAST_CALL_LOGGED = True
+            return result
+        except Exception as exc:
+            config.disabled_reason = f"{type(exc).__name__}: {exc}"
+            logger.exception(
+                "DSV4 affine MoE fast path failed; disabling it for this SwitchGLU and falling back"
+            )
+            return original_call(self, x, indices)
+
+    switch_class._vmlx_dsv4_affine_original_call = original_call
+    switch_class._vmlx_dsv4_affine_decode_fastpath = True
+    switch_class.__call__ = _guarded_call
+    _PATCHED_CLASS = switch_class
+    _ORIGINAL_CALL = original_call
+    _WRAPPER = _guarded_call
+
+
+def _weighted_decode(
+    switch: Any,
+    config: _SwitchConfig,
+    x: mx.array,
+    indices: mx.array,
+    scores: mx.array,
+) -> mx.array:
+    """Run the official DSV4 score-before-down decode order.
+
+    Current DSV4 packages can own this boundary instead of calling
+    ``SwitchGLU.__call__``. They project the selected gate/up rows, apply
+    limited SwiGLU in FP32, multiply the FP32 route score, cast once to the
+    hidden dtype, and only then run down_proj. Keep that ordering while
+    replacing only the three affine matvecs.
     """
-    if not _MLX_AVAILABLE:
-        logger.warning("MLX not available; affine MoE fast-path skipped")
-        return 0
 
+    leading = tuple(x.shape[:-1])
+    k = int(indices.shape[-1])
+    ids = indices.reshape(-1).astype(mx.uint16)
+    token = x.reshape(-1)
+    gate = _MANAGER.run_projection(token, config.gate, ids, k)
+    up = _MANAGER.run_projection(token, config.up, ids, k)
+
+    gate_fp32 = gate.astype(mx.float32)
+    up_fp32 = up.astype(mx.float32)
+    swiglu_limit = float(switch.activation.swiglu_limit)
+    if swiglu_limit > 0:
+        up_fp32 = mx.clip(up_fp32, a_min=-swiglu_limit, a_max=swiglu_limit)
+        gate_fp32 = mx.clip(gate_fp32, a_min=None, a_max=swiglu_limit)
+    activated = mx.sigmoid(gate_fp32) * gate_fp32 * up_fp32
+    activated = (
+        activated * scores.reshape(-1).astype(mx.float32)[..., None]
+    ).astype(x.dtype)
+    down = _MANAGER.run_projection(activated, config.down, ids, k)
+    return down.reshape(leading + (k, config.down.output_dims))
+
+
+def _install_weighted_moe_wrapper(moe_class: type) -> None:
+    """Patch the DSV4-owned weighted route boundary when it is present."""
+
+    global _PATCHED_WEIGHTED_CLASS, _ORIGINAL_WEIGHTED_CALL, _WEIGHTED_WRAPPER
+    if (
+        _PATCHED_WEIGHTED_CLASS is moe_class
+        and moe_class._weighted_routed_experts is _WEIGHTED_WRAPPER
+    ):
+        return
+    if _PATCHED_WEIGHTED_CLASS is not None:
+        raise RuntimeError(
+            "DSV4 affine fast path was already installed on a different MoE class"
+        )
+    original_call = moe_class._weighted_routed_experts
+
+    def _guarded_weighted_call(
+        self: Any,
+        x: mx.array,
+        indices: mx.array,
+        scores: mx.array,
+    ) -> mx.array:
+        global _FIRST_FAST_CALL_LOGGED, _FIRST_REGISTERED_FALLBACK_LOGGED
+        switch = getattr(self, "switch_mlp", None)
+        config = _CONFIGS.get(switch)
+        if (
+            config is None
+            or config.disabled_reason is not None
+            or bool(getattr(switch, "training", False))
+        ):
+            return original_call(self, x, indices, scores)
+
+        leading = tuple(x.shape[:-1])
+        fallback_reason = None
+        if x.dtype != mx.float16:
+            fallback_reason = f"activation_dtype={x.dtype}"
+        elif x.ndim not in (2, 3):
+            fallback_reason = f"activation_rank={x.ndim}"
+        elif int(x.size) != int(x.shape[-1]):
+            fallback_reason = f"multi_token_shape={tuple(x.shape)}"
+        elif indices.ndim != x.ndim or tuple(indices.shape[:-1]) != leading:
+            fallback_reason = (
+                f"route_shape={tuple(indices.shape)} activation_shape={tuple(x.shape)}"
+            )
+        elif tuple(scores.shape) != tuple(indices.shape):
+            fallback_reason = (
+                f"score_shape={tuple(scores.shape)} route_shape={tuple(indices.shape)}"
+            )
+        elif int(indices.shape[-1]) <= 0 or int(indices.shape[-1]) >= 64:
+            fallback_reason = f"route_top_k={int(indices.shape[-1])}"
+        if fallback_reason is not None:
+            if not _FIRST_REGISTERED_FALLBACK_LOGGED:
+                logger.info(
+                    "DSV4 affine MoE registered module used stock weighted route: %s",
+                    fallback_reason,
+                )
+                _FIRST_REGISTERED_FALLBACK_LOGGED = True
+            return original_call(self, x, indices, scores)
+
+        try:
+            result = _weighted_decode(switch, config, x, indices, scores)
+            if not config.first_call_evaluated:
+                mx.eval(result)
+                config.first_call_evaluated = True
+            if not _FIRST_FAST_CALL_LOGGED:
+                logger.info(
+                    "DSV4 affine MoE Metal weighted decode path active: "
+                    "activation_dtype=%s route_top_k=%d hidden=%d",
+                    x.dtype,
+                    int(indices.shape[-1]),
+                    config.gate.input_dims,
+                )
+                _FIRST_FAST_CALL_LOGGED = True
+            return result
+        except Exception as exc:
+            config.disabled_reason = f"{type(exc).__name__}: {exc}"
+            logger.exception(
+                "DSV4 affine MoE weighted fast path failed; disabling it for "
+                "this SwitchGLU and falling back"
+            )
+            return original_call(self, x, indices, scores)
+
+    moe_class._vmlx_dsv4_affine_original_weighted_call = original_call
+    moe_class._vmlx_dsv4_affine_weighted_decode_fastpath = True
+    moe_class._weighted_routed_experts = _guarded_weighted_call
+    _PATCHED_WEIGHTED_CLASS = moe_class
+    _ORIGINAL_WEIGHTED_CALL = original_call
+    _WEIGHTED_WRAPPER = _guarded_weighted_call
+
+
+def install_dsv4_affine_moe_fastpath(model: Any, *, model_type: str | None = None) -> int:
+    """Enable the fused path only for validated DSV4 affine SwitchGLU modules.
+
+    Unsupported modules remain completely owned by the stock call. Repeated
+    installation is idempotent and only refreshes validated weak references.
+    """
+    if mx is None:
+        logger.info("DSV4 affine MoE fast path skipped: MLX is unavailable")
+        return 0
+    # PR #248 measured a large win over an older M4 stock runtime. Current MLX
+    # on M5 Max is already faster on native gather_qmm (18.7 vs 17.1 tok/s in
+    # the exact 400-token keeper A/B), so this remains an explicit hardware
+    # evaluation opt-in instead of regressing the production default.
+    enabled = os.environ.get("VMLX_DSV4_AFFINE_MOE_FASTPATH", "0").strip().lower()
+    if enabled in {"0", "false", "no", "off"}:
+        logger.info(
+            "DSV4 affine MoE fast path disabled by VMLX_DSV4_AFFINE_MOE_FASTPATH=%s",
+            enabled,
+        )
+        return 0
+    if (model_type or _infer_model_type(model)) != "deepseek_v4":
+        logger.info("DSV4 affine MoE fast path skipped: model_type is not deepseek_v4")
+        return 0
     from mlx_lm.models.switch_layers import SwitchGLU
 
-    mgr = get_manager()
-    _orig_call = getattr(SwitchGLU, "_affine_original_call", SwitchGLU.__call__)
-    setattr(SwitchGLU, "_affine_original_call", _orig_call)
-
-    # Per-layer constant cache (avoids mx.array allocation per token)
-    _layer_cache: dict[int, dict] = {}
-
-    def _get_layer_cfg(switch: Any) -> dict:
-        sid = id(switch)
-        if sid in _layer_cache:
-            return _layer_cache[sid]
-        gp, up, dp = switch.gate_proj, switch.up_proj, switch.down_proj
-        cfg = {
-            "gate": {
-                "w": gp.weight, "s": gp.scales,
-                "b": gp.biases if gp.biases is not None else mx.zeros_like(gp.scales),
-                "out": gp.output_dims, "ng": gp.scales.shape[2],
-                "bits": gp.bits, "gs": gp.group_size,
-            },
-            "up": {
-                "w": up.weight, "s": up.scales,
-                "b": up.biases if up.biases is not None else mx.zeros_like(up.scales),
-                "out": up.output_dims, "ng": up.scales.shape[2],
-                "bits": up.bits, "gs": up.group_size,
-            },
-            "down": {
-                "w": dp.weight, "s": dp.scales,
-                "b": dp.biases if dp.biases is not None else mx.zeros_like(dp.scales),
-                "out": dp.output_dims, "ng": dp.scales.shape[2],
-                "inter": up.output_dims,
-                "bits": dp.bits, "gs": dp.group_size,
-            },
-            "hidden_u32": None,
-        }
-        _layer_cache[sid] = cfg
-        return cfg
-
-    def _affine_switchglu_call(self: Any, x: "mx.array", indices: "mx.array") -> "mx.array":
-        batch = x.shape[0] * (x.shape[1] if x.ndim > 2 else 1)
-        if batch > 1 or indices.size >= 64:
-            return _orig_call(self, x, indices)
-
-        idx = indices.reshape(-1)
-        x1 = x.reshape(-1)
-        k = idx.shape[0]
-        idx16 = idx.astype(mx.uint16)
-        c = _get_layer_cfg(self)
-
-        if c["hidden_u32"] is None:
-            c["hidden_u32"] = mx.array(x1.shape[0], dtype=mx.uint32)
-        hidden_val = c["hidden_u32"]
-
-        def _run(proj: dict, x_in: "mx.array", h_val: "mx.array") -> "mx.array":
-            return mgr.run_projection(
-                x_in, proj["w"], proj["s"], proj["b"], idx16,
-                h_val.item() if hasattr(h_val, "item") else int(h_val),
-                proj["out"], proj["ng"], k,
-                proj["bits"], proj["gs"],
+    accepted: list[tuple[Any, _SwitchConfig]] = []
+    rejected: list[str] = []
+    switch_modules: list[Any] = []
+    named_modules = getattr(model, "named_modules", None)
+    if not callable(named_modules):
+        logger.warning("DSV4 affine MoE fast path skipped: model has no named_modules()")
+        return 0
+    modules = list(named_modules())
+    for name, module in modules:
+        if not isinstance(module, SwitchGLU):
+            continue
+        switch_modules.append(module)
+        try:
+            accepted.append((module, _switch_config(module)))
+        except (AttributeError, TypeError, ValueError) as exc:
+            rejected.append(f"{name}: {exc}")
+    if rejected:
+        for module in switch_modules:
+            _CONFIGS.discard(module)
+        logger.warning(
+            "DSV4 affine MoE fast path rejected the model atomically: "
+            "%d compatible SwitchGLU modules, %d incompatible (%s)",
+            len(accepted),
+            len(rejected),
+            "; ".join(rejected[:3]),
+        )
+        return 0
+    if not accepted:
+        logger.warning(
+            "DSV4 affine MoE fast path found no exact affine SwitchGLU modules%s",
+            f" ({'; '.join(rejected[:3])})" if rejected else "",
+        )
+        return 0
+    accepted_ids = {id(module) for module, _config in accepted}
+    weighted_owners = [
+        module
+        for _name, module in modules
+        if id(getattr(module, "switch_mlp", None)) in accepted_ids
+        and callable(getattr(module, "_weighted_routed_experts", None))
+    ]
+    weighted_classes = {type(module) for module in weighted_owners}
+    weighted_switch_ids = [
+        id(getattr(module, "switch_mlp", None)) for module in weighted_owners
+    ]
+    if weighted_owners and (
+        len(weighted_classes) != 1
+        or len(weighted_switch_ids) != len(accepted_ids)
+        or len(set(weighted_switch_ids)) != len(weighted_switch_ids)
+        or set(weighted_switch_ids) != accepted_ids
+    ):
+        for module in switch_modules:
+            _CONFIGS.discard(module)
+        logger.warning(
+            "DSV4 affine MoE fast path rejected mixed owner topology: "
+            "accepted_switches=%d weighted_owners=%d owner_classes=%d",
+            len(accepted_ids),
+            len(weighted_owners),
+            len(weighted_classes),
+        )
+        return 0
+    # Install the class boundary only after every module and owner relationship
+    # has passed. This keeps registration atomic if wrapper topology collides.
+    if weighted_classes:
+        try:
+            _install_weighted_moe_wrapper(next(iter(weighted_classes)))
+        except RuntimeError as exc:
+            for module in switch_modules:
+                _CONFIGS.discard(module)
+            logger.warning(
+                "DSV4 affine MoE weighted owner install rejected: %s",
+                exc,
             )
-
-        g = _run(c["gate"], x1, hidden_val)
-        u = _run(c["up"], x1, hidden_val)
-        act = self.activation(u, g)
-        d = _run(c["down"], act, mx.array(c["down"]["inter"], dtype=mx.uint32))
-
-        if x.ndim == 3:
-            return d.reshape(x.shape[0], k, -1)
-        return d.reshape(1, k, -1)
-
-    SwitchGLU.__call__ = _affine_switchglu_call
-
-    # Tag affine-quantized modules
-    n_patched = 0
-    for _, m in model.named_modules():
-        if isinstance(m, SwitchGLU):
-            gp = getattr(m, "gate_proj", None)
-            if gp is not None and hasattr(gp, "bits") and hasattr(gp, "group_size"):
-                n_patched += 1
-
+            return 0
+    else:
+        # Older DSV4 packages delegate directly to SwitchGLU and apply route
+        # scores after it returns. Current packages own score-before-down in
+        # ``_weighted_routed_experts`` and must never enter this generic hook.
+        try:
+            _install_class_wrapper(SwitchGLU)
+        except RuntimeError as exc:
+            for module in switch_modules:
+                _CONFIGS.discard(module)
+            logger.warning(
+                "DSV4 affine MoE SwitchGLU install rejected: %s",
+                exc,
+            )
+            return 0
+    for module, config in accepted:
+        # Hydration/reload can replace projection tensors while retaining the
+        # enclosing SwitchGLU object. Always refresh the validated tensor refs.
+        _CONFIGS[module] = config
     logger.info(
-        "Affine MoE decode fast-path installed (%d SwitchGLU modules, "
-        "n_chunks=%d, tg_y=%d)",
-        n_patched, mgr.n_chunks, mgr.threadgroup_y,
+        "DSV4 affine MoE fast path enabled for %d exact modules; rejected=%d; "
+        "weighted_owner=%s",
+        len(accepted),
+        len(rejected),
+        bool(weighted_classes),
     )
-    return n_patched
+    return len(accepted)
+
+
+__all__ = ["AffineMoEDecodeManager", "install_dsv4_affine_moe_fastpath"]

--- a/vmlx_engine/models/dsv4_compiled_moe.py
+++ b/vmlx_engine/models/dsv4_compiled_moe.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Decode-only compiled native-gather path for DeepSeek-V4 routed MoE.
+
+The DSV4 model's weighted route boundary issues native ``gather_qmm`` for
+gate, up, and down projections, but leaves the sequence as a fresh Python/MLX
+graph on every token. This patch compiles that exact sequence for the two
+validated gate layouts (2-bit and 3-bit, both group-64) and only accepts the
+single-token decode shape. Multi-token prefill and unsupported modules retain
+the original implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+try:
+    import mlx.core as mx
+except ImportError:  # pragma: no cover - package inspection off Apple Silicon
+    mx = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+_SUPPORTED_MOES: set[int] = set()
+_DISABLED_MOES: set[int] = set()
+_COMPILED: dict[int, Any] = {}
+_PATCHED_CLASS: type | None = None
+_ORIGINAL_CALL: Any = None
+_WRAPPER: Any = None
+
+
+def _enabled() -> bool:
+    value = os.environ.get("VMLX_DSV4_COMPILED_MOE", "1")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_affine_projection(projection: Any, bits: set[int], group_size: int) -> bool:
+    try:
+        return (
+            int(getattr(projection, "bits", -1)) in bits
+            and int(getattr(projection, "group_size", -1)) == group_size
+            and getattr(projection, "mode", "affine") == "affine"
+            and getattr(projection, "scales", None) is not None
+            and getattr(projection, "biases", None) is not None
+            and getattr(projection, "weight", None) is not None
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _is_supported_candidate(module: Any) -> bool:
+    switch = getattr(module, "switch_mlp", None)
+    if switch is None or not callable(
+        getattr(module, "_weighted_routed_experts", None)
+    ):
+        return False
+    gate = getattr(switch, "gate_proj", None)
+    up = getattr(switch, "up_proj", None)
+    down = getattr(switch, "down_proj", None)
+    try:
+        return (
+            _is_affine_projection(gate, {2, 3}, 64)
+            and _is_affine_projection(up, {2}, 64)
+            and _is_affine_projection(down, {2}, 32)
+            and int(gate.output_dims) == int(up.output_dims)
+            and int(down.input_dims) == int(up.output_dims)
+            and int(down.output_dims) == int(gate.input_dims)
+            and float(
+                getattr(getattr(switch, "activation", None), "swiglu_limit", -1.0)
+            )
+            == 10.0
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _clear_runtime_selection() -> None:
+    _SUPPORTED_MOES.clear()
+    _DISABLED_MOES.clear()
+
+
+def _compiled_for(gate_bits: int):
+    if gate_bits in _COMPILED:
+        return _COMPILED[gate_bits]
+    if mx is None:
+        raise RuntimeError("MLX is unavailable")
+
+    def _weighted_decode(
+        x: mx.array,
+        indices: mx.array,
+        scores: mx.array,
+        gate_weight: mx.array,
+        gate_scales: mx.array,
+        gate_biases: mx.array,
+        up_weight: mx.array,
+        up_scales: mx.array,
+        up_biases: mx.array,
+        down_weight: mx.array,
+        down_scales: mx.array,
+        down_biases: mx.array,
+    ) -> mx.array:
+        expanded = mx.expand_dims(x, (-2, -3))
+        up = mx.gather_qmm(
+            expanded,
+            up_weight,
+            up_scales,
+            up_biases,
+            rhs_indices=indices,
+            transpose=True,
+            group_size=64,
+            bits=2,
+            mode="affine",
+            sorted_indices=False,
+        )
+        gate = mx.gather_qmm(
+            expanded,
+            gate_weight,
+            gate_scales,
+            gate_biases,
+            rhs_indices=indices,
+            transpose=True,
+            group_size=64,
+            bits=gate_bits,
+            mode="affine",
+            sorted_indices=False,
+        )
+        gate_fp32 = gate.astype(mx.float32)
+        up_fp32 = up.astype(mx.float32)
+        up_fp32 = mx.clip(up_fp32, a_min=-10.0, a_max=10.0)
+        gate_fp32 = mx.clip(gate_fp32, a_min=None, a_max=10.0)
+        activated = mx.sigmoid(gate_fp32) * gate_fp32 * up_fp32
+        activated = (activated * scores.astype(mx.float32)[..., None, None]).astype(
+            x.dtype
+        )
+        routed = mx.gather_qmm(
+            activated,
+            down_weight,
+            down_scales,
+            down_biases,
+            rhs_indices=indices,
+            transpose=True,
+            group_size=32,
+            bits=2,
+            mode="affine",
+            sorted_indices=False,
+        )
+        return routed.squeeze(-2)
+
+    compiled = mx.compile(_weighted_decode)
+    _COMPILED[gate_bits] = compiled
+    return compiled
+
+
+def install_dsv4_compiled_moe(model: Any) -> int:
+    """Install the guarded native-gather decode graph on exact DSV4 MoEs."""
+
+    if mx is None or not _enabled():
+        _clear_runtime_selection()
+        return 0
+    named_modules = getattr(model, "named_modules", None)
+    if not callable(named_modules):
+        _clear_runtime_selection()
+        return 0
+
+    candidates: list[Any] = []
+    rejected = 0
+    for _name, module in list(named_modules()):
+        switch = getattr(module, "switch_mlp", None)
+        if switch is None or not callable(
+            getattr(module, "_weighted_routed_experts", None)
+        ):
+            continue
+        if _is_supported_candidate(module):
+            candidates.append(module)
+        else:
+            rejected += 1
+    if not candidates or rejected:
+        _clear_runtime_selection()
+        if rejected:
+            logger.info(
+                "DSV4 compiled MoE path skipped atomically: exact=%d rejected=%d",
+                len(candidates),
+                rejected,
+            )
+        return 0
+
+    global _PATCHED_CLASS, _ORIGINAL_CALL, _WRAPPER
+    moe_class = type(candidates[0])
+    if getattr(moe_class, "_vmlx_dsv4_affine_weighted_decode_fastpath", False):
+        logger.info(
+            "DSV4 compiled native-gather path skipped: affine weighted path is explicitly selected"
+        )
+        return 0
+    if any(type(module) is not moe_class for module in candidates):
+        _clear_runtime_selection()
+        return 0
+    if _PATCHED_CLASS is not None and _PATCHED_CLASS is not moe_class:
+        _clear_runtime_selection()
+        return 0
+    if _PATCHED_CLASS is None:
+        original_call = moe_class._weighted_routed_experts
+
+        def _guarded_weighted_call(
+            self: Any,
+            x: mx.array,
+            indices: mx.array,
+            scores: mx.array,
+        ) -> mx.array:
+            module_id = id(self)
+            if (
+                not _enabled()
+                or module_id not in _SUPPORTED_MOES
+                or module_id in _DISABLED_MOES
+            ):
+                return original_call(self, x, indices, scores)
+            if (
+                x.dtype != mx.float16
+                or int(x.size) != int(x.shape[-1])
+                or indices.ndim != x.ndim
+                or tuple(indices.shape) != tuple(scores.shape)
+                or int(indices.shape[-1]) <= 0
+                or int(indices.shape[-1]) >= 64
+            ):
+                return original_call(self, x, indices, scores)
+            switch = self.switch_mlp
+            gate = switch.gate_proj
+            up = switch.up_proj
+            down = switch.down_proj
+            try:
+                compiled = _compiled_for(int(gate.bits))
+                return compiled(
+                    x,
+                    indices,
+                    scores,
+                    gate.weight,
+                    gate.scales,
+                    gate.biases,
+                    up.weight,
+                    up.scales,
+                    up.biases,
+                    down.weight,
+                    down.scales,
+                    down.biases,
+                )
+            except Exception as exc:
+                # A future MLX/JANG shape or dispatch change must not turn a
+                # production request into a hard failure. Disable this exact
+                # module for the process and preserve the reference path.
+                _DISABLED_MOES.add(module_id)
+                logger.warning(
+                    "DSV4 compiled MoE disabled for layer=%s after dispatch "
+                    "failure; falling back to stock path: %s",
+                    getattr(self, "layer_id", "?"),
+                    exc,
+                )
+                return original_call(self, x, indices, scores)
+
+        moe_class._vmlx_dsv4_compiled_moe_original_call = original_call
+        moe_class._vmlx_dsv4_compiled_moe = True
+        moe_class._weighted_routed_experts = _guarded_weighted_call
+        _PATCHED_CLASS = moe_class
+        _ORIGINAL_CALL = original_call
+        _WRAPPER = _guarded_weighted_call
+    elif moe_class._weighted_routed_experts is not _WRAPPER:
+        _clear_runtime_selection()
+        return 0
+
+    current_ids = {id(module) for module in candidates}
+    _SUPPORTED_MOES.clear()
+    _DISABLED_MOES.intersection_update(current_ids)
+    _SUPPORTED_MOES.update(current_ids)
+    logger.info(
+        "DSV4 compiled native-gather MoE decode path enabled for %d modules; "
+        "prefill remains stock",
+        len(candidates),
+    )
+    return len(candidates)
+
+
+__all__ = ["install_dsv4_compiled_moe"]

--- a/vmlx_engine/models/dsv4_indexer_skip.py
+++ b/vmlx_engine/models/dsv4_indexer_skip.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded DSV4 indexer bypass for contexts below sparse-selection use.
+
+The request-level guard is enabled by default and can be disabled with
+``VMLX_DSV4_SKIP_UNUSED_INDEXER=0``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+_PATCHED_CLASS: type | None = None
+
+
+def _enabled() -> bool:
+    return os.environ.get("VMLX_DSV4_SKIP_UNUSED_INDEXER", "1").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def install_dsv4_indexer_skip(model: Any) -> int:
+    global _PATCHED_CLASS
+    if not _enabled():
+        return 0
+
+    indexers = [
+        module
+        for _name, module in list(getattr(model, "named_modules", lambda: [])())
+        if hasattr(module, "index_topk")
+        and hasattr(module, "update_pool")
+        and hasattr(module, "compressor")
+    ]
+    if not indexers:
+        return 0
+    indexer_class = type(indexers[0])
+    if _PATCHED_CLASS is indexer_class:
+        return len(indexers)
+    if getattr(indexer_class, "_vmlx_dsv4_indexer_skip", False):
+        _PATCHED_CLASS = indexer_class
+        return len(indexers)
+    if _PATCHED_CLASS is not None:
+        logger.info(
+            "DSV4 unused-indexer bypass skipped: multiple indexer classes in process"
+        )
+        return 0
+    if any(type(module) is not indexer_class for module in indexers):
+        return 0
+    original_update_pool = indexer_class.update_pool
+
+    def _skip_update(self: Any, x: mx.array, rope: Any, cache: Any, start_pos: int):
+        if (
+            not _enabled()
+            or cache is None
+            or not hasattr(cache, "_branch_state")
+            or getattr(x, "ndim", 0) < 2
+            or int(x.shape[1]) != 1
+            or not bool(getattr(cache, "_vmlx_dsv4_indexer_skip_decode", False))
+        ):
+            return original_update_pool(self, x, rope, cache, start_pos)
+        try:
+            main_state = cache._branch_state("compressor_state")
+            main_pooled = main_state.get("pooled")
+            indexer_state = cache._branch_state("indexer_state")
+            if main_pooled is None:
+                indexer_state["buffer_kv"] = None
+                indexer_state["buffer_gate"] = None
+                indexer_state["pooled"] = None
+                return mx.zeros((int(x.shape[0]), 0, int(self.head_dim)), dtype=x.dtype)
+            if getattr(main_pooled, "ndim", 0) < 2:
+                raise ValueError("compressed pool has no sequence dimension")
+            rows = int(main_pooled.shape[1])
+            zeros = mx.zeros((int(x.shape[0]), rows, int(self.head_dim)), dtype=x.dtype)
+            indexer_state["buffer_kv"] = None
+            indexer_state["buffer_gate"] = None
+            indexer_state["pooled"] = zeros
+            return zeros
+        except Exception as exc:
+            logger.warning(
+                "DSV4 unused-indexer bypass fell back to native update_pool: %s",
+                exc,
+            )
+            return original_update_pool(self, x, rope, cache, start_pos)
+
+    indexer_class._vmlx_dsv4_indexer_original_update_pool = original_update_pool
+    indexer_class.update_pool = _skip_update
+    indexer_class._vmlx_dsv4_indexer_skip = True
+    _PATCHED_CLASS = indexer_class
+    logger.info(
+        "DSV4 unused-indexer bypass candidate enabled for %d modules", len(indexers)
+    )
+    return len(indexers)
+
+
+__all__ = ["install_dsv4_indexer_skip"]

--- a/vmlx_engine/models/dsv4_lm_head_cache.py
+++ b/vmlx_engine/models/dsv4_lm_head_cache.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Decode-only fast paths for the quantized DeepSeek-V4 vocabulary head.
+
+The JANG DSV4 model implementation dequantizes an 8-bit ``lm_head`` on every
+forward call before its FP32 vocabulary projection. The default fast path uses
+MLX's native affine ``quantized_matmul`` directly; the conservative ``fp32``
+mode retains the exact dequantized matrix once. Both avoid repeated full-head
+dequantization and have an explicit native opt-out.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+try:
+    import mlx.core as mx
+except ImportError:  # pragma: no cover - package inspection off Apple Silicon
+    mx = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+_MAX_CACHE_GB = 4.0
+
+
+def _mode() -> str:
+    explicit = os.environ.get("VMLX_DSV4_LM_HEAD_MODE", "quantized")
+    value = explicit.strip().lower()
+    if value in {"0", "false", "no", "off", "native"}:
+        return "native"
+    if value in {"fp32", "cache", "exact"}:
+        return "fp32"
+    if os.environ.get("VMLX_DSV4_CACHE_LM_HEAD", "1").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        return "native"
+    return "quantized"
+
+
+def _estimated_fp32_bytes(head: Any) -> int:
+    try:
+        weight = getattr(head, "weight", None)
+        if weight is None or getattr(weight, "ndim", 0) != 2:
+            return 0
+        bits = int(getattr(head, "bits", 0) or 0)
+        if bits <= 0 or 32 % bits:
+            return 0
+        input_dim = int(weight.shape[1]) * 32 // bits
+        return int(weight.shape[0]) * input_dim * 4
+    except (AttributeError, TypeError, ValueError, IndexError):
+        return 0
+
+
+def _max_fp32_cache_bytes() -> int:
+    raw = os.environ.get("VMLX_DSV4_CACHE_LM_HEAD_MAX_GB", str(_MAX_CACHE_GB))
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid VMLX_DSV4_CACHE_LM_HEAD_MAX_GB=%r", raw)
+        value = _MAX_CACHE_GB
+    if value <= 0:
+        logger.warning(
+            "Ignoring non-positive VMLX_DSV4_CACHE_LM_HEAD_MAX_GB=%r",
+            raw,
+        )
+        value = _MAX_CACHE_GB
+    return int(value * (1024**3))
+
+
+def install_dsv4_lm_head_cache(model: Any) -> bool:
+    """Install the selected DSV4 vocabulary-head fast path on the model class.
+
+    Returns ``True`` when the loaded model exposes a supported quantized head.
+    Installation is idempotent; FP32 cache materialization, when selected, is
+    lazy so load-time behavior remains bounded.
+    """
+
+    mode = _mode()
+    if mx is None or mode == "native":
+        return False
+    head = getattr(model, "lm_head", None)
+    if (
+        not hasattr(head, "scales")
+        or not hasattr(head, "bits")
+        or not hasattr(mx, "quantized_matmul")
+    ):
+        return False
+    estimated = _estimated_fp32_bytes(head)
+    if mode == "fp32":
+        max_cache_bytes = _max_fp32_cache_bytes()
+        if estimated <= 0 or estimated > max_cache_bytes:
+            logger.info(
+                "DSV4 lm_head FP32 cache skipped: estimated %.2f GB exceeds %.2f GB bound",
+                estimated / 1024**3,
+                max_cache_bytes / 1024**3,
+            )
+            return False
+
+    cls = type(model)
+    if getattr(cls, "_vmlx_dsv4_lm_head_cache_installed", False):
+        return True
+    original_call = cls.__call__
+
+    def _cached_call(self: Any, input_ids: Any, cache: Any = None, mask: Any = None):
+        active_mode = _mode()
+        if active_mode == "native" or getattr(
+            self, "_vmlx_dsv4_lm_head_fastpath_disabled", False
+        ):
+            return original_call(self, input_ids, cache=cache, mask=mask)
+
+        hidden = self.model(input_ids, cache=cache, mask=mask)
+        current_head = self.lm_head
+        weight = current_head.weight
+        scales = current_head.scales
+        biases = getattr(current_head, "biases", None)
+        try:
+            if active_mode == "quantized":
+                return mx.quantized_matmul(
+                    hidden,
+                    weight,
+                    scales,
+                    biases,
+                    transpose=True,
+                    group_size=current_head.group_size,
+                    bits=current_head.bits,
+                    mode=getattr(current_head, "mode", "affine"),
+                )
+            signature = (
+                id(weight),
+                id(scales),
+                id(biases),
+                int(current_head.bits),
+                int(current_head.group_size),
+                str(getattr(current_head, "mode", "affine")),
+            )
+            cached = getattr(self, "_vmlx_dsv4_lm_head_fp32", None)
+            if (
+                cached is None
+                or getattr(self, "_vmlx_dsv4_lm_head_signature", None) != signature
+            ):
+                cached = mx.dequantize(
+                    weight,
+                    scales,
+                    biases,
+                    group_size=current_head.group_size,
+                    bits=current_head.bits,
+                    mode=getattr(current_head, "mode", "affine"),
+                ).astype(mx.float32)
+                # Materialize once. Subsequent decode calls reuse the exact same
+                # dequantized values and do not rebuild the 2 GB graph.
+                mx.eval(cached)
+                self._vmlx_dsv4_lm_head_fp32 = cached
+                self._vmlx_dsv4_lm_head_signature = signature
+                logger.info(
+                    "DSV4 lm_head FP32 cache materialized: %.2f GB",
+                    estimated / 1024**3,
+                )
+            return hidden.astype(mx.float32) @ cached.T
+        except Exception as exc:
+            logger.warning(
+                "DSV4 lm_head fast path failed; falling back to native path: %s",
+                exc,
+            )
+            self._vmlx_dsv4_lm_head_fastpath_disabled = True
+            return original_call(self, input_ids, cache=cache, mask=mask)
+
+    cls.__call__ = _cached_call
+    cls._vmlx_dsv4_lm_head_cache_installed = True
+    cls._vmlx_dsv4_lm_head_cache_original_call = original_call
+    logger.info(
+        "DSV4 lm_head mode=%s enabled; set VMLX_DSV4_LM_HEAD_MODE=native "
+        "to restore the original per-call dequantization",
+        mode,
+    )
+    return True
+
+
+__all__ = ["install_dsv4_lm_head_cache"]

--- a/vmlx_engine/models/dsv4_rope_cache.py
+++ b/vmlx_engine/models/dsv4_rope_cache.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact RoPE table reuse for DSV4 decode and prefill.
+
+The cache is enabled by default for the exact DSV4 RoPE implementation and
+can be disabled with ``VMLX_DSV4_ROPE_CACHE=0``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import OrderedDict
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+_PATCHED_CLASS: type | None = None
+_TABLES: OrderedDict[tuple[Any, ...], tuple[mx.array, mx.array]] = OrderedDict()
+_DEFAULT_MAX_TABLES = 64
+
+
+def _max_tables() -> int:
+    raw = os.environ.get("VMLX_DSV4_ROPE_CACHE_MAX_ENTRIES", str(_DEFAULT_MAX_TABLES))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Ignoring invalid VMLX_DSV4_ROPE_CACHE_MAX_ENTRIES=%r",
+            raw,
+        )
+        return _DEFAULT_MAX_TABLES
+    if value <= 0:
+        logger.warning(
+            "Ignoring non-positive VMLX_DSV4_ROPE_CACHE_MAX_ENTRIES=%r",
+            raw,
+        )
+        return _DEFAULT_MAX_TABLES
+    return value
+
+
+def _enabled() -> bool:
+    value = os.environ.get("VMLX_DSV4_ROPE_CACHE", "1")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _native_enabled() -> bool:
+    """Use MLX's fused RoPE kernel when the operator has not opted out."""
+
+    # The fused kernel is useful for exploratory profiling, but its FP16
+    # transcendental rounding can accumulate into a different long-run token
+    # stream. Keep the exact table path as the production default until a
+    # bit-exact native implementation is available.
+    value = os.environ.get("VMLX_DSV4_ROPE_NATIVE", "0")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def install_dsv4_rope_cache(model: Any | None = None) -> bool:
+    """Reuse identical default-position RoPE tables on the exact DSV4 class."""
+
+    global _PATCHED_CLASS
+    if not _enabled():
+        return False
+    from jang_tools.dsv4.mlx_model import DeepseekV4RoPE
+
+    if _PATCHED_CLASS is DeepseekV4RoPE:
+        return True
+    if getattr(DeepseekV4RoPE, "_vmlx_dsv4_rope_cache", False):
+        _PATCHED_CLASS = DeepseekV4RoPE
+        if model is not None:
+            _tag_rope_signatures(model, DeepseekV4RoPE)
+        return True
+    if model is not None:
+        _tag_rope_signatures(model, DeepseekV4RoPE)
+    original_call = DeepseekV4RoPE.__call__
+
+    def _cached_call(
+        self: Any,
+        x: mx.array,
+        offset: int = 0,
+        inverse: bool = False,
+        positions: Any = None,
+    ) -> mx.array:
+        # Position arrays are used by compressed-pool/indexer RoPE and may be
+        # ragged. Leave those on the source implementation; the hot q/k/v
+        # path uses the scalar offset form and is exactly reusable.
+        if positions is not None:
+            return original_call(
+                self, x, offset=offset, inverse=inverse, positions=positions
+            )
+
+        # The native kernel is retained as an explicit experiment only. Its
+        # transcendental rounding can accumulate into a different token
+        # stream, so the exact table path below remains the default.
+        if (
+            _native_enabled()
+            and getattr(x, "ndim", 0) >= 2
+            and int(x.shape[-2]) == 1
+            and hasattr(mx.fast, "rope")
+        ):
+            native_freqs = getattr(self, "_vmlx_dsv4_native_freqs", None)
+            if native_freqs is None:
+                native_freqs = 1.0 / self.inv_freq
+                native_inverse_freqs = -native_freqs
+                mx.eval(native_freqs, native_inverse_freqs)
+                self._vmlx_dsv4_native_freqs = native_freqs
+                self._vmlx_dsv4_native_inverse_freqs = native_inverse_freqs
+            elif inverse:
+                native_inverse_freqs = getattr(
+                    self, "_vmlx_dsv4_native_inverse_freqs", -native_freqs
+                )
+            else:
+                native_inverse_freqs = None
+            return mx.fast.rope(
+                x,
+                dims=self.dims,
+                traditional=True,
+                base=None,
+                scale=1.0,
+                offset=offset,
+                freqs=(native_inverse_freqs if inverse else native_freqs),
+            )
+
+        dtype = x.dtype
+        length = int(x.shape[-2])
+        signature = getattr(self, "_vmlx_dsv4_rope_signature", id(self.inv_freq))
+        key = (signature, int(offset), length, str(dtype))
+        entry = _TABLES.get(key)
+        if entry is None:
+            pos = mx.arange(offset, offset + length, dtype=mx.float32)
+            freqs = pos[:, None] * self.inv_freq[None, :]
+            entry = (mx.cos(freqs).astype(dtype), mx.sin(freqs).astype(dtype))
+            while len(_TABLES) >= _max_tables():
+                _TABLES.popitem(last=False)
+            _TABLES[key] = entry
+        else:
+            _TABLES.move_to_end(key)
+        cos, sin = entry
+        broadcast_shape = (1,) * (x.ndim - 2) + cos.shape
+        cos = cos.reshape(broadcast_shape)
+        sin = sin.reshape(broadcast_shape)
+
+        if inverse:
+            sin = -sin
+        reshaped = x.reshape(*x.shape[:-1], x.shape[-1] // 2, 2)
+        x0, x1 = reshaped[..., 0], reshaped[..., 1]
+        out = mx.stack([x0 * cos - x1 * sin, x0 * sin + x1 * cos], axis=-1)
+        return out.reshape(*out.shape[:-2], out.shape[-2] * 2)
+
+    DeepseekV4RoPE._vmlx_dsv4_rope_original_call = original_call
+    DeepseekV4RoPE.__call__ = _cached_call
+    DeepseekV4RoPE._vmlx_dsv4_rope_cache = True
+    _PATCHED_CLASS = DeepseekV4RoPE
+    logger.info("DSV4 exact RoPE table cache enabled")
+    return True
+
+
+def _tag_rope_signatures(model: Any, rope_class: type) -> None:
+    """Assign equal signatures to equal-frequency RoPE objects once at load."""
+
+    named_modules = getattr(model, "named_modules", None)
+    if not callable(named_modules):
+        return
+    for _name, module in list(named_modules()):
+        if not isinstance(module, rope_class):
+            continue
+        try:
+            values = tuple(float(value) for value in module.inv_freq.tolist())
+            module._vmlx_dsv4_rope_signature = values
+        except Exception:
+            module._vmlx_dsv4_rope_signature = id(module.inv_freq)
+
+
+__all__ = ["install_dsv4_rope_cache"]

--- a/vmlx_engine/utils/dsv4_batch_generator.py
+++ b/vmlx_engine/utils/dsv4_batch_generator.py
@@ -335,6 +335,53 @@ class DSV4BatchGenerator:
             # decode token on the DSV4 hot path.
             return int(sampled.tolist()[0]) if hasattr(sampled, "tolist") else int(sampled.item())
 
+    @staticmethod
+    def _iter_cache_state_arrays(value):
+        if isinstance(value, mx.array):
+            yield value
+            return
+        if isinstance(value, dict):
+            for child in value.values():
+                yield from DSV4BatchGenerator._iter_cache_state_arrays(child)
+            return
+        if isinstance(value, (tuple, list)):
+            for child in value:
+                yield from DSV4BatchGenerator._iter_cache_state_arrays(child)
+
+    @staticmethod
+    def _realize_decode_cache_state(cache, *, step: int | None = None) -> None:
+        """Optionally detach DSV4 cache graphs after a decode forward.
+
+        DSV4 composite caches retain pooled arrays and rotating KV updates.
+        Realizing their state collapses the per-token lazy graph on MLX while
+        preserving the cache values. It is opt-in during evaluation because
+        the extra state barrier can trade throughput for long-run residency.
+        """
+        periodic = os.environ.get("VMLX_DSV4_REALIZE_CACHE_STATE_EVERY", "").strip()
+        if periodic:
+            try:
+                every = int(periodic)
+            except ValueError:
+                every = 0
+            if every <= 0 or step is None or int(step) % every != 0:
+                return
+        elif os.environ.get("VMLX_DSV4_REALIZE_CACHE_STATE", "0").strip().lower() not in {
+            "1", "true", "yes", "on"
+        }:
+            return
+        arrays = []
+        for layer_cache in cache or []:
+            for attr in ("storage_state", "state"):
+                try:
+                    state = getattr(layer_cache, attr)
+                except Exception:
+                    continue
+                arrays.extend(DSV4BatchGenerator._iter_cache_state_arrays(state))
+                if arrays:
+                    break
+        if arrays:
+            mx.eval(*arrays)
+
     # ---------- helpers ----------
     def _make_new_cache(self):
         if hasattr(self.model, "make_cache"):
@@ -1340,6 +1387,20 @@ class DSV4BatchGenerator:
                     # This preserves SWA+CSA/HCA state while bounding transient
                     # MLX allocations for long prompts.
                     r.cache = self._make_new_cache()
+                    # The ratio-4 indexer is only consulted after 512 pool
+                    # rows. For a fresh request whose prompt plus output cap
+                    # stays within 2048 tokens, its decode updates are provably
+                    # unused; mark only those per-request caches for the
+                    # bounded indexer bypass. Prompt prefill stays exact, and
+                    # prefix-cache-hit requests retain the full indexer state.
+                    if os.environ.get("VMLX_DSV4_SKIP_UNUSED_INDEXER", "1").strip().lower() in {
+                        "1", "true", "yes", "on"
+                    } and len(r.prompt_tokens) + int(r.max_tokens) <= 2048:
+                        for _layer_cache in r.cache:
+                            try:
+                                _layer_cache._vmlx_dsv4_indexer_skip_decode = True
+                            except Exception:
+                                pass
                     if not r.prompt_tokens:
                         r.finish_reason = "stop"
                         r.prompt_processed = True
@@ -1625,6 +1686,7 @@ class DSV4BatchGenerator:
                     _t_decode_model = time.perf_counter()
                     logits = self.model(ids, cache=r.cache)
                     last_logits = logits[:, -1, :]
+                    self._realize_decode_cache_state(r.cache, step=len(r.out_tokens))
                     self._trace_timing(
                         "decode_model",
                         _t_decode_model,


### PR DESCRIPTION
## Summary

Harden the DeepSeek-V4 affine decode integration and add guarded native-MLX stability paths with reproducible exact-output gates.

The original timing-only submission has been extended to address the review blockers:

- Loader-owned DSV4 installation with atomic layout validation.
- Single-token decode ownership with prefill and unsupported-shape fallback.
- Preserved `[B, S, K, H]` route rank.
- Runtime exception fallback and per-module disable behavior.
- Idempotent installation and stale-module selection clearing.
- Populated numeric parity coverage for the affine route.
- Native compiled weighted-gather MoE decode path.
- Native quantized lm-head path with a bounded FP32 opt-in fallback.
- Bounded exact RoPE table reuse; native RoPE remains opt-in.
- Request-bounded unused-indexer bypass with native fallback.
- Portable 30-token and 1,000-token harnesses with optional expected stream-hash gates.

## Why

The DSV4 JANG runtime is sensitive to cache state, long-run arithmetic drift, and mixed affine layouts. Short throughput results are not sufficient evidence: a candidate must preserve the token stream and must not turn a runtime/compiler mismatch into a production request failure.

The default path remains fail-closed. Unsupported layouts, prefill shapes, cache-hit paths, malformed state, and optimized dispatch failures retain the native implementation.

## Validation

Environment:

- Apple M4 Max, 40 GPU cores, 128 GB unified memory
- MLX 0.32.0
- mlx-lm 0.31.3
- JANG 2.5.39
- DeepSeek-V4-Flash mixed-affine JANG bundle

Focused no-model suite:

- **87 passed, 1 skipped**
- Includes affine fast-path parity/fallback, stability fast paths, batch-generator, DSV4 contract, route-mode, and bundle-integrity tests.

Real-model target gate:

- 3 repeats, 30 generated tokens each
- Median decode: **27.12 tok/s**
- Median prefill: **231.01 tok/s**
- All streams matched reference hash `fc38a393f08f90ccf8e0daab774f33a6c2d67090b43f471eeb45f0e3c50d86c1`

Real-model long-run gate:

- 1,000 generated tokens
- Decode: **27.03 tok/s**
- Prefill: **233.58 tok/s**
- Exact reference hash: `d3df86b62ad4fc14a0a0be8f6e08261417ef4002c630d1778c10ad87e070e3b1`

The 30 tok/s objective remains open; this PR does not claim to have reached it.

## Reproduction

See `docs/development/dsv4-decode-acceptance.md`.

The important boundary is to pass `--expected-token-hash` when a run is being used as an exact-reference acceptance gate. A repeatable stream without a supplied reference is reported separately and is not promoted as exactness evidence.

## Additional check

The broader `tests/test_dsv4_*.py` family reached 265 passed and 2 skipped, with one unrelated pre-existing panel-source contract failure on the PR base branch. The focused DSV4 suite and both real-model gates pass.