### PR TITLE
tool_calling: accept a native <tools> catalog only when its rendered schemas match the request, not just its tool names

### DIFF
--- a/tests/test_native_tool_schema_completeness.py
+++ b/tests/test_native_tool_schema_completeness.py
@@ -1,0 +1,246 @@
+"""Native tool prompts are accepted only when the rendered schemas match the request.
+
+The fallback-injection gate used to accept a native ``<tools>`` block as soon as
+it carried every requested tool NAME. A template (or a stale/cached render) that
+names the tools but omits, renames or retypes their parameters therefore passed
+as "native" and the model was never told that ``read_file`` needs ``path`` or
+``terminal`` needs ``command`` (audit CODEX-CROSS-FAMILY-TOOL-SCHEMA-CACHE,
+mechanism B, reproduced with the MiniMax M2.7 fixture).
+
+These fixtures render the real bundle templates with tools whose names match
+the request but whose parameter definitions differ, and require the fallback
+injection; the exact request, a description-only difference and a re-ordered
+property set stay accepted unchanged (semantic comparison, not byte equality).
+"""
+
+import copy
+import json
+import logging
+import re
+from pathlib import Path
+
+import jinja2
+import pytest
+from jinja2 import sandbox
+
+from vmlx_engine.api.tool_calling import check_and_inject_fallback_tools
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Repo-relative path"}
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "terminal",
+            "description": "Run a command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "timeout_s": {"type": "integer"},
+                },
+                "required": ["command"],
+            },
+        },
+    },
+]
+
+ROWS = (
+    (
+        "minimax_m27_chat_template.jinja",
+        "minimax",
+        "MiniMax M2.7: <tool>{function}</tool> entries",
+    ),
+    (
+        "qwen38_27b_d_chat_template.jinja",
+        "qwen3_coder",
+        "Qwen3.8-27B D-series: {type,function} entries",
+    ),
+    (
+        "nanbeige42_chat_template.jinja",
+        "xml_function",
+        "Nanbeige 4.2: {type,function} entries",
+    ),
+)
+
+
+class _FixtureTokenizer:
+    """Renders a checked-in bundle template the way transformers does."""
+
+    def __init__(self, fixture: str) -> None:
+        env = sandbox.ImmutableSandboxedEnvironment(
+            trim_blocks=True, lstrip_blocks=True, extensions=["jinja2.ext.loopcontrols"]
+        )
+        env.filters["tojson"] = lambda v, ensure_ascii=False, **kw: json.dumps(
+            v, ensure_ascii=ensure_ascii, **kw
+        )
+        env.globals["raise_exception"] = lambda msg: (_ for _ in ()).throw(
+            jinja2.TemplateError(msg)
+        )
+        self._template = env.from_string((FIXTURES / fixture).read_text())
+
+    def apply_chat_template(
+        self, messages, tools=None, add_generation_prompt=True, tokenize=False, **kwargs
+    ):
+        return self._template.render(
+            messages=messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            **kwargs,
+        )
+
+
+def _render_with(tok, rendered_tools):
+    messages = [{"role": "user", "content": "Inspect the repository."}]
+    return messages, tok.apply_chat_template(messages, tools=rendered_tools)
+
+
+def _gate(tok, messages, prompt, parser, caplog):
+    with caplog.at_level(logging.WARNING, logger="vmlx_engine.api.tool_calling"):
+        return check_and_inject_fallback_tools(
+            prompt, messages, TOOLS, tok, {"tools": TOOLS}, tool_parser_id=parser
+        )
+
+
+def _mutated(mutate):
+    tools = copy.deepcopy(TOOLS)
+    mutate(tools)
+    return tools
+
+
+def _drop_all_parameters(tools):
+    for t in tools:
+        t["function"]["parameters"] = {"type": "object", "properties": {}}
+
+
+def _drop_required_list(tools):
+    tools[0]["function"]["parameters"].pop("required")
+
+
+def _rename_parameter(tools):
+    params = tools[1]["function"]["parameters"]
+    params["properties"] = {
+        "cmd": params["properties"]["command"],
+        "timeout_s": params["properties"]["timeout_s"],
+    }
+    params["required"] = ["cmd"]
+
+
+def _retype_parameter(tools):
+    tools[1]["function"]["parameters"]["properties"]["timeout_s"]["type"] = "string"
+
+
+def _drop_optional_property(tools):
+    tools[1]["function"]["parameters"]["properties"].pop("timeout_s")
+
+
+DEFICIENT = (
+    ("all parameters dropped", _drop_all_parameters),
+    ("required list dropped", _drop_required_list),
+    ("required parameter renamed", _rename_parameter),
+    ("parameter retyped", _retype_parameter),
+    ("optional parameter missing", _drop_optional_property),
+)
+
+
+@pytest.mark.parametrize("fixture, parser, label", ROWS, ids=[r[0] for r in ROWS])
+@pytest.mark.parametrize("case, mutate", DEFICIENT, ids=[d[0] for d in DEFICIENT])
+def test_names_present_but_schema_deficient_gets_fallback(
+    fixture, parser, label, case, mutate, caplog
+):
+    tok = _FixtureTokenizer(fixture)
+    messages, prompt = _render_with(tok, _mutated(mutate))
+    assert "<tools>" in prompt and "read_file" in prompt and "terminal" in prompt, label
+    out = _gate(tok, messages, prompt, parser, caplog)
+    assert (
+        out != prompt
+    ), f"{label}: {case} — names-only recognition accepted a deficient schema"
+    # Each dialect renders its own fallback shape (JSON schema, `fields:` lists,
+    # native exemplars); the request's parameter names must reach the model.
+    assert re.search(r"\bpath\b", out) and re.search(
+        r"\bcommand\b", out
+    ), f"{label}: {case} — fallback must carry the request's parameters"
+
+
+@pytest.mark.parametrize("fixture, parser, label", ROWS, ids=[r[0] for r in ROWS])
+def test_exact_schema_is_accepted_unchanged(fixture, parser, label, caplog):
+    tok = _FixtureTokenizer(fixture)
+    messages, prompt = _render_with(tok, copy.deepcopy(TOOLS))
+    out = _gate(tok, messages, prompt, parser, caplog)
+    assert out == prompt, f"{label}: exact native render must not be re-rendered"
+    assert "needs fallback tool schema injection" not in caplog.text
+
+
+def _description_only_difference(tools):
+    tools[0]["function"]["description"] = "Read one file from the workspace"
+    tools[0]["function"]["parameters"]["properties"]["path"]["description"] = "A path"
+
+
+def _reordered_properties(tools):
+    params = tools[1]["function"]["parameters"]
+    props = params["properties"]
+    params["properties"] = {
+        "timeout_s": props["timeout_s"],
+        "command": props["command"],
+    }
+
+
+@pytest.mark.parametrize("fixture, parser, label", ROWS, ids=[r[0] for r in ROWS])
+@pytest.mark.parametrize(
+    "case, mutate",
+    (
+        ("description-only difference", _description_only_difference),
+        ("re-ordered properties", _reordered_properties),
+    ),
+    ids=["description-only", "reordered"],
+)
+def test_semantically_equal_schema_is_accepted(
+    fixture, parser, label, case, mutate, caplog
+):
+    # The comparison is over parameter names, required-ness and types — a
+    # template that renders the same contract with different prose or key
+    # order is native, not deficient (no byte-equality demand, no forced
+    # fallback that would move the SSD prefix on every turn).
+    tok = _FixtureTokenizer(fixture)
+    messages, prompt = _render_with(tok, _mutated(mutate))
+    out = _gate(tok, messages, prompt, parser, caplog)
+    assert out == prompt, f"{label}: {case} must stay accepted"
+
+
+def test_unrelated_extra_tool_in_render_is_not_a_match():
+    # A render that carries the requested names plus a foreign tool is a
+    # different catalog (stale cache / other request); the request's own
+    # contract still has to be re-rendered.
+    tok = _FixtureTokenizer("minimax_m27_chat_template.jinja")
+    extra = copy.deepcopy(TOOLS) + [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                    "required": ["q"],
+                },
+            },
+        }
+    ]
+    messages, prompt = _render_with(tok, extra)
+    out = check_and_inject_fallback_tools(
+        prompt, messages, TOOLS, tok, {"tools": TOOLS}, tool_parser_id="minimax"
+    )
+    assert out != prompt

