### PR TITLE
perf(dsv4): cache exact decode projections safely

### DIFF
--- a/bench/dsv4_api_tool_cache_proof.py
+++ b/bench/dsv4_api_tool_cache_proof.py
@@ -101,7 +101,7 @@ def main():
     base_msgs = [
         {"role": "system", "content": "You are a helpful coding agent."},
         {"role": "user",
-         "content": "Read the file /Users/eric/r21-dsv4-work/r21_probe_one.txt "
+         "content": "Read the file /workspace/r21_probe_one.txt "
                     "and tell me exactly what it contains."},
     ]
 

--- a/bench/dsv4_fallback_probe.py
+++ b/bench/dsv4_fallback_probe.py
@@ -8,11 +8,15 @@ documented cause of the unbounded literal `response` loop.
 """
 import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.environ.get("VMLX_SRC", "/Users/eric/mlx/vllm-mlx-r20-dsv4"))
+sys.path.insert(
+    0,
+    os.environ.get("VMLX_SRC", str(Path(__file__).resolve().parents[1])),
+)
 
 from vmlx_engine.api.tool_calling import check_and_inject_fallback_tools  # noqa: E402
-from vmlx_engine.loaders import dsv4_chat_encoder as E  # noqa: E402
+from vmlx_engine.loaders import dsv4_chat_encoder as E  # noqa: E402, N812
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from dsv4_prefix_probe import MODEL_PATH, TOOLS, TURNS  # noqa: E402

--- a/bench/dsv4_interleaved_probe.py
+++ b/bench/dsv4_interleaved_probe.py
@@ -27,13 +27,17 @@ import copy
 import json
 import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.environ.get("VMLX_SRC", "/Users/eric/mlx/vllm-mlx-r20-dsv4"))
+sys.path.insert(
+    0,
+    os.environ.get("VMLX_SRC", str(Path(__file__).resolve().parents[1])),
+)
 
-from vmlx_engine.loaders import dsv4_chat_encoder as E  # noqa: E402
+from vmlx_engine.loaders import dsv4_chat_encoder as E  # noqa: E402, N812
 
 MODEL_PATH = os.environ.get(
-    "DSV4_BUNDLE", "/Volumes/EricsLLMDrive/models/DeepSeek-V4-Flash-0731-JANG"
+    "DSV4_BUNDLE", "/path/to/DeepSeek-V4-Flash-0731-JANG"
 )
 
 TOOLS = [
@@ -207,7 +211,7 @@ def main():
             print(f"    keep @{n}: {a[n:n+140]!r}")
             print(f"    drop @{n}: {b[n:n+140]!r}")
 
-    print("\nsummary: keep_chain_ok=%s drop_chain_ok=%s" % (keep_ok, drop_ok))
+    print(f"\nsummary: keep_chain_ok={keep_ok} drop_chain_ok={drop_ok}")
     return 0 if keep_ok else 1
 
 

--- a/bench/dsv4_performance_suite.py
+++ b/bench/dsv4_performance_suite.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Reproducible native-versus-optimized DeepSeek-V4 performance suite.
+
+Run the native profile first, then pass its report to the optimized profile.
+Acceptance requires exact output hashes for every case and bounded throughput
+ratios; repeatability without a native report is never called exactness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+with contextlib.suppress(ValueError):
+    sys.path.remove(str(REPOSITORY_ROOT))
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+SCHEMA = "dsv4_performance_suite.v1"
+DEFAULT_CASES = "256:30:3,400:30:3,512:30:3,1024:30:3,2048:30:3,256:1000:1"
+PROMPT = (
+    "We are reviewing a production Apple-Silicon inference service. A recent "
+    "optimization changed the request loop to reuse a mutable KV cache and to "
+    "batch prompt tokens in chunks. Users report slow first answers and "
+    "occasional repetition from a previous request. Review this simplified "
+    "code: cache = shared_cache; for request in requests: prompt = "
+    "tokenizer.encode(request.text); for start in range(0, len(prompt), 2048): "
+    "logits = model(prompt[start:start + 2048], cache=cache); token = "
+    "sample(logits[:, -1, :]); while token not in stop_tokens: logits = "
+    "model(token, cache=cache); token = sample(logits[:, -1, :]); yield "
+    "tokenizer.decode(token). Give a concise diagnosis, corrected pseudocode, "
+    "and three tests. State assumptions."
+)
+
+
+@dataclass(frozen=True)
+class Case:
+    prompt_target: int
+    generation_target: int
+    repeats: int
+
+    @property
+    def key(self) -> str:
+        return f"p{self.prompt_target}-g{self.generation_target}"
+
+
+def _parse_cases(raw: str) -> tuple[Case, ...]:
+    cases: list[Case] = []
+    seen: set[str] = set()
+    for item in raw.split(","):
+        parts = item.strip().split(":")
+        if len(parts) != 3:
+            raise ValueError(f"invalid case {item!r}; expected prompt:generation:repeats")
+        case = Case(*(int(value) for value in parts))
+        if min(case.prompt_target, case.generation_target, case.repeats) <= 0:
+            raise ValueError("case values must be positive")
+        if case.key in seen:
+            raise ValueError(f"duplicate case {case.key}")
+        seen.add(case.key)
+        cases.append(case)
+    if not cases:
+        raise ValueError("at least one case is required")
+    return tuple(cases)
+
+
+def _configure_profile(profile: str, features: str = "all") -> dict[str, str]:
+    controls = {
+        "VMLX_DSV4_AFFINE_MOE_FASTPATH": "0",
+        "VMLX_DSV4_COMPILED_MOE": "0",
+        "VMLX_DSV4_SKIP_UNUSED_INDEXER": "0",
+        "VMLX_DSV4_ROPE_NATIVE": "0",
+        "DSV4_LAYERWISE_PREFILL_MIN_TOKENS": "256",
+    }
+    if profile == "native":
+        controls.update(
+            {
+                "VMLX_DSV4_LM_HEAD_MODE": "native",
+                "VMLX_DSV4_ROPE_CACHE": "0",
+            }
+        )
+    else:
+        controls.update(
+            {
+                "VMLX_DSV4_LM_HEAD_MODE": (
+                    "exact-cache" if features in {"all", "lm-head"} else "native"
+                ),
+                "VMLX_DSV4_ROPE_CACHE": (
+                    "1" if features in {"all", "rope-cache"} else "0"
+                ),
+            }
+        )
+    os.environ.update(controls)
+    return controls
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def _git_revision() -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip() or None
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _model_identity(model_path: Path) -> dict[str, Any]:
+    """Return a public, reproducible identity without exposing a local path."""
+
+    digest = hashlib.sha256()
+    metadata_names = (
+        "config.json",
+        "jang_config.json",
+        "generation_config.json",
+        "tokenizer_config.json",
+        "tokenizer.json",
+        "model.safetensors.index.json",
+    )
+    for name in metadata_names:
+        path = model_path / name
+        if not path.is_file():
+            continue
+        digest.update(name.encode())
+        digest.update(b"\0")
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+
+    index_path = model_path / "model.safetensors.index.json"
+    shard_names: list[str]
+    try:
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+        shard_names = sorted(set(index.get("weight_map", {}).values()))
+    except (OSError, TypeError, ValueError):
+        shard_names = sorted(path.name for path in model_path.glob("model*.safetensors"))
+
+    shard_bytes = 0
+    present_shards = 0
+    for name in shard_names:
+        path = model_path / name
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = -1
+        if size >= 0:
+            present_shards += 1
+            shard_bytes += size
+        digest.update(f"{name}\0{size}\0".encode())
+
+    return {
+        "bundle_name": model_path.name,
+        "manifest_sha256": digest.hexdigest(),
+        "shard_count": present_shards,
+        "shard_bytes": shard_bytes,
+    }
+
+
+def _prompt(tokenizer: Any, target_tokens: int, mx: Any) -> Any:
+    body = PROMPT
+    while len(tokenizer.encode(body)) < target_tokens:
+        body += " Preserve request isolation and exact timing receipts."
+    rendered = tokenizer.apply_chat_template(
+        [{"role": "user", "content": body}],
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+    return mx.array(tokenizer.encode(rendered), dtype=mx.uint32)
+
+
+class _Runner:
+    def __init__(self, model: Any, *, max_tokens: int):
+        from vmlx_engine.sampling import make_sampler
+        from vmlx_engine.utils.dsv4_batch_generator import DSV4BatchGenerator
+
+        self.generator = DSV4BatchGenerator(
+            model,
+            max_tokens=max_tokens,
+            sampler=make_sampler(temp=0.0, top_p=0.0),
+            prefill_step_size=2048,
+            capture_prompt_snapshot=False,
+        )
+
+    def request(self, prompt: Any, generation_target: int) -> dict[str, Any]:
+        prompt_ids = [int(value) for value in prompt.tolist()]
+        uid = self.generator.insert(
+            [prompt_ids],
+            max_tokens=[generation_target],
+            capture_prompt_snapshots=[False],
+        )[0]
+        started = time.perf_counter()
+        first_token_at: float | None = None
+        output_tokens: list[int] = []
+        finish_reason: str | None = None
+        try:
+            while len(output_tokens) < generation_target:
+                prompt_responses, generated_responses = self.generator.next()
+                responses = [*prompt_responses, *generated_responses]
+                if not responses:
+                    break
+                if first_token_at is None:
+                    first_token_at = time.perf_counter()
+                output_tokens.extend(int(response.token) for response in responses)
+                reasons = [response.finish_reason for response in responses]
+                finish_reason = next((reason for reason in reasons if reason), None)
+                if finish_reason is not None:
+                    break
+        finally:
+            self.generator.remove([uid])
+        finished = time.perf_counter()
+        ttft = first_token_at - started if first_token_at is not None else None
+        decode_seconds = (
+            finished - first_token_at if first_token_at is not None else None
+        )
+        return {
+            "prompt_tokens": len(prompt_ids),
+            "new_tokens": len(output_tokens),
+            "finish_reason": finish_reason,
+            "ttft_s": ttft,
+            "prefill_tok_s": len(prompt_ids) / ttft if ttft else None,
+            "decode_tok_s": (
+                (len(output_tokens) - 1) / decode_seconds
+                if decode_seconds and len(output_tokens) > 1
+                else None
+            ),
+            "token_ids_sha256": hashlib.sha256(
+                ",".join(map(str, output_tokens)).encode()
+            ).hexdigest(),
+        }
+
+
+def _summarize(
+    case: Case,
+    samples: list[dict[str, Any]],
+    *,
+    min_within_profile_decode_ratio: float = 0.75,
+) -> dict[str, Any]:
+    hashes = {sample["token_ids_sha256"] for sample in samples}
+    decode = [float(sample["decode_tok_s"]) for sample in samples if sample["decode_tok_s"]]
+    prefill = [
+        float(sample["prefill_tok_s"]) for sample in samples if sample["prefill_tok_s"]
+    ]
+    complete = bool(samples) and all(
+        sample["new_tokens"] == case.generation_target for sample in samples
+    )
+    median_decode = statistics.median(decode) if decode else None
+    minimum_decode = min(decode) if decode else None
+    tail_ratio = (
+        minimum_decode / median_decode
+        if minimum_decode is not None and median_decode
+        else 0.0
+    )
+    stable_decode_tail = tail_ratio >= min_within_profile_decode_ratio
+    return {
+        "passed": bool(
+            complete
+            and len(hashes) == 1
+            and decode
+            and prefill
+            and stable_decode_tail
+        ),
+        "complete": complete,
+        "stable_token_stream": len(hashes) == 1,
+        "stable_decode_tail": stable_decode_tail,
+        "token_ids_sha256": next(iter(hashes)) if len(hashes) == 1 else None,
+        "median_decode_tok_s": median_decode,
+        "min_decode_tok_s": minimum_decode,
+        "min_to_median_decode_ratio": tail_ratio,
+        "median_prefill_tok_s": statistics.median(prefill) if prefill else None,
+        "samples": samples,
+    }
+
+
+def _compare(
+    candidate: dict[str, Any],
+    baseline: dict[str, Any],
+    *,
+    min_decode_ratio: float,
+    min_prefill_ratio: float,
+    min_sample_decode_ratio: float = 0.75,
+) -> dict[str, Any]:
+    comparisons: dict[str, Any] = {}
+    passed = True
+    candidate_results = candidate.get("results", {})
+    baseline_results = baseline.get("results", {})
+    for key in sorted(set(candidate_results) | set(baseline_results)):
+        candidate_case = candidate_results.get(key)
+        baseline_case = baseline_results.get(key)
+        if candidate_case is None:
+            comparisons[key] = {"passed": False, "reason": "missing candidate case"}
+            passed = False
+            continue
+        if baseline_case is None:
+            comparisons[key] = {"passed": False, "reason": "missing baseline case"}
+            passed = False
+            continue
+        exact = (
+            candidate_case.get("token_ids_sha256")
+            == baseline_case.get("token_ids_sha256")
+            and candidate_case.get("token_ids_sha256") is not None
+        )
+        candidate_decode = float(candidate_case.get("median_decode_tok_s") or 0.0)
+        baseline_decode = float(baseline_case.get("median_decode_tok_s") or 0.0)
+        candidate_min_decode = float(candidate_case.get("min_decode_tok_s") or 0.0)
+        baseline_min_decode = float(
+            baseline_case.get("min_decode_tok_s")
+            or baseline_case.get("median_decode_tok_s")
+            or 0.0
+        )
+        candidate_prefill = float(candidate_case.get("median_prefill_tok_s") or 0.0)
+        baseline_prefill = float(baseline_case.get("median_prefill_tok_s") or 0.0)
+        decode_ratio = candidate_decode / baseline_decode if baseline_decode else 0.0
+        sample_decode_ratio = (
+            candidate_min_decode / baseline_min_decode if baseline_min_decode else 0.0
+        )
+        prefill_ratio = candidate_prefill / baseline_prefill if baseline_prefill else 0.0
+        case_passed = bool(
+            candidate_case.get("passed")
+            and baseline_case.get("passed")
+            and exact
+            and decode_ratio >= min_decode_ratio
+            and sample_decode_ratio >= min_sample_decode_ratio
+            and prefill_ratio >= min_prefill_ratio
+        )
+        comparisons[key] = {
+            "passed": case_passed,
+            "exact_token_hash": exact,
+            "decode_ratio": decode_ratio,
+            "min_sample_decode_ratio": sample_decode_ratio,
+            "prefill_ratio": prefill_ratio,
+        }
+        passed = passed and case_passed
+    return {"passed": passed and bool(comparisons), "cases": comparisons}
+
+
+def _baseline_compatibility(
+    candidate: dict[str, Any], baseline: dict[str, Any]
+) -> dict[str, Any]:
+    checks = {
+        "schema": baseline.get("schema") == candidate.get("schema") == SCHEMA,
+        "native_profile": baseline.get("profile") == "native",
+        "native_passed": baseline.get("passed") is True,
+        "native_feature_state": baseline.get("feature_state_passed") is True,
+        "model": baseline.get("model") == candidate.get("model"),
+        "source": baseline.get("source") == candidate.get("source"),
+        "git_revision": baseline.get("git_revision") == candidate.get("git_revision"),
+        "hardware": baseline.get("hardware") == candidate.get("hardware"),
+        "runtime": baseline.get("runtime") == candidate.get("runtime"),
+        "cases": baseline.get("cases") == candidate.get("cases"),
+        "benchmark_controls": baseline.get("benchmark_controls")
+        == candidate.get("benchmark_controls"),
+    }
+    return {"passed": all(checks.values()), "checks": checks}
+
+
+def _decode_floor_sanity(
+    results: dict[str, Any],
+    *,
+    anchor_key: str = "p256-g1000",
+    min_anchor_ratio: float = 0.40,
+) -> dict[str, Any]:
+    anchor = results.get(anchor_key)
+    anchor_decode = float(anchor.get("median_decode_tok_s") or 0.0) if anchor else 0.0
+    if anchor_decode <= 0:
+        return {
+            "passed": True,
+            "applied": False,
+            "reason": f"anchor case {anchor_key} was not requested",
+            "cases": {},
+        }
+    checks = {}
+    passed = True
+    for key, result in sorted(results.items()):
+        decode = float(result.get("median_decode_tok_s") or 0.0)
+        ratio = decode / anchor_decode
+        case_passed = ratio >= min_anchor_ratio
+        checks[key] = {"passed": case_passed, "anchor_decode_ratio": ratio}
+        passed = passed and case_passed
+    return {"passed": passed, "applied": True, "cases": checks}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--profile", choices=("native", "optimized"), required=True)
+    parser.add_argument(
+        "--features",
+        choices=("all", "lm-head", "rope-cache"),
+        default="all",
+        help="optimized components to enable; native always disables all",
+    )
+    parser.add_argument("--cases", default=DEFAULT_CASES)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--baseline-report", type=Path)
+    parser.add_argument("--acceptance", action="store_true")
+    parser.add_argument("--min-decode-ratio", type=float, default=0.98)
+    parser.add_argument("--min-prefill-ratio", type=float, default=0.95)
+    parser.add_argument("--min-sample-decode-ratio", type=float, default=0.75)
+    parser.add_argument("--min-within-profile-decode-ratio", type=float, default=0.75)
+    parser.add_argument("--min-anchor-decode-ratio", type=float, default=0.40)
+    args = parser.parse_args()
+    if not args.model.is_dir():
+        parser.error(f"model directory does not exist: {args.model}")
+    model_path = args.model.resolve()
+    try:
+        cases = _parse_cases(args.cases)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if args.acceptance and (args.profile != "optimized" or args.baseline_report is None):
+        parser.error("acceptance requires --profile optimized and --baseline-report")
+    required_acceptance_cases = {case.key for case in _parse_cases(DEFAULT_CASES)}
+    if args.acceptance and not required_acceptance_cases.issubset(
+        {case.key for case in cases}
+    ):
+        parser.error("acceptance requires the complete default case matrix")
+    if min(
+        args.min_decode_ratio,
+        args.min_prefill_ratio,
+        args.min_sample_decode_ratio,
+        args.min_within_profile_decode_ratio,
+        args.min_anchor_decode_ratio,
+    ) <= 0:
+        parser.error("throughput ratios must be positive")
+
+    controls = _configure_profile(args.profile, args.features)
+    import mlx.core as mx
+
+    import vmlx_engine
+    from vmlx_engine.loaders.load_jangtq_dsv4 import load_jangtq_dsv4_model
+    from vmlx_engine.models.dsv4_lm_head_fastpath import (
+        dsv4_lm_head_fastpath_status,
+    )
+    from vmlx_engine.models.dsv4_rope_cache import dsv4_rope_cache_status
+
+    # Resolve candidate modules before the external JANG loader registers its
+    # model implementation. This makes the benchmark's source boundary
+    # explicit and prevents an installed package from silently satisfying a
+    # checkout-under-test import later in the run.
+    model, tokenizer = load_jangtq_dsv4_model(str(model_path))
+    source_root = Path(vmlx_engine.__file__).resolve().parents[1]
+    if source_root != REPOSITORY_ROOT:
+        raise RuntimeError(
+            f"benchmark imported vmlx_engine from {source_root}, "
+            f"expected checkout {REPOSITORY_ROOT}"
+        )
+
+    prompts = {
+        target: _prompt(tokenizer, target, mx)
+        for target in {case.prompt_target for case in cases}
+    }
+    mx.eval(*prompts.values())
+    runner = _Runner(model, max_tokens=max(case.generation_target for case in cases))
+    runner.request(next(iter(prompts.values())), min(4, cases[0].generation_target))
+
+    results: dict[str, Any] = {}
+    for case in cases:
+        samples = [
+            runner.request(prompts[case.prompt_target], case.generation_target)
+            for _repeat in range(case.repeats)
+        ]
+        results[case.key] = _summarize(
+            case,
+            samples,
+            min_within_profile_decode_ratio=args.min_within_profile_decode_ratio,
+        )
+
+    feature_state = {
+        "lm_head": dsv4_lm_head_fastpath_status(model),
+        "rope_cache": dsv4_rope_cache_status(model),
+    }
+    expected_head = args.profile == "optimized" and args.features in {"all", "lm-head"}
+    expected_rope = args.profile == "optimized" and args.features in {"all", "rope-cache"}
+    head_active = bool(
+        feature_state["lm_head"]["installed"]
+        and feature_state["lm_head"]["validated"]
+        and feature_state["lm_head"]["disabled_reason"] is None
+    )
+    rope_active = bool(
+        feature_state["rope_cache"]["registered_instances"] > 0
+        and feature_state["rope_cache"]["table_entries"] > 0
+    )
+    feature_state_passed = head_active == expected_head and rope_active == expected_rope
+
+    report: dict[str, Any] = {
+        "schema": SCHEMA,
+        "finished_at": datetime.now(UTC).isoformat(),
+        "profile": args.profile,
+        "features": "none" if args.profile == "native" else args.features,
+        "model": _model_identity(model_path),
+        "git_revision": _git_revision(),
+        "source": {"checkout_verified": True, "repository_root": "."},
+        "hardware": {"machine": platform.machine(), "macos": platform.mac_ver()[0]},
+        "runtime": {
+            "vmlx": vmlx_engine.__version__,
+            "jang": importlib.metadata.version("jang"),
+            "mlx": importlib.metadata.version("mlx"),
+            "mlx_lm": importlib.metadata.version("mlx-lm"),
+        },
+        "controls": controls,
+        "benchmark_controls": {
+            "min_within_profile_decode_ratio": args.min_within_profile_decode_ratio,
+            "min_anchor_decode_ratio": args.min_anchor_decode_ratio,
+        },
+        "feature_state": feature_state,
+        "feature_state_passed": feature_state_passed,
+        "cases": [case.__dict__ | {"key": case.key} for case in cases],
+        "results": results,
+        "decode_floor_sanity": _decode_floor_sanity(
+            results,
+            min_anchor_ratio=args.min_anchor_decode_ratio,
+        ),
+    }
+    report["passed"] = bool(
+        feature_state_passed
+        and results
+        and all(result["passed"] for result in results.values())
+        and report["decode_floor_sanity"]["passed"]
+    )
+    if args.baseline_report is not None:
+        baseline = json.loads(args.baseline_report.read_text())
+        report["baseline_compatibility"] = _baseline_compatibility(report, baseline)
+        report["comparison"] = _compare(
+            report,
+            baseline,
+            min_decode_ratio=args.min_decode_ratio,
+            min_prefill_ratio=args.min_prefill_ratio,
+            min_sample_decode_ratio=args.min_sample_decode_ratio,
+        )
+        if args.acceptance:
+            report["passed"] = bool(
+                report["passed"]
+                and report["baseline_compatibility"]["passed"]
+                and report["comparison"]["passed"]
+            )
+
+    _atomic_write(args.out, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(f"Report: {args.out}")
+    return 0 if report["passed"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/dsv4_prefix_probe.py
+++ b/bench/dsv4_prefix_probe.py
@@ -9,13 +9,17 @@ identity(turn N+1).
 import json
 import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.environ.get("VMLX_SRC", "/Users/eric/mlx/vllm-mlx-r20-dsv4"))
+sys.path.insert(
+    0,
+    os.environ.get("VMLX_SRC", str(Path(__file__).resolve().parents[1])),
+)
 
-from vmlx_engine.loaders import dsv4_chat_encoder as E  # noqa: E402
+from vmlx_engine.loaders import dsv4_chat_encoder as E  # noqa: E402, N812
 
 MODEL_PATH = os.environ.get(
-    "DSV4_BUNDLE", "/Volumes/EricsLLMDrive/models/DeepSeek-V4-Flash-0731-JANG"
+    "DSV4_BUNDLE", "/path/to/DeepSeek-V4-Flash-0731-JANG"
 )
 
 TOOLS = [

--- a/docs/benchmarks/dsv4-performance-acceptance.md
+++ b/docs/benchmarks/dsv4-performance-acceptance.md
@@ -1,0 +1,60 @@
+# DeepSeek-V4 performance acceptance
+
+DSV4 performance changes are accepted against the source runtime, not against
+another experimental configuration. The suite runs the same prompts and greedy
+generation cases twice: first with all promoted fast paths disabled, then with
+only the candidate paths enabled.
+
+The promoted profile intentionally contains two changes:
+
+- a headroom-gated cache of the exact dequantized FP32 vocabulary matrix,
+  preserving JANG's FP32 matmul while avoiding repeated dequantization. Its
+  persistent bytes are deducted from the existing MLX allocator-cache ceiling
+  so the optimization does not expand the runtime's memory envelope;
+- bounded sharing of the existing manual RoPE cosine/sine tables across equal
+  DSV4 RoPE instances.
+
+The custom affine Metal MoE kernel remains an explicit hardware experiment.
+Compiled MoE, unused-indexer mutation, native RoPE, and a raised layerwise
+prefill threshold are disabled by the suite and are not part of promotion.
+
+## Required commands
+
+Use one runtime and one immutable model bundle for both runs:
+
+```text
+python bench/dsv4_performance_suite.py \
+  --model /path/to/DeepSeek-V4-Flash-JANG \
+  --profile native \
+  --out dsv4-native.json
+
+python bench/dsv4_performance_suite.py \
+  --model /path/to/DeepSeek-V4-Flash-JANG \
+  --profile optimized \
+  --baseline-report dsv4-native.json \
+  --acceptance \
+  --out dsv4-optimized.json
+```
+
+The default matrix covers three 30-token samples at prompt targets 256, 400,
+512, 1024, and 2048, plus a 1,000-token identity gate at prompt target 256. Every
+acceptance run must include this complete matrix; custom subsets are diagnostic
+only. Every
+candidate hash must equal its native counterpart. Median decode must remain at
+least 98% of native, the slowest decode sample at least 75% of the native
+minimum, and median prefill at least 95%. Independently, the slowest repeat in
+each profile must remain at least 75% of that profile's median; an unstable
+native run cannot be used to inflate an optimized ratio. Every median decode
+must also remain at least 40% of the warm 1,000-token anchor. This catches a
+consistently pathological short case that a within-case ratio alone would call
+stable. Improvements are reported as ratios rather than a machine-specific
+absolute target.
+
+The matrix runs sequentially without clearing MLX allocator state. This models
+the warm multi-request runtime and makes allocator-residency cliffs part of the
+acceptance result rather than hiding them with a synthetic cold-cache protocol.
+
+Keep both JSON reports with the PR evidence. A report without
+`--baseline-report` proves repeatability only and is not an acceptance result.
+Reports record a bundle manifest fingerprint and a verified relative checkout
+identity; they never publish machine-local model or source paths.

--- a/docs/development/dsv4-encoder-contract.md
+++ b/docs/development/dsv4-encoder-contract.md
@@ -2,7 +2,8 @@
 
 Source of truth: the bundle's own `encoding/README.md` and `encoding/encoding_dsv4.py`
 (mirrored at <https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/main/encoding/README.md>).
-Local copy on the box: `/Volumes/EricsLLMDrive/sources/DeepSeek-V4-Flash-0731-9e165c30e270/encoding/`.
+For local reproduction, point `DSV4_BUNDLE` at a verified bundle copy; no
+machine-local source path is part of this public contract.
 
 vMLX adapter: `vmlx_engine/loaders/dsv4_chat_encoder.py`.
 Tool parser: `vmlx_engine/tool_parsers/dsml_tool_parser.py` (parser key `dsml`,

--- a/panel/tests/builtin-tool-working-dir.test.ts
+++ b/panel/tests/builtin-tool-working-dir.test.ts
@@ -8,6 +8,8 @@
  * no visible answer. Observed live on DSV4 against a deleted release-gate run
  * directory.
  */
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('electron', () => ({ clipboard: { readText: () => '', writeText: () => {} } }))
@@ -16,7 +18,7 @@ vi.mock('../src/main/database', () => ({ db: {} }))
 describe('built-in tool working directory validation', () => {
   it('names a missing working directory instead of leaking ENOENT', async () => {
     const { executeBuiltinTool } = await import('../src/main/tools/executor')
-    const missing = '/Users/eric/.cache/vmlx-proof/does-not-exist-r21/r20'
+    const missing = join(tmpdir(), `vmlx-missing-working-directory-${process.pid}`, 'r20')
 
     const result = await executeBuiltinTool(
       'write_file',

--- a/reports/pr249/dsv4-native-15e9420d.json
+++ b/reports/pr249/dsv4-native-15e9420d.json
@@ -1,0 +1,348 @@
+{
+  "benchmark_controls": {
+    "min_anchor_decode_ratio": 0.4,
+    "min_within_profile_decode_ratio": 0.75
+  },
+  "cases": [
+    {
+      "generation_target": 30,
+      "key": "p256-g30",
+      "prompt_target": 256,
+      "repeats": 3
+    },
+    {
+      "generation_target": 30,
+      "key": "p400-g30",
+      "prompt_target": 400,
+      "repeats": 3
+    },
+    {
+      "generation_target": 30,
+      "key": "p512-g30",
+      "prompt_target": 512,
+      "repeats": 3
+    },
+    {
+      "generation_target": 30,
+      "key": "p1024-g30",
+      "prompt_target": 1024,
+      "repeats": 3
+    },
+    {
+      "generation_target": 30,
+      "key": "p2048-g30",
+      "prompt_target": 2048,
+      "repeats": 3
+    },
+    {
+      "generation_target": 1000,
+      "key": "p256-g1000",
+      "prompt_target": 256,
+      "repeats": 1
+    }
+  ],
+  "controls": {
+    "DSV4_LAYERWISE_PREFILL_MIN_TOKENS": "256",
+    "VMLX_DSV4_AFFINE_MOE_FASTPATH": "0",
+    "VMLX_DSV4_COMPILED_MOE": "0",
+    "VMLX_DSV4_LM_HEAD_MODE": "native",
+    "VMLX_DSV4_ROPE_CACHE": "0",
+    "VMLX_DSV4_ROPE_NATIVE": "0",
+    "VMLX_DSV4_SKIP_UNUSED_INDEXER": "0"
+  },
+  "decode_floor_sanity": {
+    "applied": true,
+    "cases": {
+      "p1024-g30": {
+        "anchor_decode_ratio": 0.6006626860475128,
+        "passed": true
+      },
+      "p2048-g30": {
+        "anchor_decode_ratio": 0.9243499684660541,
+        "passed": true
+      },
+      "p256-g1000": {
+        "anchor_decode_ratio": 1.0,
+        "passed": true
+      },
+      "p256-g30": {
+        "anchor_decode_ratio": 0.9898317262387689,
+        "passed": true
+      },
+      "p400-g30": {
+        "anchor_decode_ratio": 0.5527126422667411,
+        "passed": true
+      },
+      "p512-g30": {
+        "anchor_decode_ratio": 0.5783466676893934,
+        "passed": true
+      }
+    },
+    "passed": true
+  },
+  "feature_state": {
+    "lm_head": {
+      "allocator_cache_limit_bytes": 24739011624,
+      "cache_bytes": 0,
+      "disabled_reason": null,
+      "installed": false,
+      "reservation_bytes": 0,
+      "validated": false
+    },
+    "rope_cache": {
+      "registered_instances": 0,
+      "table_entries": 0
+    }
+  },
+  "feature_state_passed": true,
+  "features": "none",
+  "finished_at": "2026-08-04T10:07:04.254817+00:00",
+  "git_revision": "15e9420db804cfa81167acaceae13476d856a7b5",
+  "hardware": {
+    "machine": "arm64",
+    "macos": "26.5.1"
+  },
+  "model": {
+    "bundle_name": "OsaurusAI__DeepSeek-V4-Flash-0731-JANG",
+    "manifest_sha256": "fc68310e3b81ccbf5b86b9c28929b629dd89fa204d5de563d5442b13f6f2978c",
+    "shard_bytes": 101982500132,
+    "shard_count": 102
+  },
+  "passed": true,
+  "profile": "native",
+  "results": {
+    "p1024-g30": {
+      "complete": true,
+      "median_decode_tok_s": 11.169768624697728,
+      "median_prefill_tok_s": 264.0771074434441,
+      "min_decode_tok_s": 11.153348006768613,
+      "min_to_median_decode_ratio": 0.9985299052754946,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 11.169768624697728,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 261.0435887772903,
+          "prompt_tokens": 1032,
+          "token_ids_sha256": "3640799ff00ab31ca9d900db2990c5703e9e59ea7b9a8fe0083d0dbdbf6cbbcc",
+          "ttft_s": 3.9533627500059083
+        },
+        {
+          "decode_tok_s": 11.582113741735728,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 268.7641643615346,
+          "prompt_tokens": 1032,
+          "token_ids_sha256": "3640799ff00ab31ca9d900db2990c5703e9e59ea7b9a8fe0083d0dbdbf6cbbcc",
+          "ttft_s": 3.8397976249980275
+        },
+        {
+          "decode_tok_s": 11.153348006768613,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 264.0771074434441,
+          "prompt_tokens": 1032,
+          "token_ids_sha256": "3640799ff00ab31ca9d900db2990c5703e9e59ea7b9a8fe0083d0dbdbf6cbbcc",
+          "ttft_s": 3.9079495000187308
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "3640799ff00ab31ca9d900db2990c5703e9e59ea7b9a8fe0083d0dbdbf6cbbcc"
+    },
+    "p2048-g30": {
+      "complete": true,
+      "median_decode_tok_s": 17.188973971317687,
+      "median_prefill_tok_s": 225.6388956204617,
+      "min_decode_tok_s": 16.898871574836168,
+      "min_to_median_decode_ratio": 0.983122762477528,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 17.270165061099984,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 223.89935293370806,
+          "prompt_tokens": 2058,
+          "token_ids_sha256": "b112862461dea4dc5024cef1b0575aa08f8db8a33f3cc78a1a94a39d8fc57b61",
+          "ttft_s": 9.19162995798979
+        },
+        {
+          "decode_tok_s": 17.188973971317687,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 226.13002589017898,
+          "prompt_tokens": 2058,
+          "token_ids_sha256": "b112862461dea4dc5024cef1b0575aa08f8db8a33f3cc78a1a94a39d8fc57b61",
+          "ttft_s": 9.100958583003376
+        },
+        {
+          "decode_tok_s": 16.898871574836168,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 225.6388956204617,
+          "prompt_tokens": 2058,
+          "token_ids_sha256": "b112862461dea4dc5024cef1b0575aa08f8db8a33f3cc78a1a94a39d8fc57b61",
+          "ttft_s": 9.12076791698928
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "b112862461dea4dc5024cef1b0575aa08f8db8a33f3cc78a1a94a39d8fc57b61"
+    },
+    "p256-g1000": {
+      "complete": true,
+      "median_decode_tok_s": 18.595742476026206,
+      "median_prefill_tok_s": 214.87886583557705,
+      "min_decode_tok_s": 18.595742476026206,
+      "min_to_median_decode_ratio": 1.0,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 18.595742476026206,
+          "finish_reason": "length",
+          "new_tokens": 1000,
+          "prefill_tok_s": 214.87886583557705,
+          "prompt_tokens": 267,
+          "token_ids_sha256": "8c07bb952476d34c928d3e4513d1306fe7fe9fd526ff78eb70d22d832cfcbe8a",
+          "ttft_s": 1.2425605420139618
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "8c07bb952476d34c928d3e4513d1306fe7fe9fd526ff78eb70d22d832cfcbe8a"
+    },
+    "p256-g30": {
+      "complete": true,
+      "median_decode_tok_s": 18.406655875736618,
+      "median_prefill_tok_s": 225.54881685264766,
+      "min_decode_tok_s": 18.31881689566433,
+      "min_to_median_decode_ratio": 0.9952278686218025,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 18.406655875736618,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 226.58093506165383,
+          "prompt_tokens": 267,
+          "token_ids_sha256": "fc38a393f08f90ccf8e0daab774f33a6c2d67090b43f471eeb45f0e3c50d86c1",
+          "ttft_s": 1.178386874991702
+        },
+        {
+          "decode_tok_s": 18.31881689566433,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 223.19523772480372,
+          "prompt_tokens": 267,
+          "token_ids_sha256": "fc38a393f08f90ccf8e0daab774f33a6c2d67090b43f471eeb45f0e3c50d86c1",
+          "ttft_s": 1.196262083016336
+        },
+        {
+          "decode_tok_s": 18.444972723176015,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 225.54881685264766,
+          "prompt_tokens": 267,
+          "token_ids_sha256": "fc38a393f08f90ccf8e0daab774f33a6c2d67090b43f471eeb45f0e3c50d86c1",
+          "ttft_s": 1.1837792089791037
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "fc38a393f08f90ccf8e0daab774f33a6c2d67090b43f471eeb45f0e3c50d86c1"
+    },
+    "p400-g30": {
+      "complete": true,
+      "median_decode_tok_s": 10.278101958836315,
+      "median_prefill_tok_s": 237.681724217519,
+      "min_decode_tok_s": 10.219551948635582,
+      "min_to_median_decode_ratio": 0.9943034219318678,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 10.219551948635582,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 225.5450380641675,
+          "prompt_tokens": 411,
+          "token_ids_sha256": "7aa4ae81f778346b9df9e60e05670369ac97809e0e01906b3fa60590faee7c7e",
+          "ttft_s": 1.822252457990544
+        },
+        {
+          "decode_tok_s": 10.358216441932909,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 238.16877183880544,
+          "prompt_tokens": 411,
+          "token_ids_sha256": "7aa4ae81f778346b9df9e60e05670369ac97809e0e01906b3fa60590faee7c7e",
+          "ttft_s": 1.7256670420174487
+        },
+        {
+          "decode_tok_s": 10.278101958836315,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 237.681724217519,
+          "prompt_tokens": 411,
+          "token_ids_sha256": "7aa4ae81f778346b9df9e60e05670369ac97809e0e01906b3fa60590faee7c7e",
+          "ttft_s": 1.7292032080003992
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "7aa4ae81f778346b9df9e60e05670369ac97809e0e01906b3fa60590faee7c7e"
+    },
+    "p512-g30": {
+      "complete": true,
+      "median_decode_tok_s": 10.754785694219866,
+      "median_prefill_tok_s": 246.12131211662964,
+      "min_decode_tok_s": 10.448541473744449,
+      "min_to_median_decode_ratio": 0.9715248421323721,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 10.856912556046248,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 245.47681952875465,
+          "prompt_tokens": 519,
+          "token_ids_sha256": "c68a6f7230219aaa2acdaa5be59827e9ee4990162a1bf2e2cf0b42caf6ca2926",
+          "ttft_s": 2.1142525839968584
+        },
+        {
+          "decode_tok_s": 10.448541473744449,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 246.12131211662964,
+          "prompt_tokens": 519,
+          "token_ids_sha256": "c68a6f7230219aaa2acdaa5be59827e9ee4990162a1bf2e2cf0b42caf6ca2926",
+          "ttft_s": 2.108716208022088
+        },
+        {
+          "decode_tok_s": 10.754785694219866,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 248.71255908364228,
+          "prompt_tokens": 519,
+          "token_ids_sha256": "c68a6f7230219aaa2acdaa5be59827e9ee4990162a1bf2e2cf0b42caf6ca2926",
+          "ttft_s": 2.0867462500173133
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "c68a6f7230219aaa2acdaa5be59827e9ee4990162a1bf2e2cf0b42caf6ca2926"
+    }
+  },
+  "runtime": {
+    "jang": "2.5.39",
+    "mlx": "0.32.0",
+    "mlx_lm": "0.31.3",
+    "vmlx": "1.6.22"
+  },
+  "schema": "dsv4_performance_suite.v1",
+  "source": {
+    "checkout_verified": true,
+    "repository_root": "."
+  }
+}

--- a/reports/pr249/dsv4-optimized-15e9420d.json
+++ b/reports/pr249/dsv4-optimized-15e9420d.json
@@ -1,0 +1,411 @@
+{
+  "baseline_compatibility": {
+    "checks": {
+      "benchmark_controls": true,
+      "cases": true,
+      "git_revision": true,
+      "hardware": true,
+      "model": true,
+      "native_feature_state": true,
+      "native_passed": true,
+      "native_profile": true,
+      "runtime": true,
+      "schema": true,
+      "source": true
+    },
+    "passed": true
+  },
+  "benchmark_controls": {
+    "min_anchor_decode_ratio": 0.4,
+    "min_within_profile_decode_ratio": 0.75
+  },
+  "cases": [
+    {
+      "generation_target": 30,
+      "key": "p256-g30",
+      "prompt_target": 256,
+      "repeats": 3
+    },
+    {
+      "generation_target": 30,
+      "key": "p400-g30",
+      "prompt_target": 400,
+      "repeats": 3
+    },
+    {
+      "generation_target": 30,
+      "key": "p512-g30",
+      "prompt_target": 512,
+      "repeats": 3
+    },
+    {
+      "generation_target": 30,
+      "key": "p1024-g30",
+      "prompt_target": 1024,
+      "repeats": 3
+    },
+    {
+      "generation_target": 30,
+      "key": "p2048-g30",
+      "prompt_target": 2048,
+      "repeats": 3
+    },
+    {
+      "generation_target": 1000,
+      "key": "p256-g1000",
+      "prompt_target": 256,
+      "repeats": 1
+    }
+  ],
+  "comparison": {
+    "cases": {
+      "p1024-g30": {
+        "decode_ratio": 1.1863576345982116,
+        "exact_token_hash": true,
+        "min_sample_decode_ratio": 1.1844839191169467,
+        "passed": true,
+        "prefill_ratio": 1.0214283723916437
+      },
+      "p2048-g30": {
+        "decode_ratio": 1.3145484713021645,
+        "exact_token_hash": true,
+        "min_sample_decode_ratio": 1.3254764344529508,
+        "passed": true,
+        "prefill_ratio": 1.0076165726021578
+      },
+      "p256-g1000": {
+        "decode_ratio": 1.2730819078657754,
+        "exact_token_hash": true,
+        "min_sample_decode_ratio": 1.2730819078657754,
+        "passed": true,
+        "prefill_ratio": 1.0566099943948195
+      },
+      "p256-g30": {
+        "decode_ratio": 1.2933591107737317,
+        "exact_token_hash": true,
+        "min_sample_decode_ratio": 1.226860374729966,
+        "passed": true,
+        "prefill_ratio": 0.9833581895161249
+      },
+      "p400-g30": {
+        "decode_ratio": 1.2407123857803362,
+        "exact_token_hash": true,
+        "min_sample_decode_ratio": 1.2096956443455822,
+        "passed": true,
+        "prefill_ratio": 0.9960846061767306
+      },
+      "p512-g30": {
+        "decode_ratio": 1.1952400266639736,
+        "exact_token_hash": true,
+        "min_sample_decode_ratio": 1.185274258759258,
+        "passed": true,
+        "prefill_ratio": 0.9970408827647017
+      }
+    },
+    "passed": true
+  },
+  "controls": {
+    "DSV4_LAYERWISE_PREFILL_MIN_TOKENS": "256",
+    "VMLX_DSV4_AFFINE_MOE_FASTPATH": "0",
+    "VMLX_DSV4_COMPILED_MOE": "0",
+    "VMLX_DSV4_LM_HEAD_MODE": "exact-cache",
+    "VMLX_DSV4_ROPE_CACHE": "1",
+    "VMLX_DSV4_ROPE_NATIVE": "0",
+    "VMLX_DSV4_SKIP_UNUSED_INDEXER": "0"
+  },
+  "decode_floor_sanity": {
+    "applied": true,
+    "cases": {
+      "p1024-g30": {
+        "anchor_decode_ratio": 0.5597446315181371,
+        "passed": true
+      },
+      "p2048-g30": {
+        "anchor_decode_ratio": 0.9544577065212422,
+        "passed": true
+      },
+      "p256-g1000": {
+        "anchor_decode_ratio": 1.0,
+        "passed": true
+      },
+      "p256-g30": {
+        "anchor_decode_ratio": 1.005597419422897,
+        "passed": true
+      },
+      "p400-g30": {
+        "anchor_decode_ratio": 0.5386593091935001,
+        "passed": true
+      },
+      "p512-g30": {
+        "anchor_decode_ratio": 0.5429839841718751,
+        "passed": true
+      }
+    },
+    "passed": true
+  },
+  "feature_state": {
+    "lm_head": {
+      "allocator_cache_limit_bytes": 22620888104,
+      "cache_bytes": 2118123520,
+      "disabled_reason": null,
+      "installed": true,
+      "reservation_bytes": 2118123520,
+      "validated": true
+    },
+    "rope_cache": {
+      "registered_instances": 86,
+      "table_entries": 128
+    }
+  },
+  "feature_state_passed": true,
+  "features": "all",
+  "finished_at": "2026-08-04T10:10:39.419661+00:00",
+  "git_revision": "15e9420db804cfa81167acaceae13476d856a7b5",
+  "hardware": {
+    "machine": "arm64",
+    "macos": "26.5.1"
+  },
+  "model": {
+    "bundle_name": "OsaurusAI__DeepSeek-V4-Flash-0731-JANG",
+    "manifest_sha256": "fc68310e3b81ccbf5b86b9c28929b629dd89fa204d5de563d5442b13f6f2978c",
+    "shard_bytes": 101982500132,
+    "shard_count": 102
+  },
+  "passed": true,
+  "profile": "optimized",
+  "results": {
+    "p1024-g30": {
+      "complete": true,
+      "median_decode_tok_s": 13.251340284605716,
+      "median_prefill_tok_s": 269.73585004185037,
+      "min_decode_tok_s": 13.210961358332474,
+      "min_to_median_decode_ratio": 0.9969528420970254,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 13.251340284605716,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 268.5261728745587,
+          "prompt_tokens": 1032,
+          "token_ids_sha256": "3640799ff00ab31ca9d900db2990c5703e9e59ea7b9a8fe0083d0dbdbf6cbbcc",
+          "ttft_s": 3.843200791015988
+        },
+        {
+          "decode_tok_s": 13.716473052456692,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 270.4167867522648,
+          "prompt_tokens": 1032,
+          "token_ids_sha256": "3640799ff00ab31ca9d900db2990c5703e9e59ea7b9a8fe0083d0dbdbf6cbbcc",
+          "ttft_s": 3.816331124980934
+        },
+        {
+          "decode_tok_s": 13.210961358332474,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 269.73585004185037,
+          "prompt_tokens": 1032,
+          "token_ids_sha256": "3640799ff00ab31ca9d900db2990c5703e9e59ea7b9a8fe0083d0dbdbf6cbbcc",
+          "ttft_s": 3.8259652910055593
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "3640799ff00ab31ca9d900db2990c5703e9e59ea7b9a8fe0083d0dbdbf6cbbcc"
+    },
+    "p2048-g30": {
+      "complete": true,
+      "median_decode_tok_s": 22.59573945724836,
+      "median_prefill_tok_s": 227.35749065082564,
+      "min_decode_tok_s": 22.399056041292166,
+      "min_to_median_decode_ratio": 0.9912955530254576,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 22.399056041292166,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 227.35749065082564,
+          "prompt_tokens": 2058,
+          "token_ids_sha256": "b112862461dea4dc5024cef1b0575aa08f8db8a33f3cc78a1a94a39d8fc57b61",
+          "ttft_s": 9.051824041991495
+        },
+        {
+          "decode_tok_s": 22.742044951174453,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 226.26587573448631,
+          "prompt_tokens": 2058,
+          "token_ids_sha256": "b112862461dea4dc5024cef1b0575aa08f8db8a33f3cc78a1a94a39d8fc57b61",
+          "ttft_s": 9.095494375011185
+        },
+        {
+          "decode_tok_s": 22.59573945724836,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 227.38182148119728,
+          "prompt_tokens": 2058,
+          "token_ids_sha256": "b112862461dea4dc5024cef1b0575aa08f8db8a33f3cc78a1a94a39d8fc57b61",
+          "ttft_s": 9.050855457986472
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "b112862461dea4dc5024cef1b0575aa08f8db8a33f3cc78a1a94a39d8fc57b61"
+    },
+    "p256-g1000": {
+      "complete": true,
+      "median_decode_tok_s": 23.67390330956008,
+      "median_prefill_tok_s": 227.04315722609422,
+      "min_decode_tok_s": 23.67390330956008,
+      "min_to_median_decode_ratio": 1.0,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 23.67390330956008,
+          "finish_reason": "length",
+          "new_tokens": 1000,
+          "prefill_tok_s": 227.04315722609422,
+          "prompt_tokens": 267,
+          "token_ids_sha256": "8c07bb952476d34c928d3e4513d1306fe7fe9fd526ff78eb70d22d832cfcbe8a",
+          "ttft_s": 1.1759878750017378
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "8c07bb952476d34c928d3e4513d1306fe7fe9fd526ff78eb70d22d832cfcbe8a"
+    },
+    "p256-g30": {
+      "complete": true,
+      "median_decode_tok_s": 23.806416075760797,
+      "median_prefill_tok_s": 221.79527618772363,
+      "min_decode_tok_s": 22.474630561224373,
+      "min_to_median_decode_ratio": 0.9440577065317941,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 24.50589461869785,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 228.67070273197882,
+          "prompt_tokens": 267,
+          "token_ids_sha256": "fc38a393f08f90ccf8e0daab774f33a6c2d67090b43f471eeb45f0e3c50d86c1",
+          "ttft_s": 1.167617875005817
+        },
+        {
+          "decode_tok_s": 23.806416075760797,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 221.79527618772363,
+          "prompt_tokens": 267,
+          "token_ids_sha256": "fc38a393f08f90ccf8e0daab774f33a6c2d67090b43f471eeb45f0e3c50d86c1",
+          "ttft_s": 1.2038128340209369
+        },
+        {
+          "decode_tok_s": 22.474630561224373,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 216.57095642014602,
+          "prompt_tokens": 267,
+          "token_ids_sha256": "fc38a393f08f90ccf8e0daab774f33a6c2d67090b43f471eeb45f0e3c50d86c1",
+          "ttft_s": 1.232852291985182
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "fc38a393f08f90ccf8e0daab774f33a6c2d67090b43f471eeb45f0e3c50d86c1"
+    },
+    "p400-g30": {
+      "complete": true,
+      "median_decode_tok_s": 12.75216840264135,
+      "median_prefill_tok_s": 236.7511066626137,
+      "min_decode_tok_s": 12.362547479427871,
+      "min_to_median_decode_ratio": 0.9694466924438688,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 12.362547479427871,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 234.40660224949957,
+          "prompt_tokens": 411,
+          "token_ids_sha256": "7aa4ae81f778346b9df9e60e05670369ac97809e0e01906b3fa60590faee7c7e",
+          "ttft_s": 1.753363583004102
+        },
+        {
+          "decode_tok_s": 13.470515302220452,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 241.34938972390586,
+          "prompt_tokens": 411,
+          "token_ids_sha256": "7aa4ae81f778346b9df9e60e05670369ac97809e0e01906b3fa60590faee7c7e",
+          "ttft_s": 1.702925374993356
+        },
+        {
+          "decode_tok_s": 12.75216840264135,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 236.7511066626137,
+          "prompt_tokens": 411,
+          "token_ids_sha256": "7aa4ae81f778346b9df9e60e05670369ac97809e0e01906b3fa60590faee7c7e",
+          "ttft_s": 1.736000332981348
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "7aa4ae81f778346b9df9e60e05670369ac97809e0e01906b3fa60590faee7c7e"
+    },
+    "p512-g30": {
+      "complete": true,
+      "median_decode_tok_s": 12.854550339924673,
+      "median_prefill_tok_s": 245.39301029997108,
+      "min_decode_tok_s": 12.384387250407816,
+      "min_to_median_decode_ratio": 0.9634243845888107,
+      "passed": true,
+      "samples": [
+        {
+          "decode_tok_s": 12.384387250407816,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 245.39301029997108,
+          "prompt_tokens": 519,
+          "token_ids_sha256": "c68a6f7230219aaa2acdaa5be59827e9ee4990162a1bf2e2cf0b42caf6ca2926",
+          "ttft_s": 2.114974666008493
+        },
+        {
+          "decode_tok_s": 12.854550339924673,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 239.18920853191833,
+          "prompt_tokens": 519,
+          "token_ids_sha256": "c68a6f7230219aaa2acdaa5be59827e9ee4990162a1bf2e2cf0b42caf6ca2926",
+          "ttft_s": 2.1698303330049384
+        },
+        {
+          "decode_tok_s": 13.128442856237921,
+          "finish_reason": "length",
+          "new_tokens": 30,
+          "prefill_tok_s": 246.2904137690343,
+          "prompt_tokens": 519,
+          "token_ids_sha256": "c68a6f7230219aaa2acdaa5be59827e9ee4990162a1bf2e2cf0b42caf6ca2926",
+          "ttft_s": 2.1072683749953285
+        }
+      ],
+      "stable_decode_tail": true,
+      "stable_token_stream": true,
+      "token_ids_sha256": "c68a6f7230219aaa2acdaa5be59827e9ee4990162a1bf2e2cf0b42caf6ca2926"
+    }
+  },
+  "runtime": {
+    "jang": "2.5.39",
+    "mlx": "0.32.0",
+    "mlx_lm": "0.31.3",
+    "vmlx": "1.6.22"
+  },
+  "schema": "dsv4_performance_suite.v1",
+  "source": {
+    "checkout_verified": true,
+    "repository_root": "."
+  }
+}

--- a/scripts/check-public-repo-hygiene.sh
+++ b/scripts/check-public-repo-hygiene.sh
@@ -13,6 +13,7 @@ forbidden=$(
         !/^docs\/mlxstudio-releases-readme\.md$/ &&
         !/^docs\/api\// &&
         !/^docs\/benchmarks\// &&
+        !/^docs\/development\/dsv4-decode-acceptance\.md$/ &&
         !/^docs\/development\/dsv4-encoder-contract\.md$/ &&
         !/^docs\/development\/(architecture|build-test-deploy|contributing)\.md$/ &&
         !/^docs\/getting-started\// &&
@@ -153,6 +154,7 @@ historical_forbidden=$(
         !/^docs\/mlxstudio-releases-readme\.md$/ &&
         !/^docs\/api\// &&
         !/^docs\/benchmarks\// &&
+        !/^docs\/development\/dsv4-decode-acceptance\.md$/ &&
         !/^docs\/development\/dsv4-encoder-contract\.md$/ &&
         !/^docs\/development\/(architecture|build-test-deploy|contributing)\.md$/ &&
         !/^docs\/getting-started\// &&

--- a/scripts/check-public-repo-hygiene.sh
+++ b/scripts/check-public-repo-hygiene.sh
@@ -13,6 +13,7 @@ forbidden=$(
         !/^docs\/mlxstudio-releases-readme\.md$/ &&
         !/^docs\/api\// &&
         !/^docs\/benchmarks\// &&
+        !/^docs\/development\/dsv4-encoder-contract\.md$/ &&
         !/^docs\/development\/(architecture|build-test-deploy|contributing)\.md$/ &&
         !/^docs\/getting-started\// &&
         !/^docs\/guides\// &&
@@ -152,6 +153,7 @@ historical_forbidden=$(
         !/^docs\/mlxstudio-releases-readme\.md$/ &&
         !/^docs\/api\// &&
         !/^docs\/benchmarks\// &&
+        !/^docs\/development\/dsv4-encoder-contract\.md$/ &&
         !/^docs\/development\/(architecture|build-test-deploy|contributing)\.md$/ &&
         !/^docs\/getting-started\// &&
         !/^docs\/guides\// &&

--- a/tests/test_dsv4_performance_suite.py
+++ b/tests/test_dsv4_performance_suite.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for the DSV4 native-versus-optimized acceptance report."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _module():
+    path = Path(__file__).parents[1] / "bench" / "dsv4_performance_suite.py"
+    spec = importlib.util.spec_from_file_location("dsv4_performance_suite", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _case(*, token_hash="hash", decode=20.0, min_decode=None, prefill=200.0, passed=True):
+    return {
+        "passed": passed,
+        "token_ids_sha256": token_hash,
+        "median_decode_tok_s": decode,
+        "min_decode_tok_s": decode if min_decode is None else min_decode,
+        "median_prefill_tok_s": prefill,
+    }
+
+
+def test_case_parser_requires_unique_positive_triplets():
+    mod = _module()
+    cases = mod._parse_cases("256:30:3,256:1000:1")
+    assert [case.key for case in cases] == ["p256-g30", "p256-g1000"]
+    for invalid in ("", "256:30", "256:0:1", "256:30:1,256:30:2"):
+        try:
+            mod._parse_cases(invalid)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"accepted invalid case list {invalid!r}")
+
+
+def test_profile_controls_isolate_candidate_features(monkeypatch):
+    mod = _module()
+    monkeypatch.setattr(os, "environ", {})
+    head = mod._configure_profile("optimized", "lm-head")
+    assert head["VMLX_DSV4_LM_HEAD_MODE"] == "exact-cache"
+    assert head["VMLX_DSV4_ROPE_CACHE"] == "0"
+    rope = mod._configure_profile("optimized", "rope-cache")
+    assert rope["VMLX_DSV4_LM_HEAD_MODE"] == "native"
+    assert rope["VMLX_DSV4_ROPE_CACHE"] == "1"
+
+
+def test_acceptance_requires_exact_hash_and_bounded_throughput():
+    mod = _module()
+    baseline = {"results": {"p256-g30": _case()}}
+    candidate = {
+        "results": {"p256-g30": _case(decode=19.8, prefill=195.0)}
+    }
+    accepted = mod._compare(
+        candidate,
+        baseline,
+        min_decode_ratio=0.98,
+        min_prefill_ratio=0.95,
+    )
+    assert accepted["passed"] is True
+
+    candidate["results"]["p256-g30"]["token_ids_sha256"] = "different"
+    assert (
+        mod._compare(
+            candidate,
+            baseline,
+            min_decode_ratio=0.98,
+            min_prefill_ratio=0.95,
+        )["passed"]
+        is False
+    )
+
+
+def test_acceptance_fails_closed_for_missing_or_slow_cases():
+    mod = _module()
+    baseline = {"results": {"p256-g30": _case(), "p256-g1000": _case()}}
+    missing = {"results": {"p256-g30": _case()}}
+    missing_baseline = {"results": {"p256-g1000": _case()}}
+    assert (
+        mod._compare(
+            missing_baseline,
+            {"results": {}},
+            min_decode_ratio=0.98,
+            min_prefill_ratio=0.95,
+        )["passed"]
+        is False
+    )
+    assert (
+        mod._compare(
+            missing,
+            baseline,
+            min_decode_ratio=0.98,
+            min_prefill_ratio=0.95,
+        )["cases"]["p256-g1000"]["reason"]
+        == "missing candidate case"
+    )
+    slow = {"results": {"p256-g30": _case(decode=15.0)}}
+    assert (
+        mod._compare(
+            slow,
+            missing,
+            min_decode_ratio=0.98,
+            min_prefill_ratio=0.95,
+        )["passed"]
+        is False
+    )
+    assert set(baseline["results"]) == {"p256-g30", "p256-g1000"}
+
+
+def test_acceptance_rejects_incompatible_baseline_metadata():
+    mod = _module()
+    candidate = {
+        "schema": mod.SCHEMA,
+        "profile": "optimized",
+        "passed": True,
+        "feature_state_passed": True,
+        "model": {"bundle_name": "model", "manifest_sha256": "bundle"},
+        "source": {"checkout_verified": True, "repository_root": "."},
+        "git_revision": "candidate",
+        "hardware": {"machine": "arm64"},
+        "runtime": {"mlx": "1"},
+        "cases": [{"key": "p256-g30"}],
+        "benchmark_controls": {
+            "min_within_profile_decode_ratio": 0.75,
+            "min_anchor_decode_ratio": 0.40,
+        },
+    }
+    baseline = candidate | {"profile": "native"}
+    assert mod._baseline_compatibility(candidate, baseline)["passed"] is True
+
+    stale = baseline | {"git_revision": "stale"}
+    compatibility = mod._baseline_compatibility(candidate, stale)
+    assert compatibility["passed"] is False
+    assert compatibility["checks"]["git_revision"] is False
+
+
+def test_model_identity_is_public_and_changes_with_manifest(tmp_path):
+    mod = _module()
+    (tmp_path / "config.json").write_text('{"model_type":"deepseek_v4"}')
+    (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"weights")
+    (tmp_path / "model.safetensors.index.json").write_text(
+        '{"weight_map":{"model.weight":"model-00001-of-00001.safetensors"}}'
+    )
+
+    first = mod._model_identity(tmp_path)
+    assert first["bundle_name"] == tmp_path.name
+    assert first["shard_count"] == 1
+    assert first["shard_bytes"] == 7
+    assert str(tmp_path) not in json.dumps(first)
+
+    (tmp_path / "config.json").write_text('{"model_type":"changed"}')
+    second = mod._model_identity(tmp_path)
+    assert second["manifest_sha256"] != first["manifest_sha256"]
+
+
+def test_acceptance_rejects_catastrophic_tail_hidden_by_median():
+    mod = _module()
+    baseline = {"results": {"p512-g30": _case(decode=12.0, min_decode=11.0)}}
+    candidate = {"results": {"p512-g30": _case(decode=12.1, min_decode=0.8)}}
+    comparison = mod._compare(
+        candidate,
+        baseline,
+        min_decode_ratio=0.98,
+        min_prefill_ratio=0.95,
+        min_sample_decode_ratio=0.75,
+    )
+    assert comparison["passed"] is False
+
+
+def test_case_summary_rejects_unstable_profile_tail():
+    mod = _module()
+    case = mod.Case(prompt_target=512, generation_target=30, repeats=3)
+    samples = [
+        {
+            "new_tokens": 30,
+            "token_ids_sha256": "same",
+            "decode_tok_s": decode,
+            "prefill_tok_s": 200.0,
+        }
+        for decode in (12.0, 11.5, 0.7)
+    ]
+
+    summary = mod._summarize(case, samples)
+    assert summary["passed"] is False
+    assert summary["stable_decode_tail"] is False
+    assert summary["min_to_median_decode_ratio"] < 0.1
+
+
+def test_cross_case_decode_floor_rejects_consistently_cold_short_case():
+    mod = _module()
+    results = {
+        "p256-g30": _case(decode=0.75),
+        "p400-g30": _case(decode=10.0),
+        "p256-g1000": _case(decode=18.5),
+    }
+
+    sanity = mod._decode_floor_sanity(results, min_anchor_ratio=0.40)
+    assert sanity["passed"] is False
+    assert sanity["cases"]["p256-g30"]["passed"] is False
+
+    targeted = mod._decode_floor_sanity({"p400-g30": _case(decode=10.0)})
+    assert targeted["passed"] is True
+    assert targeted["applied"] is False

--- a/tests/test_dsv4_safe_fastpaths.py
+++ b/tests/test_dsv4_safe_fastpaths.py
@@ -1,0 +1,384 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Failure-isolation tests for promoted DSV4 performance paths."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class _Array:
+    def __init__(self, shape, dtype="float16", value=None):
+        self.shape = tuple(shape)
+        self.ndim = len(self.shape)
+        self.dtype = dtype
+        self.value = value
+        self.T = self
+
+    def astype(self, dtype):
+        return _Array(self.shape, dtype, self.value)
+
+    def __matmul__(self, _other):
+        return _Array(self.shape[:-1] + (16,), "float32", "reference")
+
+
+class _Head:
+    def __init__(self):
+        self.weight = _Array((16, 4), "uint32")
+        self.scales = _Array((16, 1), "float16")
+        self.biases = _Array((16, 1), "float16")
+        self.bits = 8
+        self.group_size = 64
+        self.mode = "affine"
+
+    def __contains__(self, _key):
+        return False
+
+
+def test_lm_head_failure_falls_back_without_advancing_cache_twice(monkeypatch):
+    import vmlx_engine.models.dsv4_lm_head_fastpath as mod
+
+    class _Mx:
+        float32 = "float32"
+
+        @staticmethod
+        def quantized_matmul(*_args, **_kwargs):
+            return _Array((1, 1, 16), value="fast")
+
+        @staticmethod
+        def eval(*_args):
+            raise RuntimeError("synthetic lazy dispatch failure")
+
+        @staticmethod
+        def dequantize(*_args, **_kwargs):
+            return _Array((16, 64), "float32")
+
+    class _Model:
+        model_type = "deepseek_v4"
+
+        def __init__(self):
+            self.lm_head = _Head()
+
+        def model(self, _input_ids, cache=None, mask=None):
+            del mask
+            cache.advances += 1
+            return _Array((1, 1, 64))
+
+        def __call__(self, input_ids, cache=None, mask=None):
+            hidden = self.model(input_ids, cache=cache, mask=mask)
+            return ("stock", hidden)
+
+    monkeypatch.setattr(mod, "mx", _Mx)
+    monkeypatch.setattr(mod, "_CONFIGS", mod._WeakIdentityMap())
+    monkeypatch.setattr(mod, "_CLASS_PATCHES", {})
+    monkeypatch.setattr(mod, "_cache_admitted", lambda *_args: True)
+    monkeypatch.setattr(mod, "_reserve_allocator_cache", lambda *_args: True)
+    monkeypatch.setattr(mod, "_release_cache_reservation", lambda *_args: None)
+    monkeypatch.setattr(mod, "_materialize_weight", lambda _head: _Array((16, 64), "float32"))
+    monkeypatch.setenv("VMLX_DSV4_LM_HEAD_MODE", "exact-cache")
+    model = _Model()
+    cache = SimpleNamespace(advances=0)
+
+    assert mod.install_dsv4_lm_head_fastpath(model)
+    assert mod.dsv4_lm_head_fastpath_status(model)["installed"] is True
+    result = model("ids", cache=cache)
+
+    assert result.value == "reference"
+    assert cache.advances == 1
+    assert mod._CONFIGS.get(model).disabled_reason is not None
+
+
+def test_lm_head_registration_keeps_multiple_models_active(monkeypatch):
+    import vmlx_engine.models.dsv4_lm_head_fastpath as mod
+
+    class _Mx:
+        float32 = "float32"
+
+        @staticmethod
+        def eval(*_args):
+            return None
+
+        @staticmethod
+        def dequantize(*_args, **_kwargs):
+            return _Array((16, 64), "float32")
+
+    class _Model:
+        model_type = "deepseek_v4"
+
+        def __init__(self):
+            self.lm_head = _Head()
+
+        def model(self, *_args, **_kwargs):
+            return _Array((1, 1, 64))
+
+        def __call__(self, *_args, **_kwargs):
+            return "stock"
+
+    monkeypatch.setattr(mod, "mx", _Mx)
+    monkeypatch.setattr(mod, "_CONFIGS", mod._WeakIdentityMap())
+    monkeypatch.setattr(mod, "_CLASS_PATCHES", {})
+    monkeypatch.setattr(mod, "_cache_admitted", lambda *_args: True)
+    monkeypatch.setattr(mod, "_reserve_allocator_cache", lambda *_args: True)
+    monkeypatch.setattr(
+        mod,
+        "_materialize_weight",
+        lambda _head: _Array((16, 64), "float32", "cached"),
+    )
+    monkeypatch.setenv("VMLX_DSV4_LM_HEAD_MODE", "exact-cache")
+    first, second = _Model(), _Model()
+
+    assert mod.install_dsv4_lm_head_fastpath(first)
+    assert mod.install_dsv4_lm_head_fastpath(second)
+    assert first("ids").value == second("ids").value == "reference"
+    assert mod._CONFIGS.get(first) is not None
+    assert mod._CONFIGS.get(second) is not None
+    assert mod.dsv4_lm_head_fastpath_status(first)["cache_bytes"] == 0
+
+
+def test_lm_head_reinstall_is_idempotent(monkeypatch):
+    import vmlx_engine.models.dsv4_lm_head_fastpath as mod
+
+    class _Mx:
+        float32 = "float32"
+
+        @staticmethod
+        def eval(*_args):
+            return None
+
+        @staticmethod
+        def dequantize(*_args, **_kwargs):
+            return _Array((16, 64), "float32")
+
+    class _Model:
+        model_type = "deepseek_v4"
+
+        def __init__(self):
+            self.lm_head = _Head()
+
+        def model(self, *_args, **_kwargs):
+            return _Array((1, 1, 64))
+
+        def __call__(self, *_args, **_kwargs):
+            return "stock"
+
+    materializations = []
+    monkeypatch.setattr(mod, "mx", _Mx)
+    monkeypatch.setattr(mod, "_CONFIGS", mod._WeakIdentityMap())
+    monkeypatch.setattr(mod, "_CLASS_PATCHES", {})
+    monkeypatch.setattr(mod, "_cache_admitted", lambda *_args: True)
+    monkeypatch.setattr(mod, "_reserve_allocator_cache", lambda *_args: True)
+    monkeypatch.setattr(
+        mod,
+        "_materialize_weight",
+        lambda _head: materializations.append(object()) or _Array((16, 64)),
+    )
+    monkeypatch.setenv("VMLX_DSV4_LM_HEAD_MODE", "exact-cache")
+    model = _Model()
+
+    assert mod.install_dsv4_lm_head_fastpath(model)
+    assert mod.install_dsv4_lm_head_fastpath(model)
+    assert len(materializations) == 1
+
+
+def test_lm_head_reservation_reduces_and_restores_allocator_cache(monkeypatch):
+    import vmlx_engine.models.dsv4_lm_head_fastpath as mod
+
+    limits = []
+
+    class _Mx:
+        @staticmethod
+        def set_cache_limit(value):
+            limits.append(value)
+
+    class _Model:
+        pass
+
+    monkeypatch.setattr(mod, "mx", _Mx)
+    monkeypatch.setattr(mod, "_RESERVATIONS", {})
+    monkeypatch.setattr(mod, "_CACHE_LIMIT_BASE_BYTES", None)
+    monkeypatch.setattr(mod, "_CACHE_LIMIT_EFFECTIVE_BYTES", None)
+    monkeypatch.setenv("VMLINUX_DSV4_MLX_CACHE_MIN_GB", "1")
+    gib = 1024**3
+    model = _Model()
+
+    assert mod.configure_dsv4_lm_head_cache_budget(8 * gib) == 8 * gib
+    assert mod._reserve_allocator_cache(model, 2 * gib)
+    assert limits[-1] == 6 * gib
+
+    mod._release_cache_reservation(id(model))
+    assert limits[-1] == 8 * gib
+
+
+def test_lm_head_reservation_rejects_cache_floor_violation(monkeypatch):
+    import vmlx_engine.models.dsv4_lm_head_fastpath as mod
+
+    class _Mx:
+        @staticmethod
+        def set_cache_limit(_value):
+            return None
+
+    monkeypatch.setattr(mod, "mx", _Mx)
+    monkeypatch.setattr(mod, "_RESERVATIONS", {})
+    monkeypatch.setattr(mod, "_CACHE_LIMIT_BASE_BYTES", None)
+    monkeypatch.setattr(mod, "_CACHE_LIMIT_EFFECTIVE_BYTES", None)
+    monkeypatch.setenv("VMLINUX_DSV4_MLX_CACHE_MIN_GB", "4")
+    gib = 1024**3
+    model = type("Model", (), {})()
+
+    mod.configure_dsv4_lm_head_cache_budget(5 * gib)
+    assert not mod._reserve_allocator_cache(model, 2 * gib)
+
+
+def test_lm_head_allocator_floor_never_raises_user_ceiling(monkeypatch):
+    import vmlx_engine.models.dsv4_lm_head_fastpath as mod
+
+    limits = []
+
+    class _Mx:
+        @staticmethod
+        def set_cache_limit(value):
+            limits.append(value)
+
+    monkeypatch.setattr(mod, "mx", _Mx)
+    monkeypatch.setattr(mod, "_RESERVATIONS", {})
+    monkeypatch.setattr(mod, "_CACHE_LIMIT_BASE_BYTES", None)
+    monkeypatch.setattr(mod, "_CACHE_LIMIT_EFFECTIVE_BYTES", None)
+    monkeypatch.setenv("VMLINUX_DSV4_MLX_CACHE_MIN_GB", "4")
+    gib = 1024**3
+
+    assert mod.configure_dsv4_lm_head_cache_budget(2 * gib) == 2 * gib
+    assert limits[-1] == 2 * gib
+
+
+def test_lm_head_reduced_ceiling_releases_existing_reservations(monkeypatch):
+    import vmlx_engine.models.dsv4_lm_head_fastpath as mod
+
+    class _Mx:
+        @staticmethod
+        def set_cache_limit(_value):
+            return None
+
+    model = type("Model", (), {})()
+    config = mod._HeadConfig(signature=(), weight=object(), reservation_bytes=2)
+    configs = mod._WeakIdentityMap()
+    configs[model] = config
+    reference = next(iter(configs._items.values()))[0]
+    monkeypatch.setattr(mod, "mx", _Mx)
+    monkeypatch.setattr(mod, "_CONFIGS", configs)
+    monkeypatch.setattr(mod, "_RESERVATIONS", {id(model): (reference, 2 * 1024**3)})
+    monkeypatch.setattr(mod, "_CACHE_LIMIT_BASE_BYTES", 8 * 1024**3)
+    monkeypatch.setattr(mod, "_CACHE_LIMIT_EFFECTIVE_BYTES", 6 * 1024**3)
+    monkeypatch.setenv("VMLINUX_DSV4_MLX_CACHE_MIN_GB", "4")
+
+    mod.configure_dsv4_lm_head_cache_budget(5 * 1024**3)
+    assert config.weight is None
+    assert config.reservation_bytes == 0
+    assert not mod._RESERVATIONS
+
+
+def test_rope_cache_is_instance_scoped_and_bounded(monkeypatch):
+    import vmlx_engine.models.dsv4_rope_cache as mod
+
+    class _Values:
+        shape = (2,)
+
+        def tolist(self):
+            return [1.0, 0.5]
+
+        def __getitem__(self, _key):
+            return self
+
+    class _Rope:
+        inv_freq = _Values()
+
+        def __init__(self):
+            self.reference_calls = 0
+
+        def __call__(self, x, offset=0, inverse=False, positions=None):
+            del offset, inverse, positions
+            self.reference_calls += 1
+            return x
+
+    class _Mx:
+        float32 = "float32"
+
+        @staticmethod
+        def arange(start, end, dtype=None):
+            del dtype
+            return _Array((end - start,))
+
+        @staticmethod
+        def cos(value):
+            return value
+
+        @staticmethod
+        def sin(value):
+            return value
+
+        @staticmethod
+        def eval(*_args):
+            return None
+
+        @staticmethod
+        def stack(values, axis=-1):
+            del axis
+            return values[0]
+
+    # Exercise registration/bounds without evaluating the fake rotation math.
+    monkeypatch.setattr(mod, "mx", _Mx)
+    monkeypatch.setattr(mod, "_CONFIGS", mod._WeakIdentityMap())
+    monkeypatch.setattr(mod, "_GROUPS", {})
+    monkeypatch.setattr(mod, "_GROUP_LOCK", __import__("threading").RLock())
+    monkeypatch.setattr(mod, "_CLASS_PATCHES", {})
+    monkeypatch.setenv("VMLX_DSV4_ROPE_CACHE", "1")
+    monkeypatch.setenv("VMLX_DSV4_ROPE_CACHE_MAX_ENTRIES", "1")
+    first, second, untouched = _Rope(), _Rope(), _Rope()
+    model = SimpleNamespace(named_modules=lambda: [("a", first), ("b", second)])
+
+    assert mod._install_for_class(model, _Rope) == 2
+    assert mod.dsv4_rope_cache_status(model)["registered_instances"] == 2
+    group = mod._CONFIGS.get(first)
+    assert group is mod._CONFIGS.get(second)
+    group.tables[(0, 1, "float16")] = (object(), object())
+    group.tables.popitem(last=False)
+    group.tables[(1, 1, "float16")] = (object(), object())
+    assert len(group.tables) == 1
+
+    untouched(_Array((1, 1, 4)))
+    assert untouched.reference_calls == 1
+
+
+def test_rope_cache_releases_orphaned_frequency_groups(monkeypatch):
+    import gc
+    import weakref
+
+    import vmlx_engine.models.dsv4_rope_cache as mod
+
+    class _Values:
+        shape = (2,)
+
+        def tolist(self):
+            return [1.0, 0.5]
+
+    class _Rope:
+        inv_freq = _Values()
+
+        def __call__(self, x, offset=0, inverse=False, positions=None):
+            del offset, inverse, positions
+            return x
+
+    monkeypatch.setattr(mod, "_CONFIGS", mod._WeakIdentityMap())
+    monkeypatch.setattr(mod, "_GROUPS", {})
+    monkeypatch.setattr(mod, "_GROUP_LOCK", __import__("threading").RLock())
+    monkeypatch.setattr(mod, "_CLASS_PATCHES", {})
+    monkeypatch.setenv("VMLX_DSV4_ROPE_CACHE", "1")
+    rope = _Rope()
+    rope_ref = weakref.ref(rope)
+    model = SimpleNamespace(
+        named_modules=lambda: [("rope", rope_ref())] if rope_ref() is not None else []
+    )
+
+    assert mod._install_for_class(model, _Rope) == 1
+    assert len(mod._GROUPS) == 1
+    del rope
+    gc.collect()
+    assert not mod._GROUPS

--- a/tests/test_public_repo_hygiene.py
+++ b/tests/test_public_repo_hygiene.py
@@ -109,7 +109,7 @@ def test_forbidden_artifact_on_public_tag_fails(tmp_path: Path):
     _assert_temporary_public_refs_removed(repo)
 
 
-def test_published_dsv4_encoder_contract_is_exactly_allowlisted(tmp_path: Path):
+def test_published_dsv4_contract_docs_are_exactly_allowlisted(tmp_path: Path):
     repo, _ = _public_repo(tmp_path)
     docs = repo / "docs" / "development"
     docs.mkdir(parents=True)
@@ -117,8 +117,13 @@ def test_published_dsv4_encoder_contract_is_exactly_allowlisted(tmp_path: Path):
         "# Public DSV4 encoder contract\n",
         encoding="utf-8",
     )
+    (docs / "dsv4-decode-acceptance.md").write_text(
+        "# Public DSV4 decode acceptance\n",
+        encoding="utf-8",
+    )
     _git(repo, "add", "docs/development/dsv4-encoder-contract.md")
-    _git(repo, "commit", "-m", "publish DSV4 encoder contract")
+    _git(repo, "add", "docs/development/dsv4-decode-acceptance.md")
+    _git(repo, "commit", "-m", "publish DSV4 contract docs")
     _git(repo, "push", "origin", "main")
 
     result = _run_hygiene(repo)

--- a/tests/test_public_repo_hygiene.py
+++ b/tests/test_public_repo_hygiene.py
@@ -107,3 +107,22 @@ def test_forbidden_artifact_on_public_tag_fails(tmp_path: Path):
     assert "public repository history contains forbidden" in result.stderr
     assert "notes/private.md" in result.stderr
     _assert_temporary_public_refs_removed(repo)
+
+
+def test_published_dsv4_encoder_contract_is_exactly_allowlisted(tmp_path: Path):
+    repo, _ = _public_repo(tmp_path)
+    docs = repo / "docs" / "development"
+    docs.mkdir(parents=True)
+    (docs / "dsv4-encoder-contract.md").write_text(
+        "# Public DSV4 encoder contract\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "docs/development/dsv4-encoder-contract.md")
+    _git(repo, "commit", "-m", "publish DSV4 encoder contract")
+    _git(repo, "push", "origin", "main")
+
+    result = _run_hygiene(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "Public repository hygiene check passed.\n"
+    _assert_temporary_public_refs_removed(repo)

--- a/vmlx_engine/loaders/load_jangtq_dsv4.py
+++ b/vmlx_engine/loaders/load_jangtq_dsv4.py
@@ -1234,7 +1234,7 @@ def _install_dsv4_instant_load_patch() -> None:
     )
 
 
-def _install_dsv4_memory_defaults() -> None:
+def _install_dsv4_memory_defaults() -> int | None:
     """Set DSV4-specific MLX/JANG runtime defaults before hydration.
 
     Per Eric directive 2026-06-27: honor the user's `iogpu.wired_limit_mb`
