### PR TITLE
tool_calling: the native-catalog contract is the whole validation schema; a rendered function without parameters is deficient

### DIFF
--- a/tests/test_native_tool_schema_completeness.py
+++ b/tests/test_native_tool_schema_completeness.py
@@ -221,10 +221,12 @@ def test_semantically_equal_schema_is_accepted(
     assert out == prompt, f"{label}: {case} must stay accepted"
 
 
-def test_unrelated_extra_tool_in_render_is_not_a_match():
-    # A render that carries the requested names plus a foreign tool is a
-    # different catalog (stale cache / other request); the request's own
-    # contract still has to be re-rendered.
+def test_superset_render_with_matching_contracts_stays_native():
+    # A render that carries the requested tools (with matching contracts)
+    # plus a tool this request no longer lists is a superset — a narrowed
+    # continuation catalog over a stable source-owned prompt. Re-rendering it
+    # would move the opening system bytes on every agentic turn and defeat
+    # prefix reuse; nothing the request needs is missing.
     tok = _FixtureTokenizer("minimax_m27_chat_template.jinja")
     extra = copy.deepcopy(TOOLS) + [
         {
@@ -243,4 +245,147 @@ def test_unrelated_extra_tool_in_render_is_not_a_match():
     out = check_and_inject_fallback_tools(
         prompt, messages, TOOLS, tok, {"tools": TOOLS}, tool_parser_id="minimax"
     )
-    assert out != prompt
+    assert out == prompt
+
+
+def test_subset_render_missing_a_requested_tool_gets_fallback():
+    tok = _FixtureTokenizer("minimax_m27_chat_template.jinja")
+    # terminal is never rendered
+    messages, prompt = _render_with(tok, [copy.deepcopy(TOOLS[0])])
+    out = check_and_inject_fallback_tools(
+        prompt, messages, TOOLS, tok, {"tools": TOOLS}, tool_parser_id="minimax"
+    )
+    assert out != prompt and re.search(r"\bcommand\b", out)
+
+
+# --- Constraint preservation (audit follow-up, 2026-09-07) -----------------
+# The contract is the whole validation schema, not a hand-picked subset: a
+# rendered catalog that drops a constraint (minLength, additionalProperties,
+# pattern, maxItems, …) or the parameters object itself is deficient even
+# though every property name is still present.
+
+CONSTRAINED_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "minLength": 1, "pattern": "^[^\\n]+$"}
+                },
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "terminal",
+            "description": "Run a command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "maxItems": 8,
+                    },
+                },
+                "required": ["command"],
+            },
+        },
+    },
+]
+
+
+def _drop_min_length(tools):
+    tools[0]["function"]["parameters"]["properties"]["path"].pop("minLength")
+
+
+def _drop_additional_properties(tools):
+    tools[0]["function"]["parameters"].pop("additionalProperties")
+
+
+def _drop_pattern(tools):
+    tools[0]["function"]["parameters"]["properties"]["path"].pop("pattern")
+
+
+def _drop_max_items(tools):
+    tools[1]["function"]["parameters"]["properties"]["args"].pop("maxItems")
+
+
+def _drop_parameters_object(tools):
+    for t in tools:
+        t["function"].pop("parameters")
+
+
+CONSTRAINT_HOLES = (
+    ("minLength omitted", _drop_min_length),
+    ("additionalProperties omitted", _drop_additional_properties),
+    ("pattern omitted", _drop_pattern),
+    ("maxItems omitted", _drop_max_items),
+    ("parameters object deleted", _drop_parameters_object),
+)
+
+
+def _gate_constrained(tok, messages, prompt, parser, caplog):
+    with caplog.at_level(logging.WARNING, logger="vmlx_engine.api.tool_calling"):
+        return check_and_inject_fallback_tools(
+            prompt,
+            messages,
+            CONSTRAINED_TOOLS,
+            tok,
+            {"tools": CONSTRAINED_TOOLS},
+            tool_parser_id=parser,
+        )
+
+
+@pytest.mark.parametrize("fixture, parser, label", ROWS, ids=[r[0] for r in ROWS])
+@pytest.mark.parametrize(
+    "case, mutate", CONSTRAINT_HOLES, ids=[c[0] for c in CONSTRAINT_HOLES]
+)
+def test_dropped_constraint_or_parameters_object_gets_fallback(
+    fixture, parser, label, case, mutate, caplog
+):
+    tok = _FixtureTokenizer(fixture)
+    rendered = copy.deepcopy(CONSTRAINED_TOOLS)
+    mutate(rendered)
+    messages, prompt = _render_with(tok, rendered)
+    assert "read_file" in prompt and "terminal" in prompt, label
+    out = _gate_constrained(tok, messages, prompt, parser, caplog)
+    assert (
+        out != prompt
+    ), f"{label}: {case} — accepted a catalog that lost part of the request's contract"
+    assert re.search(r"\bpath\b", out) and re.search(
+        r"\bcommand\b", out
+    ), f"{label}: {case}"
+
+
+@pytest.mark.parametrize("fixture, parser, label", ROWS, ids=[r[0] for r in ROWS])
+def test_constrained_exact_render_is_accepted(fixture, parser, label, caplog):
+    tok = _FixtureTokenizer(fixture)
+    messages, prompt = _render_with(tok, copy.deepcopy(CONSTRAINED_TOOLS))
+    out = _gate_constrained(tok, messages, prompt, parser, caplog)
+    assert out == prompt, f"{label}: exact constrained render must stay native"
+
+
+def test_prose_only_keys_are_not_part_of_the_contract(caplog):
+    # description / title / examples / $comment may differ freely.
+    tok = _FixtureTokenizer("minimax_m27_chat_template.jinja")
+    rendered = copy.deepcopy(CONSTRAINED_TOOLS)
+    rendered[0]["function"]["parameters"]["properties"]["path"].update(
+        {
+            "description": "different prose",
+            "title": "Path",
+            "examples": ["a.txt"],
+            "$comment": "x",
+        }
+    )
+    rendered[0]["function"]["parameters"]["title"] = "Read-file arguments"
+    messages, prompt = _render_with(tok, rendered)
+    out = _gate_constrained(tok, messages, prompt, "minimax", caplog)
+    assert out == prompt

