### PR TITLE
Support current mlx-vlm video loading

### DIFF
--- a/tests/test_qwen4_exp_runtime.py
+++ b/tests/test_qwen4_exp_runtime.py
@@ -1497,6 +1497,41 @@ def test_qwen_video_float_255_input_preserves_uint8_processor_scale():
     assert untouched is unit_interval
 
 
+@pytest.mark.parametrize("legacy_module", [None, object()])
+def test_current_mlx_vlm_video_loader_replaces_removed_fetch_video(
+    monkeypatch, legacy_module
+):
+    import mlx_vlm.utils as mlx_vlm_utils
+
+    import vmlx_engine.mllm_batch_generator as batch_generator
+
+    calls = []
+    frames = np.zeros((4, 3, 8, 8), dtype=np.uint8)
+
+    def import_module(name, package=None):
+        assert name == "mlx_vlm.video_generate"
+        if legacy_module is None:
+            raise ModuleNotFoundError(name)
+        return legacy_module
+
+    def load_video(path, *, fps, max_frames):
+        calls.append((path, fps, max_frames))
+        return frames, 1.5
+
+    monkeypatch.setattr(batch_generator.importlib, "import_module", import_module)
+    monkeypatch.setattr(mlx_vlm_utils, "load_video", load_video)
+
+    result, sample_fps = batch_generator._fetch_video_for_processor(
+        "/tmp/clip.mp4",
+        fps=2.0,
+        max_frames=16,
+    )
+
+    assert result is frames
+    assert sample_fps == 1.5
+    assert calls == [("/tmp/clip.mp4", 2.0, 16)]
+
+
 def test_qwen4_exp_reasoning_and_tools_preserve_native_bundle_contract():
     from vmlx_engine.model_config_registry import ModelConfigRegistry
     from vmlx_engine.model_configs import register_all

--- a/vmlx_engine/mllm_batch_generator.py
+++ b/vmlx_engine/mllm_batch_generator.py
@@ -1815,6 +1815,45 @@ def _normalize_qwen_video_arrays_for_processor(
     return normalized
 
 
+def _fetch_video_for_processor(
+    video_path: str,
+    *,
+    fps: float,
+    max_frames: int,
+) -> tuple[Any, float]:
+    """Load video frames across supported mlx-vlm API generations.
+
+    mlx-vlm 0.5 exposed ``video_generate.fetch_video``. Newer releases expose
+    the equivalent decoder as ``utils.load_video`` instead.
+    """
+    try:
+        video_generate = importlib.import_module("mlx_vlm.video_generate")
+        fetch_video = getattr(video_generate, "fetch_video")
+    except (ImportError, AttributeError):
+        from mlx_vlm.utils import load_video
+
+        video_input, sample_fps = load_video(
+            str(video_path),
+            fps=float(fps),
+            max_frames=int(max_frames),
+        )
+        return video_input, float(sample_fps)
+
+    video_result = fetch_video(
+        {
+            "video": str(video_path),
+            "fps": float(fps),
+            "max_frames": int(max_frames),
+        },
+        return_video_sample_fps=True,
+    )
+    if isinstance(video_result, tuple) and len(video_result) == 2:
+        video_input, sample_fps = video_result
+    else:
+        video_input, sample_fps = video_result, fps
+    return video_input, float(sample_fps)
+
+
 def _call_processor_direct_unscoped(
     processor: Any,
     *,
@@ -7314,8 +7353,6 @@ class MLLMBatchGenerator:
                 MAX_FRAMES,
                 process_video_input,
             )
-            from mlx_vlm.video_generate import fetch_video
-
             fps = request.video_fps or DEFAULT_FPS
             max_frames = request.video_max_frames or MAX_FRAMES
 
@@ -7323,14 +7360,11 @@ class MLLMBatchGenerator:
                 try:
                     video_path = process_video_input(video)
                     video_cache_sources.append(video_path)
-                    video_result = fetch_video(
-                        {"video": video_path, "fps": fps, "max_frames": max_frames},
-                        return_video_sample_fps=True,
+                    video_input, sample_fps = _fetch_video_for_processor(
+                        video_path,
+                        fps=fps,
+                        max_frames=max_frames,
                     )
-                    if isinstance(video_result, tuple) and len(video_result) == 2:
-                        video_input, sample_fps = video_result
-                    else:
-                        video_input, sample_fps = video_result, fps
                     video_inputs.append(video_input)
                     video_sample_fps.append(float(sample_fps))
                     video_sample_timestamps.append(


### PR DESCRIPTION
## Summary
- preserve the legacy mlx-vlm 0.5 `fetch_video` path
- fall back to the current `mlx_vlm.utils.load_video` API
- cover both a missing legacy module and a removed legacy symbol

## Why
Current mlx-vlm releases removed `video_generate.fetch_video`, causing video requests to fail before processor ingestion.

## Tests
- `.venv/bin/python -m pytest -q tests/test_qwen4_exp_runtime.py -k "current_mlx_vlm_video_loader or qwen_video_float_255"` (3 passed)