@@ -1299,14 +1299,33 @@ def _install_dsv4_memory_defaults() -> None:
             os.environ.get("DSV4_MLX_CACHE_LIMIT_GB", "%g" % _default_cache_gb)
         )
         if cache_gb > 0:
-            mx.set_cache_limit(int(cache_gb * 1024**3))
+            cache_limit_bytes = int(cache_gb * 1024**3)
+            try:
+                from ..models.dsv4_lm_head_fastpath import (
+                    configure_dsv4_lm_head_cache_budget,
+                )
+
+                effective_cache_limit = configure_dsv4_lm_head_cache_budget(
+                    cache_limit_bytes
+                )
+            except Exception as cache_budget_error:
+                _log.warning(
+                    "DSV4 lm_head cache-budget integration unavailable (%s); "
+                    "using the configured allocator ceiling",
+                    cache_budget_error,
+                )
+                mx.set_cache_limit(cache_limit_bytes)
+                effective_cache_limit = cache_limit_bytes
             print(
-                f"  [dsv4] MLX cache limit set to {cache_gb:g} GB "
+                "  [dsv4] MLX cache limit set to "
+                f"{effective_cache_limit / 1024**3:.2f} GB "
                 "(env DSV4_MLX_CACHE_LIMIT_GB)",
                 flush=True,
             )