--- a/tests/test_tool_format.py
+++ b/tests/test_tool_format.py
@@ -1005,7 +1005,7 @@ class TestFallbackToolPromptFormat:
 
         prompt = (
             "<|im_start|>system\n# Tools\n<tools>\n"
-            '{"type":"function","function":{"name":"list_directory"}}\n'
+            '{"type":"function","function":{"name":"list_directory","description":"List a directory","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}}\n'
             "</tools>\n"
             "<tool_call>\n"
             "<function=example_function_name>\n"
@@ -1163,7 +1163,7 @@ class TestFallbackToolPromptFormat:
 
         prompt = (
             "<|im_start|>system\n<tools>\n"
-            '{"type":"function","function":{"name":"list_directory"}}\n'
+            '{"type":"function","function":{"name":"list_directory","description":"List a directory","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}}\n'
             "</tools>\n"
             "<tool_call>\n<function=example_function_name>\n"
             "<parameter=example_parameter_1>value_1</parameter>\n"
@@ -1219,7 +1219,7 @@ class TestFallbackToolPromptFormat:
 
         prompt = (
             "<|im_start|>system\n<tools>\n"
-            '{"type":"function","function":{"name":"read_file"}}\n'
+            '{"type":"function","function":{"name":"read_file","description":"Read a file","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}}\n'
             "</tools>\n"
             "<tool_call>\n<function=example_function_name>\n"
             "<parameter=example_parameter_1>value_1</parameter>\n"
@@ -1289,7 +1289,7 @@ class TestFallbackToolPromptFormat:
 
         prompt = (
             "<|im_start|>system\n<tools>\n"
-            '{"type":"function","function":{"name":"read_file"}}\n'
+            '{"type":"function","function":{"name":"read_file","description":"Read a file","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}}\n'
             "</tools>\n"
             "<tool_call>\n<function=example_function_name>\n"
             "<parameter=example_parameter_1>value_1</parameter>\n"

--- a/tests/test_tool_prompt_fallback.py
+++ b/tests/test_tool_prompt_fallback.py
@@ -107,11 +107,14 @@ class OpenPanguLikeTokenizer:
 
 
 def _qwen_prompt() -> str:
-    return """<|im_start|>system
+    # The native Qwen template renders each requested tool with `tool | tojson`
+    # — the full schema, not a name-only stub. The gate compares parameter
+    # contracts, so the fixture renders what the template renders.
+    entries = "\n".join(json.dumps(t, separators=(",", ":")) for t in _qwen_test_tools())
+    return f"""<|im_start|>system
 # Tools
 <tools>
-{"type":"function","function":{"name":"run_command"}}
-{"type":"function","function":{"name":"read_file"}}
+{entries}
 </tools>
 <tool_call>
 <function=example_function_name>

--- a/vmlx_engine/api/tool_calling.py
+++ b/vmlx_engine/api/tool_calling.py
@@ -541,59 +541,98 @@ def check_and_inject_fallback_tools(
 
     _lfm2_has_native_tool_schema = _lfm2_has_exact_native_tool_schema()
 
+    _CONTRACT_PROSE_KEYS = frozenset({"description", "title", "examples", "$comment"})
+
     def _parameter_contract(schema: Any) -> Any:
         """Canonical form of a JSON-schema parameter block.
 
-        Names, required-ness, types, enums and nested object/array structure
-        are the contract; descriptions, titles, defaults and key order are
-        not. Two renders with the same contract are the same native catalog
-        even when their prose differs, so a byte-level difference alone never
-        forces the fallback (which would rewrite the opening system bytes and
-        move every SSD prefix).
+        Every validation keyword is part of the contract — type, enum, const,
+        properties, required, items, additionalProperties, minLength,
+        pattern, format, minimum, maxItems, oneOf/anyOf, ... — with key order
+        removed. Only prose (description, title, examples, $comment) is
+        ignored: two renders with the same validation schema are the same
+        native catalog even when their wording differs, so a byte-level
+        difference alone never forces the fallback (which would rewrite the
+        opening system bytes and move every SSD prefix). A render that drops
+        a constraint has changed what the model is told to produce and is
+        deficient (audit follow-up 2026-09-07: minLength, additionalProperties
+        and the parameters object itself were previously outside the contract).
         """
-        if not isinstance(schema, dict):
-            return None
-        contract: dict[str, Any] = {}
-        schema_type = schema.get("type")
-        if isinstance(schema_type, list):
-            contract["type"] = sorted(str(t) for t in schema_type)
-        elif isinstance(schema_type, str):
-            contract["type"] = schema_type
-        if isinstance(schema.get("enum"), list):
-            contract["enum"] = sorted(
-                json.dumps(value, sort_keys=True) for value in schema["enum"]
-            )
-        properties = schema.get("properties")
-        if isinstance(properties, dict):
-            contract["properties"] = {
-                str(name): _parameter_contract(sub) for name, sub in properties.items()
+        if isinstance(schema, dict):
+            contract: dict[str, Any] = {}
+            for key, value in schema.items():
+                key_text = str(key)
+                if key_text in _CONTRACT_PROSE_KEYS:
+                    continue
+                if key_text == "properties" and isinstance(value, dict):
+                    contract[key_text] = {
+                        str(name): _parameter_contract(sub)
+                        for name, sub in value.items()
+                    }
+                elif key_text == "required" and isinstance(value, list):
+                    contract[key_text] = sorted(str(name) for name in value)
+                elif key_text == "type" and isinstance(value, list):
+                    contract[key_text] = sorted(str(t) for t in value)
+                elif key_text == "enum" and isinstance(value, list):
+                    contract[key_text] = sorted(
+                        json.dumps(item, sort_keys=True) for item in value
+                    )
+                else:
+                    contract[key_text] = _parameter_contract(value)
+            return contract
+        if isinstance(schema, list):
+            return [_parameter_contract(item) for item in schema]
+        return schema
+
+    def _argument_contract(parameters: Any) -> Any:
+        """The contract of a function's ``parameters`` block. A missing block,
+        ``{}``, ``{"type": "object"}`` and ``{"type": "object", "properties":
+        {}}`` all tell the model "no arguments" and compare equal; anything
+        that names a property or adds a constraint is compared in full."""
+        contract = _parameter_contract(parameters if isinstance(parameters, dict) else {})
+        if isinstance(contract, dict):
+            residue = {
+                key: value
+                for key, value in contract.items()
+                if not (key == "type" and value == "object")
+                and not (key == "properties" and value == {})
+                and not (key == "required" and value == [])
             }
-        required = schema.get("required")
-        if isinstance(required, list):
-            contract["required"] = sorted(str(name) for name in required)
-        items = schema.get("items")
-        if isinstance(items, dict):
-            contract["items"] = _parameter_contract(items)
+            if not residue:
+                return {}
         return contract
+
+    def _requested_function_schema(tool: Any) -> Optional[dict]:
+        """The request side of the comparison: name plus ``parameters`` (None
+        when the caller declared none — a legitimate no-argument tool)."""
+        func = _tool_func(tool)
+        name = func.get("name") if isinstance(func, dict) else None
+        if not isinstance(name, str) or not name:
+            return None
+        return {"name": name, "parameters": func.get("parameters")}
 
     def _rendered_function_schema(entry: Any) -> Optional[dict]:
         """A rendered catalog entry: OpenAI ``{type, function}`` wrapper, flat
         Responses shape, or the bare function object some templates emit
-        (MiniMax renders ``tool.function | tojson``)."""
+        (MiniMax renders ``tool.function | tojson``). An entry that names a
+        function but carries no ``parameters`` object is returned with
+        ``parameters`` = None so it counts as a rendered — and deficient —
+        function, not as an XML-only catalog."""
         normalized = _normalized_function_schema(entry)
         if normalized is not None:
             return normalized
-        if (
-            isinstance(entry, dict)
-            and isinstance(entry.get("name"), str)
-            and entry.get("name")
-            and isinstance(entry.get("parameters"), dict)
-            and not isinstance(entry.get("function"), dict)
-        ):
-            bare = dict(entry)
-            bare.pop("type", None)
-            return bare
-        return None
+        if not isinstance(entry, dict):
+            return None
+        nested = entry.get("function")
+        candidate = nested if isinstance(nested, dict) else entry
+        name = candidate.get("name")
+        if not isinstance(name, str) or not name:
+            return None
+        bare = dict(candidate)
+        bare.pop("type", None)
+        if not isinstance(bare.get("parameters"), dict):
+            bare["parameters"] = None
+        return bare
 
     def _rendered_tools_block_schema_verdict() -> Optional[bool]:
         """Semantic check of the JSON entries a template rendered inside
@@ -604,8 +643,8 @@ def check_and_inject_fallback_tools(
         ``True``  — exactly the requested tools are rendered, each once, and
                     every parameter contract matches the request.
         ``False`` — a requested tool is missing, duplicated or rendered with a
-                    different parameter contract, or the block carries tools
-                    this request did not authorize.
+                    different parameter contract. Extra rendered tools are a
+                    superset (narrowed continuation catalogs stay native).
 
         Names alone are not a contract: a render that named ``read_file`` and
         ``terminal`` while omitting ``path`` and ``command`` was accepted as
@@ -614,11 +653,11 @@ def check_and_inject_fallback_tools(
         """
         expected_by_name: dict[str, Any] = {}
         for tool in template_tools:
-            normalized = _normalized_function_schema(tool)
-            if normalized is None or normalized["name"] in expected_by_name:
+            requested = _requested_function_schema(tool)
+            if requested is None or requested["name"] in expected_by_name:
                 return False
-            expected_by_name[normalized["name"]] = _parameter_contract(
-                normalized["parameters"]
+            expected_by_name[requested["name"]] = _argument_contract(
+                requested["parameters"]
             )
         if not expected_by_name:
             return None
@@ -654,12 +693,21 @@ def check_and_inject_fallback_tools(
                 found_entry = True
                 if normalized["name"] in rendered_by_name:
                     return False
-                rendered_by_name[normalized["name"]] = _parameter_contract(
+                rendered_by_name[normalized["name"]] = _argument_contract(
                     normalized["parameters"]
                 )
         if not found_entry:
             return None
-        return rendered_by_name == expected_by_name
+        # Every requested tool must be rendered once with its contract. A
+        # render that ALSO carries tools this request no longer lists (a
+        # continuation turn whose catalog was narrowed to the remaining tool,
+        # a broader source-owned catalog) is a superset, not a deficiency:
+        # forcing the fallback there would rewrite the opening system bytes
+        # on every agentic turn and defeat prefix reuse.
+        return all(
+            name in rendered_by_name and rendered_by_name[name] == contract
+            for name, contract in expected_by_name.items()
+        )
 
     # Computed once per request; ``is not False`` keeps XML-only catalogs on
     # their existing name-based recognition.


### PR DESCRIPTION
## Problem (audit follow-up 2026-09-07, holes reproduced after #268)
`_parameter_contract` canonicalized only `type`, `enum`, `properties`, `required` and `items`, so a rendered catalog that dropped `minLength`, `pattern`, `additionalProperties`, `maxItems` or any other validation keyword was still accepted as native. A rendered function entry with no `parameters` object at all decoded to nothing, which made the whole `<tools>` block look XML-only and kept the old name-based acceptance.

## Change
- The contract is every JSON-schema keyword except prose (`description`, `title`, `examples`, `$comment`), recursively and order-free.
- An entry that names a function without a `parameters` object counts as a rendered — deficient — function; a missing block, `{}`, `{"type":"object"}` and `{"type":"object","properties":{}}` are the same "no arguments" contract (name-only request tools stay native when rendered that way).
- A render carrying the requested tools with matching contracts **plus** tools the request no longer lists (a narrowed continuation catalog over a stable source-owned prompt) stays native — rewriting the opening system bytes on every agentic turn would defeat prefix reuse; a subset render that omits a requested tool still injects.

## Tests (failing-first)
`tests/test_native_tool_schema_completeness.py`: five constraint holes × three checked-in native templates (minLength, additionalProperties, pattern, maxItems, parameters object deleted) — 15 red → green; exact constrained renders and prose-only differences stay native; superset stays native, subset injects. The Qwen/Step synthetic prompts in `test_tool_prompt_fallback.py` / `test_tool_format.py` rendered name-only stubs while their requests carried real schemas — the exact gap — and now render the request's schema the way the real templates do (`tool | tojson`). Gate suites: 951 passed / 1 skipped. Full-suite control against `main` in a comment before merge.

Not covered: live per-dialect runtime proof; XML-only (`<name>tool</name>`) catalogs still rely on name-based recognition (no fixture).