### PR TITLE
Register the MiniCPM text family

### DIFF
--- a/panel/src/main/model-config-registry.ts
+++ b/panel/src/main/model-config-registry.ts
@@ -301,6 +301,10 @@ registerFamily('starcoder', { cacheType: 'kv', description: 'StarCoder', priorit
 registerFamily('stablelm', { cacheType: 'kv', description: 'StableLM', priority: 30 })
 registerFamily('baichuan', { cacheType: 'kv', description: 'Baichuan', priority: 30 })
 
+// Plain-text MiniCPM. MLX-LM already ships the runtime model; this row only
+// declares the vMLX family/session policy and stays separate from MiniCPM-V.
+registerFamily('minicpm', { cacheType: 'kv', supportsThinking: false, isMultimodal: false, description: 'MiniCPM text', priority: 20 })
+
 // VLM / MLLM models
 registerFamily('yi-vl', { cacheType: 'kv', isMultimodal: true, description: 'Yi Vision-Language', priority: 15 })
 registerFamily('llava', { cacheType: 'kv', isMultimodal: true, description: 'LLaVA vision-language', priority: 20 })
@@ -477,6 +481,7 @@ const MODEL_TYPE_TO_FAMILY: Record<string, string> = {
   'florence2': 'florence',
   'got_ocr2': 'got-ocr',
   'molmo': 'molmo',
+  'minicpm': 'minicpm',
   'minicpmv': 'minicpm-v',
   'smolvlm': 'smolvlm',
   'internvl_chat': 'internvl',

--- a/panel/src/renderer/src/components/sessions/SessionConfigForm.tsx
+++ b/panel/src/renderer/src/components/sessions/SessionConfigForm.tsx
@@ -216,7 +216,7 @@ export const MODEL_FAMILY_OVERRIDE_NAMES: string[] = [
   'gemma', 'gemma3', 'gemma3_text', 'gemma4', 'gemma4_text', 'medgemma',
   'phi4', 'phi4_reasoning', 'phi4_multimodal', 'phi3',
   'nemotron', 'nemotron_h', 'cohere', 'granite', 'granitemoehybrid', 'lfm2',
-  'minimax', 'kimi', 'kimi_k25', 'ling', 'zaya', 'zaya1_vl', 'mimo_v2',
+  'minimax', 'minicpm', 'kimi', 'kimi_k25', 'ling', 'zaya', 'zaya1_vl', 'mimo_v2',
   'hy_v3', 'step', 'step_vl', 'step3p7', 'hermes', 'mamba', 'jamba',
   'openpangu_v2',
 ]
@@ -350,6 +350,7 @@ export function SessionConfigForm({ config, onChange, onReset, detectedCacheType
   const normalizedEffectiveFamily = normalizeDetectedFamilyName(
     resolveEffectiveModelFamily(config.modelFamily, normalizedDetectedFamily),
   )
+  const minicpmCacheCodecRestricted = normalizedEffectiveFamily === 'minicpm'
   const dsv4Active = normalizedEffectiveFamily === 'deepseek-v4'
   const m3Active = normalizedDetectedFamily === 'minimax_m3'
   const hy3Active = normalizedDetectedFamily === 'hy_v3' || normalizedDetectedFamily === 'hy3'
@@ -449,7 +450,9 @@ export function SessionConfigForm({ config, onChange, onReset, detectedCacheType
   // "Auto / TurboQuant" when the runtime contract is intentionally "None".
   const effectiveStoredCacheQuantization = openPanguExactTypedCache
     ? 'none'
-    : nativeTypedCacheOwnsStoredCodec ? 'auto' : config.kvCacheQuantization
+    : minicpmCacheCodecRestricted && (config.kvCacheQuantization === 'q4' || config.kvCacheQuantization === 'q8')
+      ? 'auto'
+      : nativeTypedCacheOwnsStoredCodec ? 'auto' : config.kvCacheQuantization
   const explicitStoredCacheCodec = effectiveStoredCacheQuantization !== 'auto'
   const liveCacheCodecLabel = openPanguExactTypedCache
     ? 'openPangu typed composite cache'
@@ -620,6 +623,15 @@ export function SessionConfigForm({ config, onChange, onReset, detectedCacheType
       refreshMcpStatus()
     }
   }, [expandedSections.tools, sessionId])
+
+  useEffect(() => {
+    if (
+      minicpmCacheCodecRestricted &&
+      (config.kvCacheQuantization === 'q4' || config.kvCacheQuantization === 'q8')
+    ) {
+      onChange('kvCacheQuantization', 'auto')
+    }
+  }, [minicpmCacheCodecRestricted, config.kvCacheQuantization, onChange])
 
   const joinPolicyList = (values: Iterable<string>) => Array.from(values).sort().join('\n')
   const policyServers = normalizeMcpPolicyList(config.mcpEnabledServers)
@@ -1147,6 +1159,7 @@ export function SessionConfigForm({ config, onChange, onReset, detectedCacheType
         {!effectivelyNoBatching && dsv4Active && <PerformanceHint text="DeepSeek-V4 keeps generic TurboQuant KV q4/q8 disabled. Prefix RAM/SSD records preserve native SWA+CSA/HCA state, while CSA/HCA pool quantization is read from the loaded bundle rather than a generic cache-codec override." />}
         {!effectivelyNoBatching && m3Active && <PerformanceHint text="MiniMax-M3 keeps generic KV q4/q8 disabled. Prefix reuse uses native MSA snapshots with keys, values, idx_keys, and absolute offsets; generic stored-KV codecs cannot preserve that cache format." />}
         {!effectivelyNoBatching && openPanguExactTypedCache && <PerformanceHint text="openPangu keeps generic KV q4/q8 disabled. Its exact typed snapshot owns MLA KV, DSA indexer, rotating-SWA metadata, and causal-convolution state as one full-precision record." />}
+        {!effectivelyNoBatching && minicpmCacheCodecRestricted && <PerformanceHint text="MiniCPM keeps generic KV q4/q8 disabled because live source-artifact validation reproduced cold/warm output divergence. Auto uses native raw KV; None explicitly disables cache quantization." />}
         {/* Live/native cache codec — automatic per architecture. */}
         <div className="block">
           <span className="text-xs font-medium text-muted-foreground">
@@ -1197,8 +1210,8 @@ export function SessionConfigForm({ config, onChange, onReset, detectedCacheType
           <select value={effectiveStoredCacheQuantization} onChange={e => onChange('kvCacheQuantization', e.target.value)} className="cfg-input" disabled={effectivelyNoBatching || prefixOff || nativeTypedCacheOwnsStoredCodec}>
             <option value="auto">{dsv4Active ? 'Native typed codec (bundle-derived)' : 'Auto (engine-selected: native/TurboQuant + stored fallback)'}</option>
             <option value="none">{t('sessions.config.kvQuantNone')}</option>
-            <option value="q8">q8 (8-bit, ~2x stored cache savings)</option>
-            <option value="q4">q4 (4-bit, ~4x stored cache savings)</option>
+            {!minicpmCacheCodecRestricted && <option value="q8">q8 (8-bit, ~2x stored cache savings)</option>}
+            {!minicpmCacheCodecRestricted && <option value="q4">q4 (4-bit, ~4x stored cache savings)</option>}
           </select>
         </div>
         {effectiveStoredCacheQuantization !== 'auto' && effectiveStoredCacheQuantization !== 'none' && (

--- a/panel/tests/comprehensive-audit.test.ts
+++ b/panel/tests/comprehensive-audit.test.ts
@@ -122,6 +122,7 @@ const MODEL_TYPE_TO_FAMILY: Record<string, string> = {
   cogvlm2: "cogvlm",
   florence2: "florence",
   molmo: "molmo",
+  minicpm: "minicpm",
   minicpmv: "minicpm-v",
   smolvlm: "smolvlm",
   internvl_chat: "internvl",

--- a/panel/tests/model-config-registry.test.ts
+++ b/panel/tests/model-config-registry.test.ts
@@ -1672,6 +1672,7 @@ describe('detectModelConfigFromDir backend parity coverage', () => {
     { modelType: 'ministral3', family: 'ministral3', cacheType: 'kv', toolParser: 'mistral' },
     { modelType: 'mistral3', family: 'mistral3', cacheType: 'kv', toolParser: 'mistral', isMultimodal: true },
     { modelType: 'mistral4', family: 'mistral4', cacheType: 'kv', toolParser: 'mistral', reasoningParser: 'mistral' },
+    { modelType: 'minicpm', family: 'minicpm', cacheType: 'kv', isMultimodal: false },
     { modelType: 'mimo_v2', family: 'mimo_v2', cacheType: 'kv', toolParser: 'xml_function', reasoningParser: 'think_xml', isMultimodal: true },
     { modelType: 'nanbeige', family: 'nanbeige', cacheType: 'kv', toolParser: 'xml_function', reasoningParser: 'qwen3', isMultimodal: false },
     { modelType: 'nemotron_h_v2', family: 'nemotron-h', cacheType: 'hybrid', toolParser: 'nemotron', reasoningParser: 'deepseek_r1', cacheSubtype: 'nemotron_h_ssm_attention' },

--- a/tests/test_cache_contract_tokenizer_owner.py
+++ b/tests/test_cache_contract_tokenizer_owner.py
@@ -44,3 +44,28 @@ def test_cache_contract_identity_uses_live_scheduler_tokenizer(monkeypatch):
     assert identity["tokenizer_source"] == "llm_scheduler_tokenizer"
     assert scheduler_tokenizer.calls == [("rendered prompt", False)]
     assert fallback_tokenizer.calls == []
+
+
+def test_batched_chat_encoding_honors_family_special_token_policy(monkeypatch):
+    tokenizer = _RecordingTokenizer([1, 2])
+    engine = object.__new__(BatchedEngine)
+    engine._model_name = "/models/minicpm"
+    registry = SimpleNamespace(
+        get_architecture_hints=lambda _path: {
+            "chat_encode_add_special_tokens": True
+        }
+    )
+    monkeypatch.setattr(
+        batched_module,
+        "get_model_config_registry",
+        lambda: registry,
+    )
+
+    token_ids = engine._encode_rendered_prompt(
+        tokenizer.encode,
+        "rendered prompt",
+        engine._chat_encode_add_special_tokens(),
+    )
+
+    assert token_ids == [1, 2]
+    assert tokenizer.calls == [("rendered prompt", True)]

--- a/tests/test_engine_audit.py
+++ b/tests/test_engine_audit.py
@@ -3496,7 +3496,7 @@ class TestStandardArchitectures:
     def test_common_types_in_standard_architectures(self):
         from vmlx_engine.utils.tokenizer import _STANDARD_ARCHITECTURES
         common = ["llama", "qwen2", "qwen3", "gemma2", "gemma3", "mistral",
-                  "deepseek_v3", "phi3"]
+                  "deepseek_v3", "phi3", "minicpm"]
         for t in common:
             assert t in _STANDARD_ARCHITECTURES, \
                 f"model_type '{t}' missing from _STANDARD_ARCHITECTURES"
@@ -8341,6 +8341,47 @@ class TestStartupCompatibilityGuards:
 
         assert tokenizer._register_mimo_v2_runtime_for_mlx_lm() is False
         assert seen == ["jang_tools.mimo_v2.mlx_register", "mlx_lm.models.mimo_v2"]
+
+    def test_load_model_with_fallback_applies_authoritative_minicpm_defaults(
+        self, tmp_path, monkeypatch
+    ):
+        import mlx_lm
+
+        from vmlx_engine.model_config_registry import get_model_config_registry
+        from vmlx_engine.utils import tokenizer
+
+        raw_config = {"architectures": ["MiniCPMForCausalLM"]}
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(raw_config))
+        loaded = (object(), SimpleNamespace(chat_template="present"))
+        seen = {}
+
+        def fake_load(*args, **kwargs):
+            seen.update(kwargs)
+            return loaded
+
+        monkeypatch.setattr(mlx_lm, "load", fake_load)
+        monkeypatch.setattr(
+            tokenizer, "_inject_chat_template_if_missing", lambda *_: None
+        )
+        registry = get_model_config_registry()
+        registry.set_family_override("minicpm")
+        try:
+            assert tokenizer.load_model_with_fallback(
+                str(tmp_path), skip_turboquant=True
+            ) == loaded
+        finally:
+            registry.set_family_override(None)
+
+        assert seen["model_config"] == {
+            "model_type": "minicpm",
+            "rope_theta": 10_000.0,
+        }
+        assert json.loads(config_path.read_text()) == raw_config
+        assert tokenizer._minicpm_model_config_override(raw_config, "unknown") is None
+        assert tokenizer._minicpm_model_config_override(
+            {"model_type": "llama"}, "minicpm"
+        ) is None
 
     def test_mllm_registers_mimo_v2_before_mlx_vlm_resolution(
         self, tmp_path, monkeypatch

--- a/tests/test_jang_loader.py
+++ b/tests/test_jang_loader.py
@@ -79,6 +79,25 @@ class TestJangDetection:
         assert config["text_config"]["final_logit_softcapping"] == 30.0
         assert type(config["text_config"]["final_logit_softcapping"]) is float
 
+    def test_minicpm_defaults_follow_authoritative_jang_family(self):
+        from vmlx_engine.utils.jang_loader import _apply_minicpm_config_defaults
+
+        config = {"architectures": ["MiniCPMForCausalLM"]}
+        _apply_minicpm_config_defaults(
+            config,
+            {"capabilities": {"family": "minicpm"}},
+        )
+
+        assert config["model_type"] == "minicpm"
+        assert config["rope_theta"] == 10_000.0
+
+        unrelated = {"model_type": "llama"}
+        _apply_minicpm_config_defaults(
+            unrelated,
+            {"capabilities": {"family": "minicpm"}},
+        )
+        assert unrelated == {"model_type": "llama"}
+
     def test_gemma4_processor_path_uses_temporary_normalized_config(self, tmp_path):
         from vmlx_engine.utils.jang_loader import _prepare_gemma4_processor_model_path
 

--- a/tests/test_model_config_registry.py
+++ b/tests/test_model_config_registry.py
@@ -1923,6 +1923,23 @@ class TestModelConfigs:
         config = self._lookup(registry, "allenai/Molmo-7B", "molmo")
         assert config.is_mllm is True
 
+    def test_minicpm_text_config(self, registry):
+        config = self._lookup(registry, "openbmb/MiniCPM4-0.5B", "minicpm")
+
+        assert config.family_name == "minicpm"
+        assert config.cache_type == "kv"
+        assert config.tool_parser is None
+        assert config.reasoning_parser is None
+        assert config.supports_native_tools is False
+        assert config.supports_thinking is False
+        assert config.is_mllm is False
+        assert config.architecture_hints == {
+            "attention_arch": "full_attention_kv",
+            "live_turboquant_default": False,
+            "blocked_kv_cache_storage_quantizations": ["q4", "q8"],
+            "chat_encode_add_special_tokens": True,
+        }
+
     def test_minicpm_v_config(self, registry):
         config = self._lookup(registry, "openbmb/MiniCPM-V-2_6", "minicpmv")
         assert config.is_mllm is True

--- a/tests/test_turboquant_cache_contract.py
+++ b/tests/test_turboquant_cache_contract.py
@@ -214,6 +214,45 @@ def test_minimax_m3_native_msa_disables_tq_for_live_and_persisted_cache(
     assert os.environ.get("VMLX_FORCE_TQ_AUTO") is None
 
 
+def test_minicpm_requires_native_raw_kv(monkeypatch):
+    from types import SimpleNamespace
+
+    from vmlx_engine.cli import MiniCPMCachePolicyError, _apply_minicpm_cache_policy
+
+    config = SimpleNamespace(
+        family_name="minicpm",
+        architecture_hints={
+            "blocked_kv_cache_storage_quantizations": ["q4", "q8"]
+        },
+    )
+    auto = SimpleNamespace(
+        kv_cache_quantization="q4",
+        kv_cache_quantization_explicit=False,
+    )
+    monkeypatch.setenv("VMLX_FORCE_TQ_AUTO", "1")
+
+    assert _apply_minicpm_cache_policy(
+        auto,
+        config,
+        __import__("logging").getLogger("test"),
+    )
+    assert auto.kv_cache_quantization == "none"
+    assert os.environ["VMLX_DISABLE_TQ_KV"] == "1"
+    assert "VMLX_FORCE_TQ_AUTO" not in os.environ
+
+    for codec in ("q4", "q8"):
+        explicit = SimpleNamespace(
+            kv_cache_quantization=codec,
+            kv_cache_quantization_explicit=True,
+        )
+        with pytest.raises(MiniCPMCachePolicyError, match=codec):
+            _apply_minicpm_cache_policy(
+                explicit,
+                config,
+                __import__("logging").getLogger("test"),
+            )
+
+
 def test_mimo_v2_auto_mode_keeps_prefix_cache_lossless_by_default(tmp_path, monkeypatch):
     """MiMo mixed-SWA cache must not use lossy stored q4 in auto mode."""
 

--- a/vmlx_engine/cli.py
+++ b/vmlx_engine/cli.py
@@ -23,6 +23,10 @@ DEFAULT_MAX_OUTPUT_TOKENS = 4096
 DEFAULT_MAX_OUTPUT_TOKENS_REASONING = DEFAULT_MAX_OUTPUT_TOKENS * 4
 
 
+class MiniCPMCachePolicyError(ValueError):
+    """Raised when MiniCPM is launched with an unsafe stored-KV codec."""
+
+
 def _env_truthy(name: str) -> bool:
     return os.environ.get(name, "").lower() in ("1", "true", "yes", "on")
 
@@ -53,6 +57,37 @@ def _split_cli_values(values: list[str] | None) -> list[str]:
             if item:
                 out.append(item)
     return out
+
+
+def _apply_minicpm_cache_policy(args, model_config, logger) -> bool:
+    """Keep MiniCPM on the cache mode cleared by live validation."""
+    hints = dict(getattr(model_config, "architecture_hints", None) or {})
+    family = str(getattr(model_config, "family_name", "unknown") or "unknown")
+    if family != "minicpm":
+        return False
+
+    selected = str(
+        getattr(args, "kv_cache_quantization", "none") or "none"
+    ).strip().lower()
+    blocked = set(hints.get("blocked_kv_cache_storage_quantizations") or ())
+    if getattr(args, "kv_cache_quantization_explicit", False):
+        if selected in blocked:
+            raise MiniCPMCachePolicyError(
+                "MiniCPM blocks explicit --kv-cache-quantization "
+                f"{selected}: source-model validation reproduced cold/warm "
+                "output divergence. Use automatic mode or "
+                "--kv-cache-quantization none."
+            )
+        return True
+
+    args.kv_cache_quantization = "none"
+    os.environ["VMLX_DISABLE_TQ_KV"] = "1"
+    os.environ.pop("VMLX_FORCE_TQ_AUTO", None)
+    logger.info(
+        "MiniCPM cache policy: automatic mode uses native raw KV because "
+        "source-model validation reproduced cold/warm divergence with q4/q8"
+    )
+    return True
 
 
 def _parse_lora_scales(values: list[str] | None) -> list[float] | None:
@@ -1003,6 +1038,7 @@ def serve_command(args):
     try:
         from .model_config_registry import get_model_config_registry
         _mc = get_model_config_registry().lookup(args.model)
+        _apply_minicpm_cache_policy(args, _mc, logger)
         # SSM disk restore remains governed by the explicit
         # VMLX_DISABLE_SSM_DISK_RESTORE opt-out in the disk store. Do not
         # silently disable it by family here: current Qwen hybrid records are
@@ -1240,6 +1276,9 @@ def serve_command(args):
                                 )
                 except Exception as _jit_e:
                     logger.debug(f"JANG-affine JIT auto-default skipped: {_jit_e}")
+    except MiniCPMCachePolicyError as e:
+        logger.error("MiniCPM cache policy rejected startup: %s", e)
+        raise SystemExit(2) from e
     except Exception as e:
         logger.debug(f"Registry auto-apply skipped: {e}")
 
@@ -1989,9 +2028,13 @@ def bench_command(args):
         from .model_config_registry import get_model_config_registry
 
         _mc = get_model_config_registry().lookup(args.model)
+        _apply_minicpm_cache_policy(args, _mc, logger)
         if _mc.family_name == "deepseek_v4":
             _is_dsv4_model = True
             _apply_dsv4_runtime_policy(args, logger, clamp_max_num_seqs=True)
+    except MiniCPMCachePolicyError as exc:
+        print(f"ERROR: MiniCPM cache policy rejected benchmark: {exc}")
+        raise SystemExit(2) from exc
     except Exception as exc:
         logger.debug("Bench model runtime policy lookup failed: %s", exc)
 
@@ -3270,6 +3313,12 @@ Examples:
     # Bench command
     bench_parser = subparsers.add_parser("bench", help="Run benchmark")
     bench_parser.add_argument("model", type=str, help="Model to benchmark")
+    bench_parser.add_argument(
+        "--model-family",
+        type=str,
+        default=None,
+        help="Manually force the model family, matching the serve command.",
+    )
     bench_parser.add_argument(
         "--num-prompts", type=int, default=10, help="Number of prompts"
     )

--- a/vmlx_engine/engine/batched.py
+++ b/vmlx_engine/engine/batched.py
@@ -346,6 +346,16 @@ class BatchedEngine(BaseEngine):
         except Exception:
             return None
 
+    def _chat_encode_add_special_tokens(self) -> bool:
+        """Return the registry-owned chat encoding policy for this family."""
+        try:
+            hints = get_model_config_registry().get_architecture_hints(
+                self._model_name
+            )
+            return bool(hints.get("chat_encode_add_special_tokens", False))
+        except Exception:
+            return False
+
     def _m3_vl_active(
         self,
         images: list | None,
@@ -1413,8 +1423,13 @@ class BatchedEngine(BaseEngine):
             else:
                 return 0, None
 
-            tokens_with = self._encode_rendered_prompt(enc, prompt_with_gen)
-            tokens_without = self._encode_rendered_prompt(enc, prompt_without_gen)
+            add_special_tokens = self._chat_encode_add_special_tokens()
+            tokens_with = self._encode_rendered_prompt(
+                enc, prompt_with_gen, add_special_tokens
+            )
+            tokens_without = self._encode_rendered_prompt(
+                enc, prompt_without_gen, add_special_tokens
+            )
             gen_len = len(tokens_with) - len(tokens_without)
             if gen_len > 0:
                 logger.debug(f"Gen prompt len: {gen_len} tokens")
@@ -1464,10 +1479,12 @@ class BatchedEngine(BaseEngine):
         return gen_len
 
     @staticmethod
-    def _encode_rendered_prompt(enc, prompt: str) -> list[int]:
-        """Encode an already-rendered chat template without adding BOS/EOS."""
+    def _encode_rendered_prompt(
+        enc, prompt: str, add_special_tokens: bool = False
+    ) -> list[int]:
+        """Encode rendered chat with the registry-owned special-token policy."""
         try:
-            return enc(prompt, add_special_tokens=False)
+            return enc(prompt, add_special_tokens=add_special_tokens)
         except TypeError:
             return enc(prompt)
 
@@ -1547,7 +1564,11 @@ class BatchedEngine(BaseEngine):
                 f"Tokenizer {type(tokenizer).__name__} has no encode method"
             )
 
-        token_ids = list(self._encode_rendered_prompt(enc, prompt))
+        token_ids = list(
+            self._encode_rendered_prompt(
+                enc, prompt, self._chat_encode_add_special_tokens()
+            )
+        )
         gen_prompt_len = max(0, min(int(gen_prompt_len or 0), len(token_ids)))
         cache_prompt_token_ids = (
             token_ids[:-gen_prompt_len] if gen_prompt_len > 0 else token_ids
@@ -1639,7 +1660,11 @@ class BatchedEngine(BaseEngine):
                         extra_template_kwargs=extra_template_kwargs,
                         skip_generation_prompt=True,
                     )
-                    cur_count = len(self._encode_rendered_prompt(enc, rendered))
+                    cur_count = len(
+                        self._encode_rendered_prompt(
+                            enc, rendered, self._chat_encode_add_special_tokens()
+                        )
+                    )
                 except Exception:
                     # Re-rendering can fail for partial histories on some
                     # templates (e.g. assistant-prefix-only). Skip this
@@ -2510,7 +2535,7 @@ class BatchedEngine(BaseEngine):
             videos=all_videos if all_videos else None,
             audio=all_audio if all_audio else None,
             gen_prompt_len=gen_prompt_len,
-            encode_add_special_tokens=False,
+            encode_add_special_tokens=self._chat_encode_add_special_tokens(),
             enable_thinking=thinking_enabled,
             **kwargs,
         )
@@ -2685,7 +2710,7 @@ class BatchedEngine(BaseEngine):
             audio=all_audio if all_audio else None,
             request_id=request_id,
             gen_prompt_len=gen_prompt_len,
-            encode_add_special_tokens=False,
+            encode_add_special_tokens=self._chat_encode_add_special_tokens(),
             enable_thinking=thinking_enabled,
             **kwargs,
         ):

--- a/vmlx_engine/model_configs.py
+++ b/vmlx_engine/model_configs.py
@@ -1382,6 +1382,27 @@ def register_all(registry=None):
 
     _register(
         ModelConfig(
+            family_name="minicpm",
+            model_types=["minicpm"],
+            cache_type="kv",
+            tool_parser=None,
+            supports_native_tools=False,
+            reasoning_parser=None,
+            supports_thinking=False,
+            is_mllm=False,
+            architecture_hints={
+                "attention_arch": "full_attention_kv",
+                "live_turboquant_default": False,
+                "blocked_kv_cache_storage_quantizations": ["q4", "q8"],
+                "chat_encode_add_special_tokens": True,
+            },
+            priority=20,
+            description="MiniCPM text",
+        )
+    )
+
+    _register(
+        ModelConfig(
             family_name="minicpm_v",
             model_types=["minicpmv"],
             cache_type="kv",

--- a/vmlx_engine/utils/jang_loader.py
+++ b/vmlx_engine/utils/jang_loader.py
@@ -1380,6 +1380,16 @@ def _read_hf_config(path: Path) -> dict:
     return {}
 
 
+def _apply_minicpm_config_defaults(config: dict, jang_cfg: dict) -> None:
+    """Supply defaults omitted by authoritative MiniCPM configs in memory."""
+    capabilities = jang_cfg.get("capabilities") or {}
+    stamped_family = str(capabilities.get("family", "")).lower()
+    model_type = str(config.get("model_type", "")).lower()
+    if model_type == "minicpm" or (not model_type and stamped_family == "minicpm"):
+        config.setdefault("model_type", "minicpm")
+        config.setdefault("rope_theta", 10_000.0)
+
+
 def _is_zaya_bundle(path: Path, jang_cfg: dict | None = None) -> bool:
     """Return True for Zyphra/ZAYA bundles without loading weights."""
     cfg = _read_hf_config(path)
@@ -2472,6 +2482,7 @@ def _load_jang_v2(
 
     start = time.perf_counter()
     config = load_config(path)
+    _apply_minicpm_config_defaults(config, jang_cfg)
     _normalize_gemma4_config_scalar_types(config)
     _ensure_jang_family_runtime_supported(path, config)
     _normalize_step3p7_model_type(config)
@@ -4884,6 +4895,7 @@ def load_jang_model(
     jang_cfg = json.loads(config_path.read_text())
     _ensure_zaya_runtime_supported(path, jang_cfg)
     hf_config = _read_hf_config(path)
+    _apply_minicpm_config_defaults(hf_config, jang_cfg)
     _ensure_jang_family_runtime_supported(path, hf_config)
 
     def _finalize_loaded_jang(result):
@@ -5005,6 +5017,7 @@ def _load_jang_v1(path: Path, jang_cfg: dict, config_path: Path):
     )
 
     config = load_config(path)
+    _apply_minicpm_config_defaults(config, jang_cfg)
     _normalize_gemma4_config_scalar_types(config)
     default_bits = _jang_default_bits(jang_cfg, [2, 4, 6, 8])
     config.pop("quantization", None)

--- a/vmlx_engine/utils/tokenizer.py
+++ b/vmlx_engine/utils/tokenizer.py
@@ -123,6 +123,48 @@ def _sanitize_nemotron_quantization_config_for_load(config: dict) -> tuple[dict 
     return override, removed
 
 
+def _minicpm_model_config_override(
+    config: dict,
+    resolved_family: str | None,
+) -> dict | None:
+    """Mirror missing official defaults after authoritative family resolution.
+
+    Architecture metadata alone must not identify MiniCPM, and an explicit
+    non-MiniCPM identity remains authoritative even under a manual override.
+    """
+    if not isinstance(config, dict) or resolved_family != "minicpm":
+        return None
+
+    model_type = str(config.get("model_type") or "").lower()
+    if model_type not in {"", "minicpm"}:
+        return None
+
+    override: dict = {}
+    if not model_type:
+        override["model_type"] = "minicpm"
+    if "rope_theta" not in config:
+        override["rope_theta"] = 10_000.0
+    return override or None
+
+
+def _minicpm_model_config_override_for_path(model_path: str | Path) -> dict | None:
+    """Resolve MiniCPM authority, then build its load-only config overlay."""
+    config_path = Path(model_path) / "config.json"
+    if not config_path.is_file():
+        return None
+    try:
+        config = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(config, dict):
+        return None
+
+    from ..model_config_registry import get_model_config_registry
+
+    resolved = get_model_config_registry().lookup(str(model_path))
+    return _minicpm_model_config_override(config, resolved.family_name)
+
+
 def _apply_turboquant_to_model(model, model_path: str):
     """Apply TurboQuant KV cache compression to any MLX model.
 
@@ -491,6 +533,7 @@ _STANDARD_ARCHITECTURES = {
     "cogvlm2",
     "florence2",
     "molmo",
+    "minicpm",
     "minicpmv",
     "smolvlm",
     "internvl_chat",
@@ -1252,6 +1295,20 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None, ski
         _inject_chat_template_if_missing(_t, local_model_path)
         return _finalize_loaded_model(_m, _t)
 
+    # MiniCPM's official config class supplies model_type/rope_theta, while
+    # MLX-LM consumes the raw mapping. Apply those missing defaults only after
+    # the registry has already resolved plain-text MiniCPM through its normal
+    # authority tiers; architecture metadata alone must remain fail-closed.
+    _model_config_override = _minicpm_model_config_override_for_path(
+        local_model_path
+    )
+    if _model_config_override:
+        logger.info(
+            "MiniCPM authority resolved: applying missing official config-class "
+            "defaults in memory (%s)",
+            ", ".join(sorted(_model_config_override)),
+        )
+
     # Check if model needs tokenizer fallback (e.g., Nemotron).
     # Pass resolved local path so _get_model_type_from_config can read config.json.
     if _needs_tokenizer_fallback(local_model_path):
@@ -1266,7 +1323,10 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None, ski
 
     try:
         model, tokenizer = load(
-            model_name, tokenizer_config=tokenizer_config, lazy=False
+            model_name,
+            tokenizer_config=tokenizer_config,
+            lazy=False,
+            model_config=_model_config_override,
         )
         if not skip_turboquant:
             _apply_turboquant_to_model(model, local_model_path)


### PR DESCRIPTION
## Summary

Register plain-text MiniCPM as an existing MLX-LM family across the engine,
tokenizer loader, cache policy, benchmark/serve entrypoints, and panel. The
official MiniCPM4-0.5B source artifact and stamped JANG artifacts load through
the same `minicpm` family without a new runtime model, detector, trust path, or
dependency.

## Problem

vMLX 1.6.25 knows MiniCPM-V but not the distinct plain-text `minicpm` family.
The official source checkpoint used for validation also omits `model_type` and
`rope_theta`, so a registry row alone still leaves MLX-LM class resolution
failing with `KeyError: 'model_type'` and selects the wrong RoPE default.

## Root Cause

- The engine and panel registries have no plain MiniCPM row.
- MLX-LM receives the incomplete raw source config instead of the defaults
  supplied by MiniCPM's official config class.
- The shared rendered-chat path suppresses MiniCPM's tokenizer-owned BOS.
- Generic stored-KV q4/q8 produces divergent warm output on the validated
  source artifact, while native raw KV remains coherent.

## Fix

- Register one explicit plain-KV, non-tool, non-reasoning `minicpm` family and
  add it to the existing MLX-LM architecture path.
- Synchronize the engine and panel family maps while leaving MiniCPM-V
  separate.
- Supply missing `model_type=minicpm` and `rope_theta=10000.0` in memory only
  after the existing manual/JANG/config authority ladder resolves MiniCPM.
- Restore tokenizer-owned BOS only for the resolved MiniCPM text family.
- Use Auto/native raw KV, honor explicit None, reject q4/q8 before model load,
  and normalize stale MiniCPM q4/q8 panel values back to Auto.
- Expose the existing benchmark family override through `bench
  --model-family`, matching the serve entrypoint.

Every additional behavior is guarded by the resolved MiniCPM text family.
Other model families retain their existing loading, BOS, and cache policies.

## Why This Exceeds a Registry-Only Change

MLX-LM already ships the MiniCPM implementation, so this PR does not add or
vendor another runtime model. It also adds no name/signature/fingerprint or
media-conflict detector, MiniCPM-V alias, remote-code trust branch, converter
change, dependency change, or generic cache refactor.

Three narrow behaviors go beyond a literal registry-only change because the
validated source artifact requires them:

1. Without the authority-gated config overlay, the source artifact cannot
   resolve the existing MLX-LM class and receives the wrong RoPE default.
2. Without tokenizer-owned BOS, the shared rendered-chat path changes the
   MiniCPM prompt contract.
3. Repeated cold/warm, cache-disabled, source/JANG, soak, and restart checks
   isolate q4/q8 divergence; Auto/raw is the passing control.

## Live Proof

| Route | Artifact / Configuration | Result |
| --- | --- | --- |
| CLI serve + four streaming adapters | Official source BF16, manual MiniCPM family | Loads through MLX-LM; all four protocols terminate correctly; 5/6 contextual checks, with the same semantic miss reproduced without cache and through direct unmodified MLX-LM |
| CLI serve + four streaming adapters | Stamped JANG_6M | Loads through the stamped family and JANG v2 path; all four protocols terminate correctly; 6/6 contextual checks |
| CLI benchmark | Source, JANG_6M, and JANG_4M | Auto/raw completes for all three; q4/q8 rejects before model load |
| Cache and memory | Source and JANG_6M raw KV | Both pass 30/30 semantic requests with stable late-window RSS; forced restarts reconstruct raw SSD/L2 state without dequantization |
| Electron dev app | Source manual family and JANG_6M autodetection | Visible policy, session identity, correct chats, raw cache contracts, and fresh 16-token cache hits agree |
| Bundled Python | Source and JANG_6M | Exact candidate/JANG provenance, staged and published verification, isolated imports, production build, and live bundled queries pass |

## UI Proof

- The source settings visibly select the manual `minicpm` family required by
  the incomplete official source config; the stamped JANG artifact visibly
  autodetects `minicpm`.
- Both routes show the MiniCPM Auto/native raw-KV policy.
- Fresh source and JANG_6M chats answer correctly and visibly reuse 16 raw-KV
  tokens; cache drawers expose `plain_kv_v1`, disabled stored quantization,
  and no active generic TQ-KV.
<img width="1195" height="768" alt="v1 6 25-jang6-autodetect-minicpm" src="https://github.com/user-attachments/assets/8406315a-013c-42c6-930c-f77ab38a6f58" />
<img width="1195" height="768" alt="v1 6 25-jang6-chat-canberra" src="https://github.com/user-attachments/assets/3b0df3fc-610b-4665-a732-cf0c20d0b7f1" />
<img width="1195" height="768" alt="v1 6 25-jang6-minicpm-auto-policy" src="https://github.com/user-attachments/assets/b0fee785-9329-47b4-af7d-e89062e1231b" />
<img width="1195" height="768" alt="v1 6 25-jang6-raw-cache-contract" src="https://github.com/user-attachments/assets/fca31fc5-c2b8-415c-ab30-cfdf138d17d7" />
<img width="1195" height="768" alt="v1 6 25-jang6-warm-cache-hit" src="https://github.com/user-attachments/assets/7c05ce6f-737f-43de-ba32-828f208bfd57" />
<img width="1195" height="768" alt="v1 6 25-source-chat-tokyo" src="https://github.com/user-attachments/assets/61f58f87-4d17-47d8-a59a-b2a8677d99f5" />
<img width="1195" height="768" alt="v1 6 25-source-minicpm-auto-policy" src="https://github.com/user-attachments/assets/de88a76c-0093-434d-8cfc-eb09f3f8255c" />
<img width="1195" height="768" alt="v1 6 25-source-minicpm-family-override" src="https://github.com/user-attachments/assets/07f11968-a5d7-4612-93c0-59b40d330c1c" />
<img width="1195" height="768" alt="v1 6 25-source-raw-cache-contract" src="https://github.com/user-attachments/assets/5a932734-0e63-4330-9e2e-8fe5adf29adf" />
<img width="1195" height="768" alt="v1 6 25-source-warm-cache-hit" src="https://github.com/user-attachments/assets/1ed1e3ef-b6b9-40e7-9a72-e96b7aa62501" />



## Tests

- Python compile, scoped Ruff, TypeScript typecheck, and `git diff --check`.
- Focused MiniCPM contracts: 6/6.
- Touched Python suites: 859 passed, 1 skipped.
- Panel registry/audit: 465/465.
- Generation-default gates: panel 30 passed, engine 66 passed, local metadata
  6 passed/1 skipped, and CLI 22 passed.
- Full Python suite: 7,491 passed, 105 skipped, 92 deselected. All 39 stable
  failure nodes replay on the exact pristine upstream base; one additional
  order-dependent gate passes immediately in isolation. The bundle verifier is
  covered separately by successful exact-tip staged and published verification.
- The complete panel suite was also run with no MiniCPM-specific failure; the
  MiniCPM registry/audit subset is 465/465.

The regression additions exercise existing production contracts: five Python
test functions were added to existing shared suites and two cases were added
to existing panel audit suites. No dedicated MiniCPM test module, copied
runtime helper, or new test framework was added.

## Known Boundaries

- The source artifact's contextual result remains an honest 5/6; the same
  semantic substitution reproduces with cache disabled and through direct
  unmodified MLX-LM 0.31.3, while JANG_6M passes 6/6. This excludes a
  vMLX-specific regression but does not distinguish MLX-LM behavior from the
  underlying model logits.
- A real MiniCPM legacy JANG-v1 artifact was not available. The actual v1
  loader branch has integration coverage for family/default propagation, but
  no real-artifact v1 claim is made.
- Remote CI, release packaging/signing/notarization, and maintainer acceptance
  remain outside local proof.