+            return cache_limit_bytes
     except Exception:
         pass
+    return None
 
 
 def _configure_dsv4_pool_quant_default(model_path: str | None = None) -> str:
@@ -1481,6 +1500,32 @@ def load_jangtq_dsv4_model(model_path: str, *, skip_params_eval: bool = True) ->
                 "DSV4 affine MoE decode fast path unavailable (%s); using stock SwitchGLU",
                 _affine_fastpath_err,
             )
+
+    # These optimizations retain the source model's arithmetic and are scoped
+    # to the exact instances validated by their installers. Neither fallback
+    # replays the transformer against a mutable request cache.
+    try:
+        from ..models.dsv4_lm_head_fastpath import install_dsv4_lm_head_fastpath
+
+        if install_dsv4_lm_head_fastpath(model):
+            _log.info("DSV4 exact dequantized lm_head cache installed")
+    except Exception as _lm_head_err:
+        _log.warning(
+            "DSV4 exact dequantized lm_head cache unavailable: %s",
+            _lm_head_err,
+        )
+
+    try:
+        from ..models.dsv4_rope_cache import install_dsv4_rope_cache
+
+        rope_instances = install_dsv4_rope_cache(model)
+        if rope_instances:
+            _log.info(
+                "DSV4 exact RoPE table sharing installed for %d instances",
+                rope_instances,
+            )
+    except Exception as _rope_cache_err:
+        _log.warning("DSV4 exact RoPE table sharing unavailable: %s", _rope_cache_err)
 
     # 2026-05-03 (F17): install canonical-encoder shim on
     # tokenizer.apply_chat_template. The bundle ships a Jinja chat_template