--- a/vmlx_engine/api/tool_calling.py
+++ b/vmlx_engine/api/tool_calling.py
@@ -540,6 +540,130 @@ def check_and_inject_fallback_tools(
             search_from = payload_start
 
     _lfm2_has_native_tool_schema = _lfm2_has_exact_native_tool_schema()
+
+    def _parameter_contract(schema: Any) -> Any:
+        """Canonical form of a JSON-schema parameter block.
+
+        Names, required-ness, types, enums and nested object/array structure
+        are the contract; descriptions, titles, defaults and key order are
+        not. Two renders with the same contract are the same native catalog
+        even when their prose differs, so a byte-level difference alone never
+        forces the fallback (which would rewrite the opening system bytes and
+        move every SSD prefix).
+        """
+        if not isinstance(schema, dict):
+            return None
+        contract: dict[str, Any] = {}
+        schema_type = schema.get("type")
+        if isinstance(schema_type, list):
+            contract["type"] = sorted(str(t) for t in schema_type)
+        elif isinstance(schema_type, str):
+            contract["type"] = schema_type
+        if isinstance(schema.get("enum"), list):
+            contract["enum"] = sorted(
+                json.dumps(value, sort_keys=True) for value in schema["enum"]
+            )
+        properties = schema.get("properties")
+        if isinstance(properties, dict):
+            contract["properties"] = {
+                str(name): _parameter_contract(sub) for name, sub in properties.items()
+            }
+        required = schema.get("required")
+        if isinstance(required, list):
+            contract["required"] = sorted(str(name) for name in required)
+        items = schema.get("items")
+        if isinstance(items, dict):
+            contract["items"] = _parameter_contract(items)
+        return contract
+
+    def _rendered_function_schema(entry: Any) -> Optional[dict]:
+        """A rendered catalog entry: OpenAI ``{type, function}`` wrapper, flat
+        Responses shape, or the bare function object some templates emit
+        (MiniMax renders ``tool.function | tojson``)."""
+        normalized = _normalized_function_schema(entry)
+        if normalized is not None:
+            return normalized
+        if (
+            isinstance(entry, dict)
+            and isinstance(entry.get("name"), str)
+            and entry.get("name")
+            and isinstance(entry.get("parameters"), dict)
+            and not isinstance(entry.get("function"), dict)
+        ):
+            bare = dict(entry)
+            bare.pop("type", None)
+            return bare
+        return None
+
+    def _rendered_tools_block_schema_verdict() -> Optional[bool]:
+        """Semantic check of the JSON entries a template rendered inside
+        ``<tools>``...``</tools>`` against this request's tools.
+
+        ``None``  — no decodable JSON entry in any block (an XML-only catalog):
+                    no opinion, the name-based recognition applies unchanged.
+        ``True``  — exactly the requested tools are rendered, each once, and
+                    every parameter contract matches the request.
+        ``False`` — a requested tool is missing, duplicated or rendered with a
+                    different parameter contract, or the block carries tools
+                    this request did not authorize.
+
+        Names alone are not a contract: a render that named ``read_file`` and
+        ``terminal`` while omitting ``path`` and ``command`` was accepted as
+        native and the model was never told the required arguments
+        (cross-family schema audit 2026-09-06, mechanism B).
+        """
+        expected_by_name: dict[str, Any] = {}
+        for tool in template_tools:
+            normalized = _normalized_function_schema(tool)
+            if normalized is None or normalized["name"] in expected_by_name:
+                return False
+            expected_by_name[normalized["name"]] = _parameter_contract(
+                normalized["parameters"]
+            )
+        if not expected_by_name:
+            return None
+        decoder = json.JSONDecoder()
+        rendered_by_name: dict[str, Any] = {}
+        found_entry = False
+        search_from = 0
+        while True:
+            block_start = instruction_prompt.find("<tools>", search_from)
+            if block_start < 0:
+                break
+            block_end = instruction_prompt.find("</tools>", block_start)
+            if block_end < 0:
+                block_end = len(instruction_prompt)
+                search_from = block_end
+            else:
+                search_from = block_end + len("</tools>")
+            block = instruction_prompt[block_start + len("<tools>") : block_end]
+            position = 0
+            while True:
+                brace = block.find("{", position)
+                if brace < 0:
+                    break
+                try:
+                    entry, consumed = decoder.raw_decode(block[brace:])
+                except (json.JSONDecodeError, TypeError):
+                    position = brace + 1
+                    continue
+                position = brace + max(consumed, 1)
+                normalized = _rendered_function_schema(entry)
+                if normalized is None:
+                    continue
+                found_entry = True
+                if normalized["name"] in rendered_by_name:
+                    return False
+                rendered_by_name[normalized["name"]] = _parameter_contract(
+                    normalized["parameters"]
+                )
+        if not found_entry:
+            return None
+        return rendered_by_name == expected_by_name
+
+    # Computed once per request; ``is not False`` keeps XML-only catalogs on
+    # their existing name-based recognition.
+    _native_tools_schema_verdict = _rendered_tools_block_schema_verdict()
     _openpangu_has_concrete_tool_examples = (
         is_openpangu_native_tool_prompt
         and not explicit_tool_requested
@@ -567,6 +691,7 @@ def check_and_inject_fallback_tools(
         and "<tools>" in instruction_prompt
         and "</tools>" in instruction_prompt
         and all(name in instruction_prompt for name in tool_names)
+        and _native_tools_schema_verdict is not False
     )
     # Two native dialects render the schema block: MiMo-style XML entries
     # (<name>tool</name>) and JSON entries ({"name": "tool", ...}) as emitted
@@ -584,6 +709,7 @@ def check_and_inject_fallback_tools(
             or f'"name":"{name}"' in instruction_prompt
             for name in tool_names
         )
+        and _native_tools_schema_verdict is not False
     )
     _step3p5_has_concrete_tool_examples = (
         is_step3p5_native_tool_prompt
@@ -595,6 +721,7 @@ def check_and_inject_fallback_tools(
         and "</tools>" in instruction_prompt
         and "<function=example_function_name>" in instruction_prompt
         and all(name in instruction_prompt for name in tool_names)
+        and _native_tools_schema_verdict is not False
     )
     if all(name in prompt for name in tool_names) and (
         (
@@ -607,6 +734,9 @@ def check_and_inject_fallback_tools(
             or _qwen_has_concrete_tool_examples
             or (
                 _qwen_has_native_tool_schema
+                # The rendered JSON entries must carry this request's
+                # parameter contracts, not just its tool names.
+                and _native_tools_schema_verdict is not False
                 and not tool_choice_required
             )
         )


### PR DESCRIPTION
## Problem (cross-family tool schema audit 2026-09-06, mechanism B)
`check_and_inject_fallback_tools` recognized a MiniMax M2.7 / Qwen3.8-27B D-series / Nanbeige / Step native tool prompt as soon as the rendered `<tools>` block named every requested tool. A render that named `read_file` and `terminal` while omitting, renaming or retyping `path` and `command` was accepted unchanged, so the model was never told the required arguments. Reproduced model-free with the checked-in M2.7 template (`accepted_unchanged=True`, `required_path_present=False`).

## Change
The gate decodes the JSON entries inside every `<tools>…</tools>` span of the instruction scope (OpenAI `{type, function}` wrappers, flat Responses tools, and the bare function objects MiniMax renders via `tool.function | tojson`) and compares each tool's **parameter contract** — property names, required set, types, enums, nested object/array structure — with the request's tools. Descriptions, titles, defaults and key order are not part of the contract: a template that renders the same schema with different prose or ordering stays native and keeps its SSD prefix. A missing, duplicated, extra or mismatched tool sends the request through the dialect's existing fallback. XML-only catalogs (`<name>tool</name>` entries) yield no verdict and keep the name-based recognition unchanged.

Applied to the four `<tools>`-block recognitions: MiniMax, `xml_function`/`qwen3_coder` (JSON form), Step 3.5, and the Qwen native schema (at the decision site). DSV4 and LFM2 already had exact-schema checks and are untouched. No dialect, argument default, hidden prompt or sampling change; `tool_choice=required` semantics unchanged.

## Tests
`tests/test_native_tool_schema_completeness.py` (failing-first, 16 red → green): for each of the three checked-in native templates, five deficient renders (all parameters dropped, required list dropped, required parameter renamed, parameter retyped, optional parameter missing) must inject and the fallback must carry the request's parameter names; the exact render, a description-only difference and re-ordered properties stay accepted unchanged; a render carrying an unauthorized extra tool injects.

Gate suites: `test_native_tool_schema_completeness`, `test_minimax_m27_native_tool_prompt`, `test_tool_prompt_fallback`, `test_tool_fallback_injection`, `test_tool_format`, `test_engine_audit`, `test_atem_tool_parser`, `test_tool_call_required_args`, `test_tool_terminal_cache_durability`, `test_generation_prompt_cache_key`: 931 passed, 1 skipped. Full suite: 3843 passed, 26 skipped, one pre-existing failure unrelated to this change (`test_image_stays_in_its_own_message::test_the_upstream_builder_still_has_the_defect_we_route_around` fails identically on untouched `main`: the installed mlx_vlm no longer repositions images).

## Not covered here (recorded, per the audit)
- Live source-matched cross-family runtime proof (three-turn API/UI evidence per dialect) — not run; model-free only.
- Streaming/parsing, tool-result continuation and per-tool-call cache contracts across the registry — separate work.
- The original reporter's root cause (raw generated output, exact engine version) remains unassigned.
- Installer/PATH work is separate.