--- a/vmlx_engine/models/dsv4_lm_head_fastpath.py
+++ b/vmlx_engine/models/dsv4_lm_head_fastpath.py
@@ -1,0 +1,472 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Safe exact dequantized vocabulary-head cache for DeepSeek-V4.
+
+The JANG DSV4 reference path dequantizes the vocabulary matrix on every
+forward call before applying an FP32 matrix multiplication. This module
+materializes the dequantized FP32 matrix once, subject to projected Metal
+headroom and allocator-cache budget gates, then reuses it for the same FP32
+matmul as the reference. The arithmetic is unchanged and fallback never runs
+the transformer or mutates its cache twice.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import weakref
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import mlx.core as mx
+except ImportError:  # pragma: no cover - non-Apple package inspection
+    mx = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+
+def _enabled() -> bool:
+    value = os.environ.get("VMLX_DSV4_LM_HEAD_MODE", "exact-cache")
+    return value.strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "cache",
+        "exact-cache",
+        "fp32",
+    }
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name, str(default))
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid %s=%r", name, raw)
+        return default
+    if value <= 0:
+        logger.warning("Ignoring non-positive %s=%r", name, raw)
+        return default
+    return value
+
+
+def _model_type(model: Any) -> str:
+    for owner in (model, getattr(model, "model", None)):
+        if owner is None:
+            continue
+        value = getattr(owner, "model_type", None)
+        if value:
+            return str(value)
+        args = getattr(owner, "args", None)
+        value = getattr(args, "model_type", None)
+        if value:
+            return str(value)
+        config = getattr(owner, "config", None)
+        if isinstance(config, dict) and config.get("model_type"):
+            return str(config["model_type"])
+    return ""
+
+
+def _head_signature(head: Any) -> tuple[Any, ...]:
+    return (
+        id(getattr(head, "weight", None)),
+        id(getattr(head, "scales", None)),
+        id(getattr(head, "biases", None)),
+        int(getattr(head, "bits", -1)),
+        int(getattr(head, "group_size", -1)),
+        str(getattr(head, "mode", "affine")),
+    )
+
+
+def _validate_head(head: Any) -> tuple[Any, ...]:
+    if mx is None or not hasattr(mx, "dequantize"):
+        raise ValueError("MLX dequantize is unavailable")
+    weight = getattr(head, "weight", None)
+    scales = getattr(head, "scales", None)
+    biases = getattr(head, "biases", None)
+    bits = int(getattr(head, "bits", -1))
+    group_size = int(getattr(head, "group_size", -1))
+    mode = str(getattr(head, "mode", "affine"))
+    if weight is None or scales is None:
+        raise ValueError("lm_head is not quantized")
+    if getattr(weight, "ndim", 0) != 2 or getattr(scales, "ndim", 0) != 2:
+        raise ValueError("lm_head tensors do not use the expected rank-2 layout")
+    if biases is not None and getattr(biases, "shape", None) != scales.shape:
+        raise ValueError("lm_head affine bias geometry differs from scales")
+    if bits <= 0 or group_size <= 0:
+        raise ValueError("lm_head quantization metadata is invalid")
+    if mode != "affine":
+        raise ValueError(f"lm_head mode {mode!r} is not affine")
+    try:
+        if "bias" in head:
+            raise ValueError("post-matmul lm_head bias is unsupported")
+    except TypeError:
+        pass
+    return _head_signature(head)
+
+
+@dataclass
+class _HeadConfig:
+    signature: tuple[Any, ...]
+    weight: Any
+    reservation_bytes: int = 0
+    validated: bool = False
+    disabled_reason: str | None = None
+
+
+class _WeakIdentityMap:
+    """Weak instance map that accepts unhashable MLX modules."""
+
+    def __init__(self) -> None:
+        self._items: dict[int, tuple[weakref.ReferenceType[Any], _HeadConfig]] = {}
+
+    def __setitem__(self, owner: Any, config: _HeadConfig) -> None:
+        identity = id(owner)
+        items = self._items
+
+        def _remove(reference: weakref.ReferenceType[Any]) -> None:
+            current = items.get(identity)
+            if current is not None and current[0] is reference:
+                items.pop(identity, None)
+
+        self._items[identity] = (weakref.ref(owner, _remove), config)
+
+    def get(self, owner: Any) -> _HeadConfig | None:
+        entry = self._items.get(id(owner))
+        if entry is None or entry[0]() is not owner:
+            return None
+        return entry[1]
+
+
+_CONFIGS = _WeakIdentityMap()
+_CLASS_PATCHES: dict[type, tuple[Any, Any]] = {}
+_RESERVATION_LOCK = threading.RLock()
+_RESERVATIONS: dict[int, tuple[weakref.ReferenceType[Any], int]] = {}
+_CACHE_LIMIT_BASE_BYTES: int | None = None
+_CACHE_LIMIT_EFFECTIVE_BYTES: int | None = None
+
+
+def _reference_logits(hidden: Any, head: Any) -> Any:
+    """Apply the JANG reference head to an already-computed hidden state."""
+
+    weight = mx.dequantize(
+        head.weight,
+        head.scales,
+        getattr(head, "biases", None),
+        group_size=head.group_size,
+        bits=head.bits,
+        mode=getattr(head, "mode", "affine"),
+    ).astype(mx.float32)
+    return hidden.astype(mx.float32) @ weight.T
+
+
+def _estimated_cache_bytes(head: Any) -> int:
+    scales = head.scales
+    output_dims = int(head.weight.shape[0])
+    input_dims = int(scales.shape[1]) * int(head.group_size)
+    return output_dims * input_dims * 4
+
+
+def _cache_limit_minimum_bytes() -> int:
+    return int(_positive_float_env("VMLINUX_DSV4_MLX_CACHE_MIN_GB", 4.0) * 1024**3)
+
+
+def _reservation_bytes_locked() -> int:
+    return sum(item[1] for item in _RESERVATIONS.values())
+
+
+def _allocator_floor_bytes_locked() -> int:
+    if _CACHE_LIMIT_BASE_BYTES is None:
+        return _cache_limit_minimum_bytes()
+    return min(_CACHE_LIMIT_BASE_BYTES, _cache_limit_minimum_bytes())
+
+
+def _apply_allocator_limit_locked() -> int | None:
+    global _CACHE_LIMIT_EFFECTIVE_BYTES
+
+    if mx is None or _CACHE_LIMIT_BASE_BYTES is None:
+        _CACHE_LIMIT_EFFECTIVE_BYTES = None
+        return None
+    effective = max(
+        _allocator_floor_bytes_locked(),
+        _CACHE_LIMIT_BASE_BYTES - _reservation_bytes_locked(),
+    )
+    mx.set_cache_limit(effective)
+    _CACHE_LIMIT_EFFECTIVE_BYTES = effective
+    return effective
+
+
+def configure_dsv4_lm_head_cache_budget(base_limit_bytes: int) -> int:
+    """Apply the DSV4 allocator ceiling after persistent head reservations."""
+
+    global _CACHE_LIMIT_BASE_BYTES
+
+    if base_limit_bytes <= 0:
+        raise ValueError("base_limit_bytes must be positive")
+    with _RESERVATION_LOCK:
+        _CACHE_LIMIT_BASE_BYTES = int(base_limit_bytes)
+        floor = _allocator_floor_bytes_locked()
+        if _reservation_bytes_locked() + floor > _CACHE_LIMIT_BASE_BYTES:
+            logger.info(
+                "Releasing DSV4 lm_head caches to honor a reduced MLX cache ceiling"
+            )
+            for reference, _reserved in tuple(_RESERVATIONS.values()):
+                model = reference()
+                if model is None:
+                    continue
+                config = _CONFIGS.get(model)
+                if config is not None:
+                    config.disabled_reason = "allocator cache ceiling was reduced"
+                    config.weight = None
+                    config.reservation_bytes = 0
+            _RESERVATIONS.clear()
+        effective = _apply_allocator_limit_locked()
+    if effective is None:
+        raise RuntimeError("MLX allocator cache control is unavailable")
+    return effective
+
+
+def _release_cache_reservation(
+    identity: int,
+    reference: weakref.ReferenceType[Any] | None = None,
+) -> None:
+    with _RESERVATION_LOCK:
+        current = _RESERVATIONS.get(identity)
+        if current is None or (reference is not None and current[0] is not reference):
+            return
+        _RESERVATIONS.pop(identity, None)
+        try:
+            _apply_allocator_limit_locked()
+        except Exception as exc:
+            logger.warning("Could not restore the DSV4 MLX cache budget: %s", exc)
+
+
+def _reserve_allocator_cache(model: Any, estimated: int) -> bool:
+    if estimated <= 0:
+        return False
+    identity = id(model)
+    with _RESERVATION_LOCK:
+        current = _RESERVATIONS.get(identity)
+        if current is not None and current[0]() is model:
+            return True
+        if _CACHE_LIMIT_BASE_BYTES is None:
+            logger.info(
+                "DSV4 exact lm_head cache skipped: allocator budget was not configured"
+            )
+            return False
+        projected = _reservation_bytes_locked() + estimated
+        floor = _allocator_floor_bytes_locked()
+        if _CACHE_LIMIT_BASE_BYTES - projected < floor:
+            logger.info(
+                "DSV4 exact lm_head cache skipped: %.2f GB reservation would "
+                "reduce the MLX cache below its %.2f GB safety floor",
+                estimated / 1024**3,
+                floor / 1024**3,
+            )
+            return False
+
+        def _release(reference: weakref.ReferenceType[Any]) -> None:
+            _release_cache_reservation(identity, reference)
+
+        reference = weakref.ref(model, _release)
+        _RESERVATIONS[identity] = (reference, estimated)
+        try:
+            _apply_allocator_limit_locked()
+        except Exception as exc:
+            _RESERVATIONS.pop(identity, None)
+            logger.warning("Could not reserve the DSV4 MLX cache budget: %s", exc)
+            return False
+    return True
+
+
+def _release_model_cache(model: Any, config: _HeadConfig, reason: str) -> None:
+    config.disabled_reason = reason
+    config.weight = None
+    config.reservation_bytes = 0
+    _release_cache_reservation(id(model))
+
+
+def _parameter_bytes(model: Any) -> int:
+    parameters = getattr(model, "parameters", None)
+    if not callable(parameters) or mx is None:
+        return 0
+    try:
+        from mlx.utils import tree_flatten
+    except ImportError:
+        return 0
+    total = 0
+    seen: set[int] = set()
+    for item in tree_flatten(parameters()):
+        value = item[-1] if isinstance(item, tuple) else item
+        identity = id(value)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        total += int(getattr(value, "nbytes", 0) or 0)
+    return total
+
+
+def _cache_admitted(model: Any, estimated: int) -> bool:
+    maximum_gb = _positive_float_env("VMLX_DSV4_LM_HEAD_CACHE_MAX_GB", 4.0)
+    reserve_gb = _positive_float_env("VMLX_DSV4_LM_HEAD_CACHE_RESERVE_GB", 4.0)
+    if estimated <= 0 or estimated > maximum_gb * 1024**3:
+        return False
+    try:
+        from ..utils.memory_limits import get_effective_metal_working_set_bytes
+
+        active, maximum = get_effective_metal_working_set_bytes(mx)
+    except Exception as exc:
+        logger.info("DSV4 exact lm_head cache skipped: headroom lookup failed: %s", exc)
+        return False
+    parameters = _parameter_bytes(model)
+    if maximum <= 0 or parameters <= 0:
+        return False
+    projected = max(int(active), parameters) + estimated + int(reserve_gb * 1024**3)
+    admitted = projected <= int(maximum * 0.98)
+    if not admitted:
+        logger.info(
+            "DSV4 exact lm_head cache skipped: projected %.2f GB exceeds "
+            "safe %.2f GB working-set bound",
+            projected / 1024**3,
+            maximum * 0.98 / 1024**3,
+        )
+    return admitted
+
+
+def _materialize_weight(head: Any) -> Any:
+    weight = mx.dequantize(
+        head.weight,
+        head.scales,
+        getattr(head, "biases", None),
+        group_size=head.group_size,
+        bits=head.bits,
+        mode=getattr(head, "mode", "affine"),
+    ).astype(mx.float32)
+    mx.eval(weight)
+    return weight
+
+
+def _install_class_wrapper(model_class: type) -> bool:
+    existing = _CLASS_PATCHES.get(model_class)
+    if existing is not None:
+        return model_class.__call__ is existing[1]
+
+    original_call = model_class.__call__
+
+    def _guarded_call(
+        self: Any,
+        input_ids: Any,
+        cache: Any = None,
+        mask: Any = None,
+    ) -> Any:
+        config = _CONFIGS.get(self)
+        head = getattr(self, "lm_head", None)
+        if config is None:
+            return original_call(self, input_ids, cache=cache, mask=mask)
+        if not _enabled():
+            _release_model_cache(self, config, "disabled by VMLX_DSV4_LM_HEAD_MODE")
+            return original_call(self, input_ids, cache=cache, mask=mask)
+        if head is None or _head_signature(head) != config.signature:
+            _release_model_cache(self, config, "lm_head parameters changed")
+            return original_call(self, input_ids, cache=cache, mask=mask)
+        if config.disabled_reason is not None or config.weight is None:
+            return original_call(self, input_ids, cache=cache, mask=mask)
+
+        hidden = self.model(input_ids, cache=cache, mask=mask)
+        try:
+            logits = hidden.astype(mx.float32) @ config.weight.T
+            # Materialize the first matrix multiplication so any runtime
+            # mismatch falls back against this hidden state, never by replaying
+            # the mutable request cache.
+            if not config.validated:
+                mx.eval(logits)
+                config.validated = True
+            return logits
+        except Exception as exc:
+            reason = f"{type(exc).__name__}: {exc}"
+            _release_model_cache(self, config, reason)
+            logger.warning(
+                "DSV4 exact lm_head cache disabled after validation failure; "
+                "using the reference projection without replaying the model: %s",
+                exc,
+            )
+            return _reference_logits(hidden, head)
+
+    model_class.__call__ = _guarded_call
+    model_class._vmlx_dsv4_lm_head_original_call = original_call
+    model_class._vmlx_dsv4_lm_head_fastpath = True
+    _CLASS_PATCHES[model_class] = (original_call, _guarded_call)
+    return True
+
+
+def install_dsv4_lm_head_fastpath(model: Any) -> bool:
+    """Register one validated DSV4 model instance for exact cached dispatch."""
+
+    if mx is None or not _enabled() or _model_type(model) != "deepseek_v4":
+        return False
+    try:
+        signature = _validate_head(getattr(model, "lm_head", None))
+    except (AttributeError, TypeError, ValueError) as exc:
+        logger.info("DSV4 exact lm_head cache not installed: %s", exc)
+        return False
+    existing = _CONFIGS.get(model)
+    if (
+        existing is not None
+        and existing.signature == signature
+        and existing.weight is not None
+        and existing.disabled_reason is None
+    ):
+        return True
+    if existing is not None:
+        _release_model_cache(model, existing, "lm_head cache was reconfigured")
+    head = model.lm_head
+    estimated = _estimated_cache_bytes(head)
+    if not _cache_admitted(model, estimated):
+        return False
+    if not _reserve_allocator_cache(model, estimated):
+        return False
+    try:
+        cached_weight = _materialize_weight(head)
+    except Exception as exc:
+        _release_cache_reservation(id(model))
+        logger.warning("DSV4 exact lm_head cache materialization failed: %s", exc)
+        return False
+    if not _install_class_wrapper(type(model)):
+        _release_cache_reservation(id(model))
+        logger.warning("DSV4 exact lm_head class wrapper was replaced; using native")
+        return False
+    _CONFIGS[model] = _HeadConfig(
+        signature=signature,
+        weight=cached_weight,
+        reservation_bytes=estimated,
+    )
+    logger.info(
+        "DSV4 exact dequantized lm_head cache enabled for one validated model "
+        "instance (%.2f GB)",
+        estimated / 1024**3,
+    )
+    return True
+
+
+def dsv4_lm_head_fastpath_status(model: Any) -> dict[str, Any]:
+    """Return authoritative instance registration state for reports/tests."""
+
+    config = _CONFIGS.get(model)
+    return {
+        "installed": config is not None,
+        "validated": bool(config and config.validated),
+        "disabled_reason": config.disabled_reason if config else None,
+        "cache_bytes": int(getattr(config.weight, "nbytes", 0) or 0) if config else 0,
+        "reservation_bytes": config.reservation_bytes if config else 0,
+        "allocator_cache_limit_bytes": _CACHE_LIMIT_EFFECTIVE_BYTES,
+    }
+
+
+__all__ = [
+    "configure_dsv4_lm_head_cache_budget",
+    "dsv4_lm_head_fastpath_status",
+    "install_dsv4_lm_head_fastpath",
+]

--- a/vmlx_engine/models/dsv4_rope_cache.py
+++ b/vmlx_engine/models/dsv4_rope_cache.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded, exact RoPE table sharing for validated DeepSeek-V4 instances."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import weakref
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    import mlx.core as mx
+except ImportError:  # pragma: no cover - non-Apple package inspection
+    mx = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+_DEFAULT_MAX_ENTRIES = 64
+_DEFAULT_MAX_TOKENS = 4096
+
+
+def _positive_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, str(default))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid %s=%r", name, raw)
+        return default
+    if value <= 0:
+        logger.warning("Ignoring non-positive %s=%r", name, raw)
+        return default
+    return value
+
+
+def _enabled() -> bool:
+    value = os.environ.get("VMLX_DSV4_ROPE_CACHE", "1")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class _TableGroup:
+    signature: tuple[float, ...]
+    tables: OrderedDict[tuple[int, int, str], tuple[Any, Any]] = field(
+        default_factory=OrderedDict
+    )
+    registrations: int = 0
+    lock: threading.RLock = field(default_factory=threading.RLock)
+
+
+class _WeakIdentityMap:
+    def __init__(self) -> None:
+        self._items: dict[int, tuple[weakref.ReferenceType[Any], _TableGroup]] = {}
+
+    def __setitem__(self, owner: Any, group: _TableGroup) -> None:
+        identity = id(owner)
+        items = self._items
+        current = items.get(identity)
+        if current is not None and current[0]() is owner:
+            if current[1] is group:
+                return
+            _release_group(current[1])
+
+        def _remove(reference: weakref.ReferenceType[Any]) -> None:
+            current = items.get(identity)
+            if current is not None and current[0] is reference:
+                items.pop(identity, None)
+                _release_group(current[1])
+
+        self._items[identity] = (weakref.ref(owner, _remove), group)
+        with _GROUP_LOCK:
+            group.registrations += 1
+
+    def get(self, owner: Any) -> _TableGroup | None:
+        entry = self._items.get(id(owner))
+        if entry is None or entry[0]() is not owner:
+            return None
+        return entry[1]
+
+
+_CONFIGS = _WeakIdentityMap()
+_GROUPS: dict[tuple[float, ...], _TableGroup] = {}
+_GROUP_LOCK = threading.RLock()
+_CLASS_PATCHES: dict[type, tuple[Any, Any]] = {}
+
+
+def _release_group(group: _TableGroup) -> None:
+    with _GROUP_LOCK:
+        group.registrations = max(0, group.registrations - 1)
+        if group.registrations == 0 and _GROUPS.get(group.signature) is group:
+            _GROUPS.pop(group.signature, None)
+            group.tables.clear()
+
+
+def _table_group(signature: tuple[float, ...]) -> _TableGroup:
+    with _GROUP_LOCK:
+        group = _GROUPS.get(signature)
+        if group is None:
+            group = _TableGroup(signature=signature)
+            _GROUPS[signature] = group
+        return group
+
+
+def _frequency_signature(rope: Any) -> tuple[float, ...]:
+    return tuple(float(value) for value in rope.inv_freq.tolist())
+
+
+def _rotate_with_tables(x: Any, cos: Any, sin: Any, inverse: bool) -> Any:
+    broadcast_shape = (1,) * (x.ndim - 2) + cos.shape
+    cos = cos.reshape(broadcast_shape)
+    sin = sin.reshape(broadcast_shape)
+    if inverse:
+        sin = -sin
+    reshaped = x.reshape(*x.shape[:-1], x.shape[-1] // 2, 2)
+    x0, x1 = reshaped[..., 0], reshaped[..., 1]
+    out = mx.stack([x0 * cos - x1 * sin, x0 * sin + x1 * cos], axis=-1)
+    return out.reshape(*out.shape[:-2], out.shape[-2] * 2)
+
+
+def _install_class_wrapper(rope_class: type) -> bool:
+    existing = _CLASS_PATCHES.get(rope_class)
+    if existing is not None:
+        return rope_class.__call__ is existing[1]
+
+    original_call = rope_class.__call__
+
+    def _cached_call(
+        self: Any,
+        x: Any,
+        offset: int = 0,
+        inverse: bool = False,
+        positions: Any = None,
+    ) -> Any:
+        group = _CONFIGS.get(self)
+        length = int(x.shape[-2]) if getattr(x, "ndim", 0) >= 2 else 0
+        width = int(x.shape[-1]) if getattr(x, "ndim", 0) >= 1 else 0
+        expected_width = int(getattr(self.inv_freq, "shape", (0,))[0]) * 2
+        if (
+            group is None
+            or not _enabled()
+            or positions is not None
+            or length <= 0
+            or width != expected_width
+            or length
+            > _positive_env("VMLX_DSV4_ROPE_CACHE_MAX_TOKENS", _DEFAULT_MAX_TOKENS)
+        ):
+            return original_call(
+                self,
+                x,
+                offset=offset,
+                inverse=inverse,
+                positions=positions,
+            )
+
+        key = (int(offset), length, str(x.dtype))
+        try:
+            with group.lock:
+                entry = group.tables.get(key)
+                if entry is None:
+                    pos = mx.arange(offset, offset + length, dtype=mx.float32)
+                    freqs = pos[:, None] * self.inv_freq[None, :]
+                    cos = mx.cos(freqs).astype(x.dtype)
+                    sin = mx.sin(freqs).astype(x.dtype)
+                    mx.eval(cos, sin)
+                    entry = (cos, sin)
+                    maximum = _positive_env(
+                        "VMLX_DSV4_ROPE_CACHE_MAX_ENTRIES",
+                        _DEFAULT_MAX_ENTRIES,
+                    )
+                    while len(group.tables) >= maximum:
+                        group.tables.popitem(last=False)
+                    group.tables[key] = entry
+                else:
+                    group.tables.move_to_end(key)
+            return _rotate_with_tables(x, entry[0], entry[1], inverse)
+        except Exception as exc:
+            logger.warning("DSV4 RoPE table cache miss failed; using reference path: %s", exc)
+            return original_call(
+                self,
+                x,
+                offset=offset,
+                inverse=inverse,
+                positions=positions,
+            )
+
+    rope_class.__call__ = _cached_call
+    rope_class._vmlx_dsv4_rope_original_call = original_call
+    rope_class._vmlx_dsv4_rope_cache = True
+    _CLASS_PATCHES[rope_class] = (original_call, _cached_call)
+    return True
+
+
+def _install_for_class(model: Any, rope_class: type) -> int:
+    named_modules = getattr(model, "named_modules", None)
+    if not callable(named_modules):
+        return 0
+    ropes = [module for _name, module in list(named_modules()) if isinstance(module, rope_class)]
+    if not ropes or not _install_class_wrapper(rope_class):
+        return 0
+    registered = 0
+    for rope in ropes:
+        try:
+            signature = _frequency_signature(rope)
+        except Exception as exc:
+            logger.info("DSV4 RoPE instance not cached: %s", exc)
+            continue
+        group = _table_group(signature)
+        _CONFIGS[rope] = group
+        registered += 1
+    return registered
+
+
+def install_dsv4_rope_cache(model: Any) -> int:
+    """Register exact DSV4 RoPE instances for bounded table sharing."""
+
+    if mx is None or not _enabled():
+        return 0
+    from jang_tools.dsv4.mlx_model import DeepseekV4RoPE
+
+    registered = _install_for_class(model, DeepseekV4RoPE)
+    if registered:
+        logger.info("DSV4 exact RoPE table sharing enabled for %d instances", registered)
+    return registered
+
+
+def dsv4_rope_cache_status(model: Any) -> dict[str, int]:
+    named_modules = getattr(model, "named_modules", None)
+    if not callable(named_modules):
+        return {"registered_instances": 0, "table_entries": 0}
+    groups: dict[int, _TableGroup] = {}
+    registered = 0
+    for _name, module in list(named_modules()):
+        group = _CONFIGS.get(module)
+        if group is None:
+            continue
+        registered += 1
+        groups[id(group)] = group
+    return {
+        "registered_instances": registered,
+        "table_entries": sum(len(group.tables) for group in groups.values()),
+    }
+
+
+__all__ = ["dsv4_rope_cache_status", "install_dsv4_rope_cache"]


### PR DESCRIPTION
Supersedes #248 with a clean implementation on current `main`.

## What changed

- Cache the exact dequantized FP32 DSV4 vocabulary head once, then reuse the same FP32 matmul as JANG.
- Gate the cache on model geometry, effective Metal headroom, and a 4 GiB allocator safety floor.
- Deduct the persistent head bytes from the existing MLX allocator-cache ceiling. On the tested model, the 2,118,123,520-byte head lowers the ceiling from 24,739,011,624 to 22,620,888,104 bytes rather than expanding the runtime memory envelope.
- Scope dispatch to weakly registered model instances. Reconfiguration, unload, env disablement, or validation failure releases the reservation.
- Fall back from the already-computed hidden state, so a failure never replays the transformer or advances a mutable request cache twice.
- Share the existing exact manual RoPE tables only across validated equal-frequency instances, with bounded LRU tables and weak cleanup.
- Add a checkout-pinned native-versus-optimized acceptance suite and sealed, public-safe raw reports.

This intentionally does **not** promote compiled MoE, unused-indexer mutation, native RoPE, the 512-token layerwise-prefill threshold, or the old custom affine microbenchmark. The guarded affine Metal path already on `main` remains separately controlled.

## Rejected during iteration

- Direct quantized-head dispatch was faster but changed the 1,000-token stream hash.
- A cached FP16 head preserved hashes but produced severe residency stalls.
- An FP32 cache without allocator reservation was exact but intermittently collapsed to ~0.8-1.2 tok/s at 400/512-token prompts.
- Early benchmark runs could import the installed vMLX package instead of the checkout. The harness now pins and verifies its source root.
- Native runs can also show allocator cliffs. Acceptance rejects both repeat-level tails and consistently pathological context bands; it cannot use an unstable native run to inflate candidate ratios.
- A synthetic allocator-cold protocol was tested and rejected because it made short decode consistently pathological. The accepted matrix is warm and sequential, matching the runtime environment.

## Sealed result

Implementation commit: `15e9420db804cfa81167acaceae13476d856a7b5`.

Bundle identity: `OsaurusAI__DeepSeek-V4-Flash-0731-JANG`, 102 shards / 101,982,500,132 bytes, manifest `fc68310e3b81ccbf5b86b9c28929b629dd89fa204d5de563d5442b13f6f2978c`.

Hardware/runtime: arm64 macOS 26.5.1, MLX 0.32.0, mlx-lm 0.31.3, JANG 2.5.39, vMLX 1.6.22.

| Case | Decode ratio | Slowest-sample ratio | Prefill ratio | Exact hash |
|---|---:|---:|---:|:---:|
| p256 / 30 | 1.293x | 1.227x | 0.983x | yes |
| p400 / 30 | 1.241x | 1.210x | 0.996x | yes |
| p512 / 30 | 1.195x | 1.185x | 0.997x | yes |
| p1024 / 30 | 1.186x | 1.184x | 1.021x | yes |
| p2048 / 30 | 1.315x | 1.325x | 1.008x | yes |
| p256 / 1000 | 1.273x | 1.273x | 1.057x | yes |

Raw reports:

- `reports/pr249/dsv4-native-15e9420d.json`
- `reports/pr249/dsv4-optimized-15e9420d.json`

Both reports identify implementation commit `15e9420d`. Baseline compatibility, feature-state proof, bundle/source identity, exact hashes, repeat-tail checks, cross-context sanity, and performance thresholds all pass. Reports contain no machine-local paths.

## Public repository hygiene

The branch was rewritten before republishing so the forbidden development-doc path and private report paths are absent from its public history. The CI baseline repair:

- exact-allowlists only the two DSV4 contract documents already present on public refs;
- sanitizes six pre-existing machine-specific path literals instead of exempting private paths;
- adds a regression test for the exact allowlist;
- passes `scripts/check-public-repo-hygiene.sh` locally against all advertised public refs.

## Validation

- `301 passed, 2 skipped` across all DSV4 unit/regression tests, the answer-pass family, and public-hygiene tests
- Ruff: clean on all new/modified Python candidate, harness, probe, and test files
- Compileall: clean
- Full public-repository hygiene script: pass
- `git diff --check origin/main...HEAD`: clean
- Private-path scan over the PR diff: clean
- Panel Vitest was unavailable locally because `panel/node_modules` is not installed; the affected test only replaces a hard-coded private missing path with an equivalent `os.tmpdir()` path.
