### PR TITLE
feat(ernie4_5): add ERNIE-4.5 MoE runtime with native MTP

### DIFF
--- a/panel/src/main/model-config-registry.ts
+++ b/panel/src/main/model-config-registry.ts
@@ -254,6 +254,14 @@ registerFamily('zaya1-vl', { cacheType: 'hybrid', toolParser: 'zaya_xml', suppor
 // relies on config.json vision_config, not the family's isMultimodal flag.
 registerFamily('qwen3.5', { cacheType: 'kv', toolParser: 'qwen', reasoningParser: 'qwen3', enableAutoToolChoice: true, isMultimodal: false, description: 'Qwen 3.5 (dense)', priority: 4 })
 registerFamily('qwen3.5-moe', { cacheType: 'kv', toolParser: 'qwen', reasoningParser: 'qwen3', enableAutoToolChoice: true, isMultimodal: false, description: 'Qwen 3.5 MoE', priority: 4 })
+// ERNIE-4.5 MoE (Baidu, model_type ernie4_5_moe; vMLX-owned runtime in
+// vmlx_engine/models/ernie4_5). Plain GQA -> generic kv cache, paged OFF by
+// default like other non-hybrid families. The PT chat template has no tool
+// syntax and no think block, so no parser is stamped and thinking is pinned
+// false; the -Thinking variants get their own row once live-proven. Mirrors
+// the Python model_configs.py row exactly (eos </s> + <|end_of_sentence|>,
+// temp 0.8 / top_p 0.8 recommended by generation_config).
+registerFamily('ernie4.5', { cacheType: 'kv', supportsThinking: false, thinkInTemplate: false, defaultEnableThinking: false, usePagedCache: false, enableAutoToolChoice: false, isMultimodal: false, description: 'ERNIE-4.5 MoE (Baidu): dense layer 0 + 64-expert MoE, GQA, MTP head', priority: 20 })
 // Qwen3.8 Flash Next is a Qwen4Exp VL wrapper around the hybrid QSA/Gated
 // DeltaNet decoder.  Base MLX bundles do not require a jang_config sidecar, so
 // every user-visible capability that is invariant for this model_type must be
@@ -551,6 +559,8 @@ const MODEL_TYPE_TO_FAMILY: Record<string, string> = {
   'qwen3_5': 'qwen3.5',
   'qwen3_5_moe': 'qwen3.5-moe',
   'qwen3_5_moe_text': 'qwen3.5-moe', // Qwen3.6-35B-A3B inner text_config model_type
+  'ernie4_5_moe': 'ernie4.5',
+  'ernie4_5': 'ernie4.5', // engine family_name (capabilities.family) and dense variant
   'qwen4_exp': 'qwen4-exp',
   'glm5_next': 'glm5-next',
   'glm5_next_text': 'glm5-next',
@@ -1306,6 +1316,12 @@ function detectNativeMtpCapability(
     'dots3_note',
     'glm5_next',
     'glm5_next_text',
+    // ERNIE-4.5 MoE (Baidu): one dense MTP block stored as model.mtp_block.0.*
+    // (+ mtp_emb_norm/mtp_hidden_norm/mtp_linear_proj). Text-only, plain GQA
+    // attention -> plain_kv_v1. Measured 2026-09-05 (JANG_6M): D1 the only
+    // depth faster than AR on every prompt; sidecar pins best_depth 1.
+    'ernie4_5_moe',
+    'ernie4_5',
   ])
   const modelTypes = [
     parsedConfig.model_type,
@@ -1315,6 +1331,7 @@ function detectNativeMtpCapability(
   if (!modelTypes.some(value => supportedFamilies.has(value))) return undefined
   const hy3 = modelTypes.includes('hy_v3')
   const glm5Next = modelTypes.includes('glm5_next') || modelTypes.includes('glm5_next_text')
+  const ernie45 = modelTypes.includes('ernie4_5_moe') || modelTypes.includes('ernie4_5')
   const tuningDepth = readNativeMtpTuningDepth(modelPath)
   const hy3OutputEquivalent = hy3
     ? nativeMtpOutputEquivalent(modelPath)
@@ -1340,7 +1357,12 @@ function detectNativeMtpCapability(
       && Number.isInteger(baseLayerCount)
       && baseLayerCount > 0
       && keys.some(key => key.startsWith(`model.layers.${baseLayerCount}.`))
-    const hasMtp = keys.some(key => /(^|\.)mtp(\.|$)/.test(key)) || hasAppendedGlmMtp
+    // ERNIE stores its head as mtp_block / mtp_emb_norm / mtp_hidden_norm /
+    // mtp_linear_proj (no bare "mtp" segment), mirroring the engine's
+    // native_mtp._mtp_keys_from_weight_keys.
+    const hasMtp = keys.some(key =>
+      /(^|\.)mtp(\.|$)/.test(key) || /(^|\.)mtp_(block|emb_norm|hidden_norm|linear_proj)(\.|$)/.test(key),
+    ) || hasAppendedGlmMtp
     if (!hasMtp) return undefined
     const hasVisionWeights = keys.some(key =>
       /(^|\.)(vision_tower|vision_model|visual|patch_embed|multi_modal_projector|mm_projector|image_newline)(\.|$)/.test(key),
@@ -1380,7 +1402,7 @@ function detectNativeMtpCapability(
       // (cache.native.schema): hy3 is plain attention (plain_kv_v1); the
       // qwen3.6 hybrid SSM+attention bundle reports hybrid_ssm_v1 (NOT
       // hybrid_ssm_attention_kv_v1, which matched nothing the engine emits).
-      nativeCacheType: hy3
+      nativeCacheType: hy3 || ernie45
         ? 'plain_kv_v1'
         : glm5Next
           ? 'glm5_next_native_v2'

--- a/panel/src/shared/detectedFamilyNames.ts
+++ b/panel/src/shared/detectedFamilyNames.ts
@@ -45,6 +45,7 @@ const ENGINE_FAMILY_TO_REGISTRY: Readonly<Record<string, string>> = Object.freez
   nemotron_h: 'nemotron-h',
   glm5_next: 'glm5-next',
   glm5_next_text: 'glm5-next',
+  ernie4_5: 'ernie4.5',
 })
 
 export function normalizeDetectedFamilyName(family?: string): string | undefined {

--- a/panel/tests/model-config-registry.test.ts
+++ b/panel/tests/model-config-registry.test.ts
@@ -416,6 +416,54 @@ describe('detectModelConfigFromDir JANG multimodal detection', () => {
     })
   })
 
+  it('renders native MTP for ERNIE-4.5, whose head is stored as mtp_block (no bare mtp segment)', () => {
+    // Verbatim key shape from the shipped JANG_6M bundle index: model.mtp_block.0.*,
+    // model.mtp_emb_norm.0.weight, ... The generic /(^|\.)mtp(\.|$)/ test never
+    // matches these, so without the mtp_* pattern the family allowlist alone
+    // would still hide the control while the engine runs MTP.
+    const dir = makeModelDir(
+      { model_type: 'ernie4_5_moe', num_hidden_layers: 28, num_nextn_predict_layers: 1 },
+      { format: 'jang', mtp: { kept: true, enabled: true, num_layers: 1, tensor_count: 12 } },
+    )
+    writeFileSync(join(dir, 'model.safetensors.index.json'), JSON.stringify({
+      weight_map: {
+        'model.embed_tokens.weight': 'model.safetensors',
+        'model.mtp_block.0.self_attn.q_proj.weight': 'model.safetensors',
+        'model.mtp_emb_norm.0.weight': 'model.safetensors',
+        'model.mtp_hidden_norm.0.weight': 'model.safetensors',
+        'model.mtp_linear_proj.0.weight': 'model.safetensors',
+      },
+    }))
+    // Sidecar shape written 2026-09-05 from the measured depth sweep.
+    writeFileSync(join(dir, 'vmlx_mtp_tuning.json'), JSON.stringify({
+      native_mtp: { best_depth: 1, validated: true },
+    }))
+
+    const detected = detectModelConfigFromDir(dir)
+
+    expect(detected.nativeMtp).toMatchObject({
+      supported: true,
+      depth: 1,
+      depthSource: 'vmlx_mtp_tuning.json:native_mtp.best_depth',
+      runtimeScope: 'text',
+      // Plain GQA attention: the engine reports native_cache schema plain_kv_v1.
+      nativeCacheType: 'plain_kv_v1',
+      requiresDeterministicSampling: false,
+      defaultMode: 'auto',
+    })
+  })
+
+  it('hides native MTP for an ERNIE-4.5 bundle whose MTP tensors were dropped', () => {
+    const dir = makeModelDir(
+      { model_type: 'ernie4_5_moe', num_hidden_layers: 28, num_nextn_predict_layers: 1 },
+      { format: 'jang' },
+    )
+    writeFileSync(join(dir, 'model.safetensors.index.json'), JSON.stringify({
+      weight_map: { 'model.embed_tokens.weight': 'model.safetensors' },
+    }))
+    expect(detectModelConfigFromDir(dir).nativeMtp).toBeUndefined()
+  })
+
   it('detects the appended layer-N GLM MTP block for the native VL runtime', () => {
     const dir = makeModelDir({
       model_type: 'glm5_next',

--- a/tests/test_acceleration_contract.py
+++ b/tests/test_acceleration_contract.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 
 def _rows(contract):
     return {row["id"]: row for row in contract["features"]}
@@ -158,6 +160,52 @@ def test_glm_mtp_prompt_priming_is_exact_opt_in(monkeypatch):
     rows = _rows(build_acceleration_contract("glm5_next"))
     assert rows["mtp_prompt_priming"]["requested"] is True
     assert rows["mtp_prompt_priming"]["state"] == "configured_unattested"
+
+
+def test_ernie_mtp_prompt_priming_defaults_on_with_explicit_opt_out(monkeypatch):
+    from vmlx_engine.acceleration_contract import (
+        acceleration_family_from_config,
+        build_acceleration_contract,
+    )
+
+    assert acceleration_family_from_config({"model_type": "ernie4_5_moe"}) == "ernie4_5"
+    monkeypatch.delenv("VMLX_ERNIE45_MTP_PROMPT_PRIMING", raising=False)
+    monkeypatch.delenv("VMLINUX_ERNIE45_MTP_PROMPT_PRIMING", raising=False)
+    contract = build_acceleration_contract("ernie4_5_moe")
+    assert contract["known_family"] is True
+    rows = _rows(contract)
+    assert rows["mtp_prompt_priming"]["requested"] is True
+    assert rows["mtp_prompt_priming"]["selection_source"] == "default"
+    assert rows["mtp_prompt_priming"]["state"] == "configured_unattested"
+
+    monkeypatch.setenv("VMLX_ERNIE45_MTP_PROMPT_PRIMING", "0")
+    rows = _rows(build_acceleration_contract("ernie4_5_moe"))
+    assert rows["mtp_prompt_priming"]["requested"] is False
+    assert rows["mtp_prompt_priming"]["state"] == "disabled"
+
+
+@pytest.mark.parametrize(
+    "vmlinux,vmlx",
+    [
+        (None, None), ("", None), (None, ""), ("0", None), (None, "0"), ("1", None),
+        (None, "1"), ("false", "1"), ("1", "0"), ("0", "1"), ("off", "off"), ("yes", "no"),
+    ],
+)
+def test_ernie_priming_report_matches_runtime_gate(monkeypatch, vmlinux, vmlx):
+    """Both aliases, any combination: what /health reports must be what the gate does."""
+    from vmlx_engine.acceleration_contract import build_acceleration_contract
+    from vmlx_engine.patches.mlx_lm_mtp.batch_generator import _glm_prompt_priming_enabled
+
+    for name, value in (
+        ("VMLINUX_ERNIE45_MTP_PROMPT_PRIMING", vmlinux),
+        ("VMLX_ERNIE45_MTP_PROMPT_PRIMING", vmlx),
+    ):
+        monkeypatch.delenv(name, raising=False)
+        if value is not None:
+            monkeypatch.setenv(name, value)
+    reported = _rows(build_acceleration_contract("ernie4_5_moe"))["mtp_prompt_priming"]["requested"]
+    actual = _glm_prompt_priming_enabled(type("Model", (), {"model_type": "ernie4_5_moe"})())
+    assert reported is actual
 
 
 def test_glm_vectorized_kda_verify_defaults_on_with_explicit_opt_out(

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -237,6 +237,20 @@ class TestIsMllmModel:
         assert is_mllm_model(str(tmp_path)) is False
         assert is_mllm_model(str(tmp_path), force_mllm=True) is False
 
+    def test_ernie4_5_routes_text_runtime_even_when_force_mllm(self, tmp_path):
+        """ERNIE-4.5 is text-only; mlx_vlm has no ernie4_5_moe loader/drafter."""
+        import json
+
+        _IS_MLLM_CACHE.clear()
+        config = {
+            "model_type": "ernie4_5_moe",
+            "architectures": ["Ernie4_5_MoeForCausalLM"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+
+        assert is_mllm_model(str(tmp_path)) is False
+        assert is_mllm_model(str(tmp_path), force_mllm=True) is False
+
     def test_remote_model_name_returns_false(self):
         """Remote HF names without local config.json default to non-VLM.
         Users must force VLM mode via session settings."""

--- a/tests/test_ernie4_5_runtime.py
+++ b/tests/test_ernie4_5_runtime.py
@@ -1,0 +1,480 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ERNIE-4.5 MoE vendored text runtime — synthetic contract tests.
+
+Real-bundle reference comparisons and numerical output-equivalence limits are
+recorded separately in the introducing PR. These tests pin the source contract
+on a tiny random model: registration, config parsing, the documented
+departures from upstream mlx-lm (aux-loss-free routing bias kept for SELECTION only,
+config-driven norm_min, pre-norm hidden for the native-MTP seam, MTP head attach + sanitize
+renames), cache layout, and the engine-side detection helpers.
+"""
+import json
+from unittest.mock import patch
+
+import mlx.core as mx
+import pytest
+
+from vmlx_engine.models.ernie4_5.register import register_ernie4_5_runtime
+
+TINY_CFG = {
+    "model_type": "ernie4_5_moe",
+    "hidden_size": 64,
+    "intermediate_size": 96,
+    "moe_intermediate_size": 32,
+    "num_hidden_layers": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "vocab_size": 256,
+    "max_position_embeddings": 512,
+    "rms_norm_eps": 1e-5,
+    "rope_theta": 10000.0,
+    "use_bias": False,
+    "tie_word_embeddings": True,
+    "moe_num_experts": 8,
+    "moe_k": 2,
+    "moe_layer_start_index": 1,  # layer 0 dense, layer 1 MoE (as the real 28-layer model)
+    "moe_layer_interval": 1,
+    "moe_num_shared_experts": 1,
+    "moe_norm_min": 1e-12,
+    "num_nextn_predict_layers": 1,
+}
+
+
+@pytest.fixture(scope="module")
+def ernie():
+    register_ernie4_5_runtime()
+    import mlx_lm.models.ernie4_5_moe as mod
+
+    return mod
+
+
+@pytest.fixture(scope="module")
+def tiny_model(ernie):
+    mx.random.seed(0)
+    model = ernie.Model(ernie.ModelArgs.from_dict(TINY_CFG))
+    model.eval()
+    mx.eval(model.parameters())
+    return model
+
+
+class TestRegistration:
+    def test_registers_vendored_module_over_upstream(self, ernie):
+        assert ernie.__file__.replace("\\", "/").endswith(
+            "vmlx_engine/models/ernie4_5/ernie4_5_moe.py"
+        )
+        # Idempotent: a second call keeps the same module object.
+        register_ernie4_5_runtime()
+        import mlx_lm.models.ernie4_5_moe as again
+
+        assert again is ernie
+
+    def test_args_parse_departures_from_real_config_keys(self, ernie):
+        args = ernie.ModelArgs.from_dict(TINY_CFG)
+        assert args.moe_norm_min == 1e-12
+        assert args.num_nextn_predict_layers == 1
+        assert args.moe_k == 2 and args.moe_num_experts == 8
+
+    def test_model_configs_registry_row(self):
+        import vmlx_engine.model_configs  # noqa: F401  (registers families)
+        from vmlx_engine.model_config_registry import get_model_config_registry
+
+        registry = get_model_config_registry()
+        with patch(
+            "vmlx_engine.model_config_registry.load_config",
+            lambda _path: {"model_type": "ernie4_5_moe"},
+        ):
+            registry.clear_cache()
+            cfg = registry.lookup("ERNIE-4.5-21B-A3B-PT")
+        assert cfg.family_name == "ernie4_5"
+        assert cfg.cache_type == "kv"
+        assert cfg.eos_tokens == ["</s>", "<|end_of_sentence|>"]
+        assert cfg.tool_parser is None and cfg.supports_native_tools is False
+        assert cfg.reasoning_parser is None and cfg.supports_thinking is False
+        assert cfg.is_mllm is False
+
+
+class TestCacheAndForward:
+    def test_cache_layout_is_plain_kv(self, tiny_model):
+        from mlx_lm.models.cache import KVCache
+
+        cache = tiny_model.make_cache()
+        assert len(cache) == 2 and all(isinstance(c, KVCache) for c in cache)
+        mtp_cache = tiny_model.make_mtp_cache()
+        assert len(mtp_cache) == 1 and isinstance(mtp_cache[0], KVCache)
+        assert tiny_model.mtp is not None
+
+    def test_call_returns_pre_norm_hidden_and_logits_agree(self, tiny_model):
+        x = mx.array([[3, 17, 42, 99, 7]])
+        logits, hidden = tiny_model(x, return_hidden=True)
+        assert logits.shape == (1, 5, TINY_CFG["vocab_size"])
+        assert hidden.shape == (1, 5, TINY_CFG["hidden_size"])
+        # hidden is PRE-norm: normalising it and projecting reproduces the logits.
+        re_logits = tiny_model._logits(tiny_model.model.norm(hidden))
+        assert mx.allclose(re_logits, logits, atol=1e-5).item()
+        # ... and it is NOT already normalised (rms differs from 1 in general).
+        rms = mx.sqrt(mx.mean(hidden.astype(mx.float32) ** 2, axis=-1))
+        assert not mx.allclose(rms, mx.ones_like(rms), atol=1e-2).item()
+        only_hidden = tiny_model(x, return_logits=False)
+        assert mx.array_equal(only_hidden, hidden).item()
+
+    def test_prefill_then_decode_shapes_and_offsets(self, tiny_model):
+        cache = tiny_model.make_cache()
+        x = mx.array([[3, 17, 42, 99]])
+        logits = tiny_model(x, cache=cache)
+        mx.eval(logits)
+        assert logits.shape == (1, 4, TINY_CFG["vocab_size"])
+        assert all(c.offset == 4 for c in cache)
+        step = tiny_model(mx.array([[7]]), cache=cache)
+        mx.eval(step)
+        assert step.shape == (1, 1, TINY_CFG["vocab_size"])
+        assert all(c.offset == 5 for c in cache)
+
+    def test_mtp_forward_contract(self, tiny_model):
+        x = mx.array([[3, 17, 42, 99, 7]])
+        logits, hidden = tiny_model(x, return_hidden=True)
+        mtp_cache = tiny_model.make_mtp_cache()
+        # hidden at t + token t+1 -> distribution over token t+2
+        head_logits = tiny_model.mtp_forward(hidden[:, :-1], x[:, 1:], mtp_cache)
+        mx.eval(head_logits)
+        assert head_logits.shape == (1, 4, TINY_CFG["vocab_size"])
+        assert mtp_cache[0].offset == 4
+        with_hidden = tiny_model.mtp_forward(
+            hidden[:, -1:], x[:, -1:], mtp_cache, return_hidden=True
+        )
+        assert isinstance(with_hidden, tuple) and with_hidden[1].shape == (1, 1, TINY_CFG["hidden_size"])
+        assert mtp_cache[0].offset == 5
+        # Chained drafting feeds the returned hidden back in as the next "previous
+        # hidden", which mtp_forward norms. So the returned hidden must be the head's
+        # PRE-norm output: norm + project reproduces the logits, projecting it raw does not.
+        chain_logits, chain_hidden = with_hidden
+        assert mx.allclose(tiny_model._logits(tiny_model.model.norm(chain_hidden)), chain_logits, atol=1e-5).item()
+        assert not mx.allclose(tiny_model._logits(chain_hidden), chain_logits, atol=1e-3).item()
+
+    def test_router_bias_selects_experts_but_does_not_weight_them(self, ernie):
+        """Departure 1 (aux-loss-free routing): e_score_correction_bias is added to the
+        softmax probs ONLY to pick the top-k experts; the combine weights use the
+        unbiased probs. A uniform bias therefore changes nothing, while a targeted
+        bias changes which experts run and hence the output."""
+        mx.random.seed(1)
+        args = ernie.ModelArgs.from_dict(TINY_CFG)
+        mlp = ernie.Ernie4_5_MoeMLP(args)
+        mx.eval(mlp.parameters())
+        x = mx.random.normal((1, 3, args.hidden_size))
+        base = mlp(x)
+        mx.eval(base)
+        # Uniform shift: same selection, same weights -> identical output.
+        mlp.e_score_correction_bias = mx.full((args.moe_num_experts,), 5.0, dtype=mx.float32)
+        assert mx.allclose(mlp(x), base, atol=1e-6).item()
+        # Force the two least-likely experts of token 0 into the top-k.
+        mlp.e_score_correction_bias = mx.zeros((args.moe_num_experts,), dtype=mx.float32)
+        probs = mlp.gate_act(mlp._router_logits(x))[0, 0]
+        worst = mx.argsort(probs)[:2].tolist()
+        bias = mx.zeros((args.moe_num_experts,), dtype=mx.float32)
+        for e in worst:
+            bias[e] = 10.0
+        mlp.e_score_correction_bias = bias
+        flipped = mlp(x)
+        mx.eval(flipped)
+        assert not mx.allclose(flipped[0, 0], base[0, 0], atol=1e-4).item()
+        # Router logits are computed in float32 regardless of activation dtype.
+        assert mlp._router_logits(x.astype(mx.float16)).dtype == mx.float32
+
+
+class TestSanitize:
+    def test_renames_ernie_mtp_keys_onto_the_head(self, tiny_model):
+        w = {
+            "model.mtp_block.0.self_attn.q_proj.weight": mx.zeros((1,)),
+            "model.mtp_emb_norm.0.weight": mx.zeros((1,)),
+            "model.mtp_hidden_norm.0.weight": mx.zeros((1,)),
+            "model.mtp_linear_proj.0.weight": mx.zeros((1,)),
+            "model.layers.0.self_attn.q_proj.weight": mx.zeros((1,)),
+        }
+        out = tiny_model.sanitize(w)
+        assert set(out) == {
+            "mtp.layers.0.self_attn.q_proj.weight",
+            "mtp.emb_norm.weight",
+            "mtp.hidden_norm.weight",
+            "mtp.linear_proj.weight",
+            "model.layers.0.self_attn.q_proj.weight",
+        }
+
+    def test_drops_mtp_keys_when_no_head_is_configured(self, ernie):
+        cfg = dict(TINY_CFG, num_nextn_predict_layers=0)
+        model = ernie.Model(ernie.ModelArgs.from_dict(cfg))
+        assert not hasattr(model, "mtp") and model.make_mtp_cache() == []
+        out = model.sanitize({"model.mtp_block.0.x": mx.zeros((1,)), "model.embed_tokens.weight": mx.zeros((1,))})
+        assert set(out) == {"model.embed_tokens.weight"}
+
+    def test_routing_bias_is_flattened_to_float32_on_the_moe_block(self, tiny_model):
+        raw = mx.arange(8, dtype=mx.bfloat16).reshape(1, 8)  # HF stores [1, E]
+        out = tiny_model.sanitize({"model.layers.1.mlp.moe_statics.e_score_correction_bias": raw})
+        key = "model.layers.1.mlp.e_score_correction_bias"
+        assert key in out and out[key].shape == (8,) and out[key].dtype == mx.float32
+
+    def test_quantised_routing_bias_is_a_loud_converter_defect(self, tiny_model):
+        with pytest.raises(ValueError, match="float32 passthrough"):
+            tiny_model.sanitize({"model.layers.1.mlp.moe_statics.e_score_correction_bias.scales": mx.zeros((1,))})
+
+    def test_stacks_experts_and_drops_tied_lm_head(self, tiny_model):
+        w = {"lm_head.weight": mx.zeros((1,)), "lm_head.scales": mx.zeros((1,)), "lm_head.biases": mx.zeros((1,))}
+        for e in range(TINY_CFG["moe_num_experts"]):
+            for m in ("gate_proj", "up_proj"):
+                w[f"model.layers.1.mlp.experts.{e}.{m}.weight"] = mx.zeros((32, 64))
+            w[f"model.layers.1.mlp.experts.{e}.down_proj.weight"] = mx.zeros((64, 32))
+        out = tiny_model.sanitize(w)
+        assert not any(k.startswith("lm_head.") for k in out)  # weight AND quant sidecars
+        assert out["model.layers.1.mlp.switch_mlp.gate_proj.weight"].shape == (8, 32, 64)
+        assert out["model.layers.1.mlp.switch_mlp.down_proj.weight"].shape == (8, 64, 32)
+        assert not any(".experts." in k for k in out)
+
+    def test_stacks_quantised_expert_sidecars_too(self, tiny_model):
+        w = {}
+        for e in range(TINY_CFG["moe_num_experts"]):
+            w[f"model.layers.1.mlp.experts.{e}.up_proj.weight"] = mx.zeros((32, 8), dtype=mx.uint32)
+            w[f"model.layers.1.mlp.experts.{e}.up_proj.scales"] = mx.zeros((32, 1))
+            w[f"model.layers.1.mlp.experts.{e}.up_proj.biases"] = mx.zeros((32, 1))
+        out = tiny_model.sanitize(w)
+        assert set(out) == {
+            "model.layers.1.mlp.switch_mlp.up_proj.weight",
+            "model.layers.1.mlp.switch_mlp.up_proj.scales",
+            "model.layers.1.mlp.switch_mlp.up_proj.biases",
+        }
+        assert out["model.layers.1.mlp.switch_mlp.up_proj.scales"].shape == (8, 32, 1)
+
+class TestWeightLoading:
+    def _model(self, ernie, **overrides):
+        return ernie.Model(ernie.ModelArgs.from_dict(dict(TINY_CFG, **overrides)))
+
+    def _weights(self, model):
+        from mlx.utils import tree_flatten
+        return dict(tree_flatten(model.parameters()))
+
+    @pytest.mark.parametrize("disabled_alias", ["VMLX_NATIVE_MTP", "VMLINUX_NATIVE_MTP"])
+    @pytest.mark.parametrize("sharded", [False, True])
+    @pytest.mark.parametrize("quantized", [False, True])
+    def test_disabled_head_checkpoint_loads_backbone_only(
+        self, ernie, monkeypatch, disabled_alias, sharded, quantized
+    ):
+        import mlx.nn as nn
+        from types import SimpleNamespace
+        from vmlx_engine.patches.mlx_lm_mtp.batch_generator import _is_mtp_eligible
+
+        # The disable switch wins even when the other alias enables MTP.
+        for alias in ("VMLX_NATIVE_MTP", "VMLINUX_NATIVE_MTP"):
+            monkeypatch.setenv(alias, "1")
+        source = self._model(ernie)
+        if quantized:
+            nn.quantize(source, group_size=32, bits=4)
+        weights = self._weights(source)
+        assert any(k.startswith("mtp.") for k in weights)
+
+        monkeypatch.setenv(disabled_alias, "0")
+        model = self._model(ernie)
+        if quantized:
+            nn.quantize(model, group_size=32, bits=4)
+        assert not hasattr(model, "mtp")
+        assert not _is_mtp_eligible(SimpleNamespace(model=model, uids=[0]))
+        if sharded:
+            for group in (
+                {k: v for k, v in weights.items() if k.startswith("mtp.")},
+                {k: v for k, v in weights.items() if not k.startswith("mtp.")},
+            ):
+                model.load_weights(list(model.sanitize(group).items()), strict=False)
+            model.finalize_ernie_weight_loading()
+        else:
+            model.load_weights(list(model.sanitize(weights).items()))
+        assert model.make_mtp_cache() == []
+        loaded = self._weights(model)
+        assert set(loaded) == {k for k in weights if not k.startswith("mtp.")}
+        assert all(mx.array_equal(v, weights[k]).item() for k, v in loaded.items())
+        inputs = mx.array([[3, 17, 42]])
+        assert mx.array_equal(model(inputs), source(inputs)).item()
+
+    def test_legacy_bundle_requires_explicit_bias_opt_in(self, ernie, monkeypatch, caplog):
+        monkeypatch.delenv("VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS", raising=False)
+        model = self._model(ernie)
+        weights = {k: v for k, v in self._weights(model).items()
+                   if not k.startswith("mtp.") and "e_score_correction_bias" not in k}
+        sanitized = model.sanitize(weights)
+        assert hasattr(model, "mtp")  # sanitization cannot infer absence
+        with pytest.raises(ValueError, match="missing routing bias"):
+            model.load_weights(list(sanitized.items()))
+        monkeypatch.setenv("VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS", "1")
+        model.load_weights(list(sanitized.items()))
+        assert not hasattr(model, "mtp")
+        assert mx.all(model.layers[1].mlp.e_score_correction_bias == 0).item()
+        assert "legacy compatibility" in caplog.text and "AR-only" in caplog.text
+        assert model(mx.array([[3, 17, 42]])).shape == (1, 3, TINY_CFG["vocab_size"])
+
+    def test_no_head_with_valid_bias_loads_ar_without_compatibility_flag(self, ernie, monkeypatch):
+        monkeypatch.delenv("VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS", raising=False)
+        model = self._model(ernie)
+        weights = {k: v for k, v in self._weights(model).items() if not k.startswith("mtp.")}
+        model.load_weights(list(model.sanitize(weights).items()))
+        assert not hasattr(model, "mtp")
+
+    def test_shard_with_both_endpoints_never_detaches_head_or_overwrites_bias(self, ernie):
+        source = self._model(ernie)
+        full = self._weights(source)
+        full["model.layers.1.mlp.e_score_correction_bias"] = mx.arange(8, dtype=mx.float32)
+        endpoints = {k: full.pop(k) for k in (
+            "model.embed_tokens.weight", "model.layers.1.input_layernorm.weight")}
+        model = self._model(ernie)
+        # Head and real bias are loaded BEFORE the misleading two-tensor shard.
+        model.load_weights(list(model.sanitize(full).items()), strict=False)
+        sanitized = model.sanitize(endpoints)
+        assert set(sanitized) == set(endpoints) and hasattr(model, "mtp")
+        model.load_weights(list(sanitized.items()), strict=False)
+        model.finalize_ernie_weight_loading()
+        assert hasattr(model, "mtp")
+        assert mx.array_equal(model.layers[1].mlp.e_score_correction_bias, mx.arange(8)).item()
+
+    @pytest.mark.parametrize("quantized", [False, True])
+    def test_split_experts_and_sidecars_reach_the_actual_module(self, ernie, quantized):
+        import mlx.nn as nn
+        model = self._model(ernie)
+        if quantized:
+            nn.quantize(model, group_size=32, bits=4)
+        full = self._weights(model)
+        prefix = "model.layers.1.mlp.switch_mlp.up_proj."
+        suffixes = ("weight", "scales", "biases") if quantized else ("weight",)
+        stacks = {s: full.pop(prefix + s) for s in suffixes}
+        model.load_weights(list(model.sanitize(full).items()), strict=False)
+        wanted = {}
+        for suffix in suffixes:
+            shape = stacks[suffix].shape
+            wanted[suffix] = mx.stack([mx.full(shape[1:], i + 10, dtype=stacks[suffix].dtype) for i in range(8)])
+            # Reverse shard order also exercises groups that start without expert 0.
+            for indices in (range(4, 8), range(4)):
+                shard = {f"model.layers.1.mlp.experts.{i}.up_proj.{suffix}": wanted[suffix][i] for i in indices}
+                out = model.sanitize(shard)
+                assert not any(".experts." in k for k in out)
+                model.load_weights(list(out.items()), strict=False)
+        model.finalize_ernie_weight_loading()
+        loaded = self._weights(model)
+        for suffix in suffixes:
+            assert mx.array_equal(loaded[prefix + suffix], wanted[suffix]).item()
+        assert not model._ernie_pending_experts
+
+    def test_incomplete_group_fails_at_end_of_load(self, ernie):
+        model = self._model(ernie)
+        full = self._weights(model)
+        stack = full.pop("model.layers.1.mlp.switch_mlp.up_proj.weight")
+        full["model.layers.1.mlp.experts.0.up_proj.weight"] = stack[0]
+        model.load_weights(list(model.sanitize(full).items()), strict=False)
+        with pytest.raises(ValueError, match="incomplete expert groups"):
+            model.finalize_ernie_weight_loading()
+
+    @pytest.mark.parametrize("missing", ["model.layers.0.self_attn.q_proj.weight", "mtp.linear_proj.weight"])
+    def test_missing_backbone_or_partial_head_is_never_accepted(self, ernie, missing):
+        model = self._model(ernie)
+        full = self._weights(model)
+        full.pop(missing)
+        model.load_weights(list(model.sanitize(full).items()), strict=False)
+        with pytest.raises(ValueError, match="missing parameters|incomplete MTP"):
+            model.finalize_ernie_weight_loading()
+
+    def test_partial_bias_loss_is_not_legacy_compatibility(self, ernie, monkeypatch):
+        monkeypatch.setenv("VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS", "1")
+        model = self._model(ernie, num_hidden_layers=3)
+        full = self._weights(model)
+        full.pop("model.layers.2.mlp.e_score_correction_bias")
+        with pytest.raises(ValueError, match="missing routing bias"):
+            model.load_weights(list(model.sanitize(full).items()))
+
+    def test_strict_shape_validation_is_preserved(self, ernie):
+        model = self._model(ernie)
+        full = self._weights(model)
+        full["model.layers.0.self_attn.q_proj.weight"] = mx.zeros((1,))
+        with pytest.raises(ValueError, match="Expected shape"):
+            model.load_weights(list(model.sanitize(full).items()))
+
+    @pytest.mark.parametrize("quantized", [False, True])
+    def test_real_mlx_loader_legacy_checkpoint_policy(self, ernie, tmp_path, monkeypatch, quantized):
+        import mlx.nn as nn
+        from mlx_lm.utils import load_model
+        source = self._model(ernie)
+        cfg = dict(TINY_CFG)
+        if quantized:
+            nn.quantize(source, group_size=32, bits=4)
+            cfg["quantization"] = {"group_size": 32, "bits": 4}
+        weights = {k: v for k, v in self._weights(source).items()
+                   if not k.startswith("mtp.") and "e_score_correction_bias" not in k}
+        mx.save_safetensors(str(tmp_path / "model.safetensors"), weights)
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        monkeypatch.delenv("VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS", raising=False)
+        with pytest.raises(ValueError, match="missing routing bias"):
+            load_model(tmp_path)
+        monkeypatch.setenv("VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS", "1")
+        loaded, _ = load_model(tmp_path)
+        assert not hasattr(loaded, "mtp")
+        assert mx.array_equal(source(mx.array([[3, 17]])), loaded(mx.array([[3, 17]]))).item()
+
+    def test_public_jang_loader_finalizes_shard_loading(self, ernie, tmp_path, monkeypatch):
+        from vmlx_engine import model_bundle_integrity
+        from vmlx_engine.utils import jang_loader
+        (tmp_path / "config.json").write_text(json.dumps(TINY_CFG))
+        (tmp_path / "jang_config.json").write_text(json.dumps({"format": "jang", "version": 2}))
+        monkeypatch.setattr(model_bundle_integrity, "prepare_model_bundle_for_load", lambda *a, **kw: (str(tmp_path), {}))
+        model = self._model(ernie)
+        weights = self._weights(model)
+        weights.pop("model.layers.0.self_attn.q_proj.weight")
+        model.load_weights(list(model.sanitize(weights).items()), strict=False)
+        monkeypatch.setattr(jang_loader, "_load_jang_v2", lambda *a, **kw: (model, object()))
+        with pytest.raises(ValueError, match="missing parameters.*q_proj"):
+            jang_loader.load_jang_model(tmp_path)
+
+    def test_real_mlx_loader_merges_shards_before_completing_load(self, ernie, tmp_path):
+        from mlx_lm.utils import load_model
+        source = self._model(ernie)
+        full = self._weights(source)
+        # Entire backbone in one shard, head in another: absence cannot be
+        # inferred even when every backbone parameter is present in a shard.
+        backbone = {k: v for k, v in full.items() if not k.startswith("mtp.")}
+        head = {k: v for k, v in full.items() if k.startswith("mtp.")}
+        mx.save_safetensors(str(tmp_path / "model-00001.safetensors"), backbone)
+        mx.save_safetensors(str(tmp_path / "model-00002.safetensors"), head)
+        (tmp_path / "config.json").write_text(json.dumps(TINY_CFG))
+        loaded, _ = load_model(tmp_path)
+        assert hasattr(loaded, "mtp")
+        loaded.finalize_ernie_weight_loading()
+        x = mx.array([[3, 17, 42]])
+        assert mx.array_equal(source(x), loaded(x)).item()
+
+
+class TestEngineDetection:
+    def test_native_mtp_key_detection_sees_ernie_layout(self):
+        from vmlx_engine.native_mtp import _mtp_keys_from_weight_keys, _mtp_layer_count_from_keys
+
+        keys = [
+            "model.layers.0.self_attn.q_proj.weight",
+            "model.mtp_block.0.self_attn.q_proj.weight",
+            "model.mtp_emb_norm.0.weight",
+            "model.mtp_linear_proj.0.weight",
+            "model.layers.3.mlp.experts.0.mtp_unrelated.weight",
+        ]
+        found = _mtp_keys_from_weight_keys(keys)
+        assert found == keys[1:4]
+        assert _mtp_layer_count_from_keys(found) == 1
+
+    def test_family_alias_and_default_depth(self, tmp_path, monkeypatch):
+        from vmlx_engine.native_mtp import (
+            _FAMILY_ALIAS,
+            _RUNTIME_SUPPORTED_FAMILIES,
+            native_mtp_effective_depth,
+        )
+
+        assert _FAMILY_ALIAS["ernie4_5_moe"] == "ernie4_5"
+        assert "ernie4_5" in _RUNTIME_SUPPORTED_FAMILIES
+        for name in ("VMLINUX_NATIVE_MTP_DEPTH", "VMLX_NATIVE_MTP_DEPTH"):
+            monkeypatch.delenv(name, raising=False)
+        (tmp_path / "config.json").write_text(json.dumps(TINY_CFG))
+        # No sidecar, no stamp: the family default is the conservative depth 1.
+        assert native_mtp_effective_depth(tmp_path) == (1, "family_default:ernie4_5")
+        (tmp_path / "vmlx_mtp_tuning.json").write_text(
+            json.dumps({"native_mtp": {"best_depth": 1, "validated": True}})
+        )
+        assert native_mtp_effective_depth(tmp_path) == (
+            1,
+            "vmlx_mtp_tuning.json:native_mtp.best_depth",
+        )

--- a/tests/test_impl_campaign_20260710.py
+++ b/tests/test_impl_campaign_20260710.py
@@ -208,7 +208,8 @@ def test_ui_defaults_prefix_on_paged_off_and_hy3_mtp_native_type_visible():
     assert "usePagedCache: config.usePagedCache ?? false" in registry
     assert "config.isMultimodal ? false : true" not in registry
     assert "'hy_v3'" in registry
-    assert "nativeCacheType: hy3 ? 'plain_kv_v1'" in " ".join(registry.split())
+    # Both HY3 and ERNIE expose plain attention state through native MTP.
+    assert "nativeCacheType: hy3 || ernie45 ? 'plain_kv_v1'" in " ".join(registry.split())
     # The "native cache: <type>" note renders from the locale catalog since the
     # i18n pass. The invariant is what this test is named for — the DETECTED
     # native cache type (hy3's plain_kv_v1) stays visible in the UI — so assert

--- a/tests/test_mtp_depth_verify_cycle.py
+++ b/tests/test_mtp_depth_verify_cycle.py
@@ -829,6 +829,21 @@ class TestGlmAlignedHeadCache:
         assert _glm_prompt_priming_enabled(glm) is True
         assert _glm_prompt_priming_enabled(qwen) is False
 
+        # ERNIE-4.5 measured a wall-speed win (2026-09-05): default on, its own
+        # flag is the explicit opt-out, and the GLM flag must not leak into it.
+        monkeypatch.delenv("VMLX_ERNIE45_MTP_PROMPT_PRIMING", raising=False)
+        monkeypatch.delenv("VMLINUX_ERNIE45_MTP_PROMPT_PRIMING", raising=False)
+        ernie = type("Model", (), {"model_type": "ernie4_5_moe"})()
+        assert _glm_prompt_priming_enabled(ernie) is True
+        monkeypatch.setenv("VMLX_ERNIE45_MTP_PROMPT_PRIMING", "0")
+        assert _glm_prompt_priming_enabled(ernie) is False
+        monkeypatch.setenv("VMLX_ERNIE45_MTP_PROMPT_PRIMING", "1")
+        assert _glm_prompt_priming_enabled(ernie) is True
+        monkeypatch.delenv("VMLX_ERNIE45_MTP_PROMPT_PRIMING", raising=False)
+        monkeypatch.setenv("VMLX_GLM5_MTP_PROMPT_PRIMING", "0")
+        assert _glm_prompt_priming_enabled(ernie) is True
+        assert _glm_prompt_priming_enabled(glm) is False
+
     def test_trim_removes_only_unverified_chain_pairs(self):
         from vmlx_engine.patches.mlx_lm_mtp.batch_generator import (
             _MtpState,

--- a/vmlx_engine/acceleration_contract.py
+++ b/vmlx_engine/acceleration_contract.py
@@ -26,6 +26,8 @@ _FAMILY_ALIASES = {
     "qwen3_5_moe_text": "qwen3_5_moe",
     "glm5_next": "glm5_next",
     "deepseek_v4": "deepseek_v4",
+    "ernie4_5_moe": "ernie4_5",
+    "ernie4_5": "ernie4_5",
 }
 
 
@@ -409,6 +411,25 @@ _FAMILIES: dict[str, dict[str, Any]] = {
                 scopes=("prefill", "ar_decode", "mtp_decode"),
                 default=True,
                 env=("VMLX_DSV4_ROPE_CACHE",),
+            ),
+        ],
+    },
+    "ernie4_5": {
+        "display_family": "ERNIE-4.5",
+        "native_state": ["MoE"],
+        "features": [
+            _feature(
+                "mtp_prompt_priming",
+                label="ERNIE MTP-head prompt-history priming",
+                kind="state_algorithm",
+                scopes=("prefill", "mtp_decode"),
+                default=True,
+                # Same order as batch_generator._TEXT_PROMPT_PRIMING_FLAGS so the
+                # report and the runtime gate agree when both aliases are set.
+                env=(
+                    "VMLINUX_ERNIE45_MTP_PROMPT_PRIMING",
+                    "VMLX_ERNIE45_MTP_PROMPT_PRIMING",
+                ),
             ),
         ],
     },

--- a/vmlx_engine/api/utils.py
+++ b/vmlx_engine/api/utils.py
@@ -591,6 +591,35 @@ def is_mllm_model(model_name: str, force_mllm: bool = False, force_text_only: bo
     except Exception:
         pass
 
+    # ERNIE-4.5 (baidu, ernie4_5_moe / ernie4_5): text-only family with a
+    # source-owned runtime (vmlx_engine.models.ernie4_5). mlx_vlm has no
+    # ernie4_5_moe loader or MTP drafter, so a forced --is-mllm (panel VLM toggle,
+    # or bench/native_mtp_speed_ab.py which always passes it) crashes at load
+    # with "No module named 'mlx_vlm.speculative.drafters.ernie4_5_moe'".
+    # Same rule as MiniMax-M3 above: never let force_mllm push it into mlx_vlm.
+    try:
+        _cfg_p_ernie = os.path.join(local_path, "config.json")
+        if os.path.isfile(_cfg_p_ernie):
+            _cfg_ernie = json.loads(open(_cfg_p_ernie).read())
+            _mt_ernie = str(_cfg_ernie.get("model_type") or "").strip().lower()
+            if _mt_ernie in {"ernie4_5_moe", "ernie4_5"}:
+                if force_mllm:
+                    _logger.warning(
+                        "is_mllm_model(%s): ERNIE-4.5 overrides force_mllm — "
+                        "mlx_vlm has no %s runtime; routing through the "
+                        "source-owned text runtime",
+                        model_name,
+                        _mt_ernie,
+                    )
+                else:
+                    _logger.info(
+                        "is_mllm_model(%s): tier=ernie4_5_text_route result=False",
+                        model_name,
+                    )
+                return False
+    except Exception:
+        pass
+
     # GLM-5.3 uses one top-level model type for text and multimodal bundles.
     # Route to mlx-vlm only when both the config and the checkpoint index prove
     # that a visual tower is present; otherwise preserve the existing text lane.

--- a/vmlx_engine/cli.py
+++ b/vmlx_engine/cli.py
@@ -1227,6 +1227,15 @@ def serve_command(args):
     except Exception as _glm5reg_e:
         logger.debug("glm5_next runtime registration skipped: %s", _glm5reg_e)
 
+    # Install the vMLX-owned ERNIE-4.5 MoE runtime OVER upstream mlx-lm's
+    # ernie4_5_moe (upstream drops the router selection bias; see
+    # models/ernie4_5/ernie4_5_moe.py). Idempotent.
+    try:
+        from .models.ernie4_5.register import register_ernie4_5_runtime
+        register_ernie4_5_runtime()
+    except Exception as _ernie_reg_e:
+        logger.debug("ernie4_5 runtime registration skipped: %s", _ernie_reg_e)
+
     # -- openPangu-2.0-Flash auto-settings TRANSPARENCY log + policy --
     # Mirrors the M3 block below: on an openpangu_v2 bundle, force-disable JIT
     # (the DSA lightning-indexer top-k selection is input-dependent/dynamic —

--- a/vmlx_engine/model_configs.py
+++ b/vmlx_engine/model_configs.py
@@ -867,6 +867,40 @@ def register_all(registry=None):
         )
     )
 
+    # ── ERNIE-4.5 MoE (ernie4_5_moe model_type; baidu/ERNIE-4.5-21B-A3B-PT etc.) ──
+    # Plain GQA attention (20 q / 4 kv heads), with no hybrid cache subtype;
+    # the engine's supported plain-KV cache policy applies. Layer 0
+    # dense, layers 1-27 MoE (64 routed top-6 + 2 shared) with a router
+    # selection bias; the runtime is vMLX-owned and installed OVER upstream
+    # mlx-lm (models/ernie4_5/ernie4_5_moe.py explains why). The PT chat
+    # template is `User: ...\nAssistant: ...` with no tool-call syntax and no
+    # think block, so tools and reasoning are declared unsupported rather
+    # than left for probes to guess; the `-Thinking` variants need their own
+    # row with a reasoning parser once live-proven. Stop tokens: the model
+    # emits `</s>` (id 2, tokenizer eos, generation_config eos) — measured on
+    # 8 greedy generations 2026-09-04 — while the chat template closes
+    # assistant turns in history with `<|end_of_sentence|>` (id 100272, a
+    # different token). Both are listed so either ends a generation.
+    # generation_config recommends temperature 0.8 / top_p 0.8. The vendored
+    # runtime supplies the native MTP head (`num_nextn_predict_layers` = 1).
+    _register(
+        ModelConfig(
+            family_name="ernie4_5",
+            model_types=["ernie4_5_moe", "ernie4_5"],
+            cache_type="kv",
+            eos_tokens=["</s>", "<|end_of_sentence|>"],
+            tool_parser=None,
+            supports_native_tools=False,
+            reasoning_parser=None,
+            think_in_template=False,
+            supports_thinking=False,
+            is_mllm=False,
+            architecture_hints={"default_enable_thinking": False},
+            description="ERNIE-4.5 MoE (Baidu): dense layer 0 + 64-expert MoE, GQA, MTP head",
+            priority=20,
+        )
+    )
+
     # ── Ling-2.6-flash / Bailing-V2.5 (bailing_hybrid model_type) ──
     # Hybrid MLA + Lightning-Attn-2 (Gated Linear Attention). Layer
     # dispatch is controlled by `layer_group_size` (default 8 for

--- a/vmlx_engine/models/ernie4_5/__init__.py
+++ b/vmlx_engine/models/ernie4_5/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vendored ERNIE-4.5 MoE runtime (model_type ``ernie4_5_moe``). See ernie4_5_moe.py."""

--- a/vmlx_engine/models/ernie4_5/ernie4_5_moe.py
+++ b/vmlx_engine/models/ernie4_5/ernie4_5_moe.py
@@ -1,0 +1,558 @@
+# Copyright © 2023-2024 Apple Inc.
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+#
+# Derived from mlx-lm 0.31.3, ``mlx_lm/models/ernie4_5_moe.py`` (MIT License,
+# https://github.com/ml-explore/mlx-lm/blob/main/LICENSE). The Apple copyright
+# notice above and the MIT permission notice below apply to the portions
+# retained from that file; the vMLX modifications are Apache-2.0.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""ERNIE-4.5 MoE text runtime for vMLX (``model_type: ernie4_5_moe``).
+
+Vendored from mlx-lm 0.31.3 ``mlx_lm/models/ernie4_5_moe.py`` (the file shipped in that
+release) and installed over the upstream
+module by ``register.py``. Kept byte-for-byte where possible so
+future upstream diffs are easy to read. Deliberate departures, each with the evidence that
+motivated it (measurements in the PR that introduced this runtime):
+
+1. Router bias is KEPT. Upstream drops ``mlp.moe_statics.e_score_correction_bias`` in
+   ``sanitize`` and picks top-k on raw softmax probabilities. transformers (the reference that
+   produced our parity logits), vLLM and Baidu FastDeploy all pick top-k on
+   ``probs + bias`` and weight the chosen experts by the UNBIASED probs (DeepSeek-V3 style
+   aux-loss-free load balancing: the bias steers selection only). Measured on
+   ERNIE-4.5-21B-A3B-PT over 8 reference sequences: without the bias 29.0% of
+   (token, MoE-layer) pairs choose a different expert set and final top-1 agreement with the
+   reference falls to 0.955-0.989 on 7 of 8 prompts (max |delta logit| 6.05). The bias is F32,
+   per layer nearly constant (+22..+63) with a within-layer spread of 0.005-0.03, which is
+   exactly the scale of near-tied softmax probs, so it cannot be dropped as "almost constant".
+2. Router logits are computed in float32 from the unquantized gate, matching transformers'
+   ``F.linear(hidden.float(), weight.float())``. bf16 router logits have ~3 significant
+   digits, and near-ties at the top-k boundary sit below that resolution (same reason as 1).
+   When the gate is quantized we fall back to the module call.
+3. ``moe_norm_min`` is read from the config (1e-12 here) instead of hard-coded.
+4. ``make_cache`` is explicit: plain GQA, one ``KVCache`` per layer.
+5. Native MTP head (``num_nextn_predict_layers`` = 1) is attached as ``Model.mtp`` and
+   exposed through vMLX's duck-typed contract (``mtp_forward``, ``make_mtp_cache``, and
+   ``__call__(return_hidden=True)`` returning the PRE-norm hidden like the Qwen3.5 patch).
+   Checkpoint keys ``model.mtp_block.0.*`` / ``model.mtp_emb_norm.0`` /
+   ``model.mtp_hidden_norm.0`` / ``model.mtp_linear_proj.0`` are renamed in ``sanitize`` to
+   ``mtp.layers.0.*`` / ``mtp.emb_norm`` / ``mtp.hidden_norm`` / ``mtp.linear_proj`` so JANG
+   tier rules written for ``mtp.layers`` apply unchanged. Head conventions (Baidu FastDeploy
+   layout, chosen by an 8-way ablation against transformers, 2026-09-04): backbone hidden is
+   taken AFTER ``model.norm`` (so ``mtp_forward`` applies it to the pre-norm hidden it is
+   handed); fused = ``linear_proj(concat[emb_norm(embed(t+1)), hidden_norm(h_t)])``,
+   embedding first; position-0 embedding kept; one dense decoder block (attention + 12,288
+   SwiGLU, interleaved RoPE via its own KVCache offset); the block output goes through the
+   SHARED ``model.norm`` before the tied lm_head. vLLM differs (zeroes pos-0, no output norm)
+   and measured worse. Draft depth defaults to 1 (Baidu asserts one step). For depth 2/3
+   chained drafting the engine feeds ``mtp_forward``'s returned hidden back in as the next
+   step's "previous hidden", so that hidden is the head block's PRE-norm output (the shared
+   norm is applied only on the way to the logits), exactly as for the backbone.
+6. Weight loading has an explicit completion boundary. ``sanitize`` only renames
+   tensors and buffers incomplete expert groups across shards. ``load_weights(strict=True)``
+   or ``finalize_ernie_weight_loading`` checks that every parameter was supplied before
+   accepting a model. Only then may a completely absent MTP head become AR-only. Missing
+   routing biases require re-conversion; legacy raw-softmax routing is an explicit opt-in
+   with ``VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS=1``. Partial or quantised biases fail.
+
+Architecture (from config.json of ERNIE-4.5-21B-A3B-PT): 28 layers, hidden 2560, layer 0 dense
+SwiGLU (12,288), layers 1-27 MoE with 64 routed experts (top-6, 1536 wide) + 2 shared experts,
+GQA 20/4, interleaved RoPE theta 500k, tied embeddings, vocab 103,424.
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx.utils import tree_flatten
+
+from mlx_lm.models.base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from mlx_lm.models.cache import KVCache
+from mlx_lm.models.rope_utils import initialize_rope
+from mlx_lm.models.switch_layers import SwitchGLU
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    hidden_size: int
+    intermediate_size: int
+    model_type: str
+    max_position_embeddings: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    num_hidden_layers: int
+    rms_norm_eps: float
+    vocab_size: int
+    rope_theta: float
+    use_bias: bool
+    tie_word_embeddings: bool
+    moe_num_experts: int
+    moe_layer_start_index: int = 0
+    moe_intermediate_size: int = 0
+    moe_capacity: list[int] = field(default_factory=list)
+    moe_k: int = 1
+    moe_layer_interval: int = 1
+    moe_use_aux_free: bool = False
+    moe_num_shared_experts: int = 0
+    moe_layer_end_index: Optional[int] = None
+    head_dim: Optional[int] = None
+    moe_gate_act: str = "softmax"
+    moe_norm_min: float = 1e-12  # vMLX: from config (departure 3)
+    num_nextn_predict_layers: int = 0  # vMLX: MTP head count (departure 5)
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+
+        self.head_dim = head_dim = args.head_dim or dim // n_heads
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=args.use_bias)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.use_bias)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.use_bias)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=args.use_bias)
+
+        # traditional=True is MLX's name for interleaved (pairwise) rotation, which is what
+        # transformers' Ernie4_5 rotate_half does (x[0::2], x[1::2]).
+        self.rope = initialize_rope(
+            head_dim,
+            base=args.rope_theta,
+            traditional=True,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        queries = queries.reshape(B, L, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class Ernie4_5_MLP(nn.Module):
+    def __init__(self, dim, hidden_dim, use_bias=False):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=use_bias)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=use_bias)
+
+    def __call__(self, x) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Ernie4_5_MoeMLP(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.k = args.moe_k
+        self.norm_min = args.moe_norm_min
+        self.moe_intermediate_size = (
+            args.moe_intermediate_size
+            if args.moe_intermediate_size
+            else args.intermediate_size
+        )
+
+        self.gate = nn.Linear(args.hidden_size, args.moe_num_experts, bias=False)
+        # vMLX departure 1: selection bias, F32, filled from
+        # mlp.moe_statics.e_score_correction_bias by sanitize(). Not an nn.Linear bias.
+        self.e_score_correction_bias = mx.zeros((args.moe_num_experts,), dtype=mx.float32)
+
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size,
+            self.moe_intermediate_size,
+            args.moe_num_experts,
+            bias=args.use_bias,
+        )
+
+        if getattr(args, "moe_num_shared_experts", 0) > 0:
+            shared_intermediate_size = (
+                args.moe_intermediate_size * args.moe_num_shared_experts
+                if getattr(args, "moe_intermediate_size", None)
+                else args.intermediate_size * args.moe_num_shared_experts
+            )
+            self.shared_experts = Ernie4_5_MLP(
+                args.hidden_size, shared_intermediate_size, args.use_bias
+            )
+        else:
+            self.shared_experts = None
+
+        if args.moe_gate_act == "softmax":
+            self.gate_act = nn.Softmax()
+        elif args.moe_gate_act == "sigmoid":
+            self.gate_act = nn.Sigmoid()
+        else:
+            raise ValueError(f"{args.moe_gate_act} is not supported.")
+
+    def _router_logits(self, x: mx.array) -> mx.array:
+        # vMLX departure 2: float32 router matmul when the gate is unquantized.
+        w = getattr(self.gate, "weight", None)
+        if w is not None and not hasattr(self.gate, "scales"):
+            return mx.matmul(x.astype(mx.float32), w.astype(mx.float32).T)
+        return self.gate(x).astype(mx.float32)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        probs = self.gate_act(self._router_logits(x))  # [B, L, E] float32
+
+        k = self.k
+        # vMLX departure 1: choose on probs + bias, weight by unbiased probs.
+        choice = probs + self.e_score_correction_bias.astype(mx.float32)
+        inds = mx.stop_gradient(mx.argpartition(-choice, kth=k - 1, axis=-1)[..., :k])
+        scores = mx.take_along_axis(probs, inds, axis=-1)
+
+        scores = scores / mx.maximum(scores.sum(axis=-1, keepdims=True), self.norm_min)
+
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None].astype(y.dtype)).sum(axis=-2).astype(y.dtype)
+
+        if self.shared_experts is not None:
+            y = y + self.shared_experts(x)
+
+        return y
+
+
+class Ernie4_5_DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(args)
+
+        moe_layer_start_index = (
+            min(args.moe_layer_start_index)
+            if isinstance(args.moe_layer_start_index, (tuple, list))
+            else args.moe_layer_start_index
+        )
+
+        if args.moe_layer_end_index is None:
+            moe_layer_end_index = args.num_hidden_layers - 1
+        else:
+            moe_layer_end_index = (
+                max(args.moe_layer_end_index)
+                if isinstance(args.moe_layer_end_index, (tuple, list))
+                else args.moe_layer_end_index
+            )
+
+        if (
+            ((layer_idx + 1) % args.moe_layer_interval == 0)
+            and layer_idx >= moe_layer_start_index
+            and layer_idx <= moe_layer_end_index
+        ):
+            self.mlp = Ernie4_5_MoeMLP(args)
+        else:
+            self.mlp = Ernie4_5_MLP(
+                args.hidden_size, args.intermediate_size, args.use_bias
+            )
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class Ernie4_5_MTP(nn.Module):
+    """One-step MTP head (departure 5). ``layers[0]`` is a dense decoder block: passing
+    ``layer_idx=0`` to Ernie4_5_DecoderLayer selects the dense MLP because layer 0 sits below
+    ``moe_layer_start_index``; the head's 12,288-wide MLP matches ``intermediate_size``."""
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.emb_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.hidden_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.linear_proj = nn.Linear(2 * args.hidden_size, args.hidden_size, bias=False)
+        self.layers = [Ernie4_5_DecoderLayer(args, layer_idx=0) for _ in range(args.num_nextn_predict_layers)]
+
+    def __call__(self, pre_norm_hidden, next_token_ids, embed_tokens, final_norm, cache=None):
+        e = self.emb_norm(embed_tokens(next_token_ids))
+        h = self.hidden_norm(final_norm(pre_norm_hidden))
+        fused = self.linear_proj(mx.concatenate([e, h], axis=-1))
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(fused, cache[0] if cache else None)
+        for layer, c in zip(self.layers, cache):
+            fused = layer(fused, mask, c)
+        # PRE-norm head output: the caller applies the shared final norm for the
+        # logits and hands this raw state to the next chained draft step.
+        return fused
+
+
+class Ernie45Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            Ernie4_5_DecoderLayer(args, i) for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache=None,
+    ):
+        h = self.embed_tokens(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(h, cache[0])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        # vMLX departure 5: return the PRE-norm residual stream; Model applies
+        # self.norm for logits and hands the pre-norm tensor to the MTP head.
+        return h
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self._ernie_loaded_keys = set()
+        object.__setattr__(self, "_ernie_pending_experts", {})
+        self.model_type = args.model_type
+        self.model = Ernie45Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        if args.num_nextn_predict_layers > 0:
+            from vmlx_engine.native_mtp import native_mtp_disabled_by_env
+
+            # Text dispatch uses head presence as its runtime eligibility gate.
+            # Honor both disable aliases before sanitize/load, as Qwen does.
+            if not native_mtp_disabled_by_env():
+                self.mtp = Ernie4_5_MTP(args)
+
+    def _logits(self, normed: mx.array) -> mx.array:
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(normed)
+        return self.lm_head(normed)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache=None,
+        return_hidden: bool = False,
+        return_logits: bool = True,
+        **_ignored,
+    ):
+        hidden = self.model(inputs, cache)
+        # Native-MTP prompt priming hook (same placement as the Qwen3.5 patch):
+        # only a normal prompt prefill is folded, never seed/verify forwards.
+        if not return_hidden and hasattr(self, "mtp"):
+            try:
+                from vmlx_engine.native_mtp_prompt_priming import capture_prefill, capture_requested
+                if capture_requested(self):
+                    capture_prefill(self, inputs, hidden, cache)
+            except Exception:
+                pass
+        if not return_logits:
+            return hidden
+        out = self._logits(self.model.norm(hidden))
+        if return_hidden:
+            return out, hidden
+        return out
+
+    def mtp_forward(self, hidden_states, next_token_ids, mtp_cache, return_hidden=False):
+        """vMLX native-MTP contract. ``hidden_states`` is a PRE-norm hidden: the backbone's
+        (from ``__call__(return_hidden=True)``) or, for chained drafting, the raw head output
+        this method returned on the previous step. The head normalises it; the returned
+        hidden is likewise the head block's PRE-norm output (the shared final norm is applied
+        only on the way to the logits), so feeding it back in does not norm twice."""
+        mtp_out = self.mtp(hidden_states, next_token_ids, self.model.embed_tokens, self.model.norm, mtp_cache)
+        logits = self._logits(self.model.norm(mtp_out))
+        if return_hidden:
+            return logits, mtp_out
+        return logits
+
+    def make_mtp_cache(self):
+        if hasattr(self, "mtp"):
+            return [KVCache() for _ in self.mtp.layers]
+        return []
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        # vMLX departure 4: plain GQA, one KV cache per layer, no hybrid state.
+        return [KVCache() for _ in self.model.layers]
+
+    def sanitize(self, weights):
+        mtp_patterns = ("mtp_block.", "mtp_linear_proj.", "mtp_hidden_norm.", "mtp_emb_norm.")
+        has_head = hasattr(self, "mtp")
+
+        def _rename_mtp(key: str) -> str:
+            # model.mtp_block.0.X -> mtp.layers.0.X ; model.mtp_emb_norm.0.weight -> mtp.emb_norm.weight
+            k = key[len("model."):] if key.startswith("model.") else key
+            if k.startswith("mtp_block."):
+                return "mtp.layers." + k[len("mtp_block."):]
+            for name in ("mtp_emb_norm", "mtp_hidden_norm", "mtp_linear_proj"):
+                if k.startswith(name + "."):
+                    rest = k[len(name) + 1:].split(".", 1)[1]  # drop the ".0" index
+                    return "mtp." + name[len("mtp_"):] + "." + rest
+            return key
+
+        out = {}
+        for key, value in weights.items():
+            if not has_head and key.startswith("mtp."):
+                continue
+            if any(pattern in key for pattern in mtp_patterns):
+                if has_head:
+                    out[_rename_mtp(key)] = value
+                continue
+            if "e_score_correction_bias" in key and (
+                key.endswith(".scales") or key.endswith(".biases") or key.endswith(".weight")
+            ):
+                # A quantised routing bias is a converter defect (jang_tools convert.py
+                # float32 passthrough rule). Loading it silently left the runtime bias
+                # at zeros and routing without it; fail loudly instead.
+                raise ValueError(
+                    f"{key}: e_score_correction_bias must be a float32 passthrough tensor, "
+                    "not a quantised weight/scales/biases triplet; re-convert with the "
+                    "fixed jang_tools (routing-fp32 passthrough)"
+                )
+            if key.endswith(".mlp.moe_statics.e_score_correction_bias"):
+                # vMLX departure 1: keep, as [E] float32 on the MoE block.
+                new_key = key.replace(".moe_statics.e_score_correction_bias", ".e_score_correction_bias")
+                out[new_key] = value.reshape(-1).astype(mx.float32)
+                continue
+            out[key] = value
+        weights = out
+
+        if self.args.tie_word_embeddings:
+            for suffix in ("weight", "scales", "biases"):
+                weights.pop(f"lm_head.{suffix}", None)
+
+        # A JANG load can split an expert group across files, including its
+        # quantization sidecars. Retain those tensors until a complete stack
+        # can be emitted under a real module path; never pass experts.N keys
+        # to nn.Module.load_weights(strict=False), which would discard them.
+        pending = self._ernie_pending_experts
+        n_exp = self.args.moe_num_experts
+        for l in range(self.args.num_hidden_layers):
+            for m in ("gate_proj", "down_proj", "up_proj"):
+                base = f"model.layers.{l}.mlp"
+                for suffix in ("weight", "scales", "biases"):
+                    target = f"{base}.switch_mlp.{m}.{suffix}"
+                    keys = [f"{base}.experts.{e}.{m}.{suffix}" for e in range(n_exp)]
+                    present = {k: weights.pop(k) for k in keys if k in weights}
+                    if present:
+                        pending.setdefault(target, {}).update(present)
+                    group = pending.get(target)
+                    if group is not None and target in weights:
+                        raise ValueError(f"ERNIE checkpoint mixes stacked and individual experts: {target}")
+                    if group is not None and all(k in group for k in keys):
+                        weights[target] = mx.stack([group[k] for k in keys])
+                        del pending[target]
+
+        return weights
+
+    def _prepare_complete_weight_load(self, keys):
+        """Validate a complete load, never an individual shard. Return legacy defaults."""
+        if self._ernie_pending_experts:
+            groups = ", ".join(sorted(self._ernie_pending_experts))
+            raise ValueError(f"ERNIE checkpoint has incomplete expert groups: {groups}")
+        expected = set(dict(tree_flatten(self.parameters())))
+        head = {k for k in expected if k.startswith("mtp.")}
+        biases = {k for k in expected if k.endswith(".mlp.e_score_correction_bias")}
+        missing = expected - keys
+        required_missing = missing - head - biases
+        if required_missing:
+            raise ValueError("ERNIE checkpoint missing parameters: " + ", ".join(sorted(required_missing)))
+        if head & keys and head - keys:
+            raise ValueError("ERNIE checkpoint has an incomplete MTP head: " + ", ".join(sorted(head - keys)))
+        defaults = {}
+        if missing & biases:
+            allow_legacy = os.environ.get("VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS", "").strip() == "1"
+            if biases & keys or not allow_legacy:
+                raise ValueError(
+                    "ERNIE checkpoint missing routing bias (e_score_correction_bias). "
+                    "Re-convert from the original HF checkpoint to preserve expert selection. "
+                    "For legacy upstream conversions with ALL routing biases absent, explicitly "
+                    "set VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS=1 to accept raw-softmax routing."
+                )
+            logger.warning(
+                "ERNIE legacy compatibility enabled: all routing biases are absent; using "
+                "raw-softmax routing. This changed 29%% of expert choices in the measured "
+                "%s checkpoint. Re-convert from HF to restore the biases.",
+                "ERNIE-4.5-21B-A3B-PT",
+            )
+            defaults = {k: mx.zeros((self.args.moe_num_experts,), dtype=mx.float32) for k in biases}
+        if head and not head & keys:
+            logger.warning("ERNIE checkpoint has no MTP head tensors; loading AR-only")
+            delattr(self, "mtp")
+        return defaults
+
+    def load_weights(self, file_or_weights, strict=True):
+        weights = dict(mx.load(file_or_weights) if isinstance(file_or_weights, str) else file_or_weights)
+        if strict:
+            weights.update(self._prepare_complete_weight_load(set(weights)))
+        # Preserve MLX's strict shape validation for whole-model loads.
+        result = super().load_weights(list(weights.items()), strict=strict)
+        expected = set(dict(tree_flatten(self.parameters())))
+        self._ernie_loaded_keys.update(expected & weights.keys())
+        return result
+
+    def finalize_ernie_weight_loading(self):
+        """Called by vMLX after ALL JANG shards, including strict=False loads."""
+        defaults = self._prepare_complete_weight_load(self._ernie_loaded_keys)
+        if defaults:
+            super().load_weights(list(defaults.items()), strict=False)
+            self._ernie_loaded_keys.update(defaults)

--- a/vmlx_engine/models/ernie4_5/register.py
+++ b/vmlx_engine/models/ernie4_5/register.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Register the vMLX-owned ERNIE-4.5 MoE runtime under ``mlx_lm.models.ernie4_5_moe``.
+
+Unlike glm5_next this does NOT defer to upstream when mlx-lm ships the module, because
+upstream mlx-lm's ``ernie4_5_moe.py`` drops the router selection bias
+(``e_score_correction_bias``) and therefore routes ~29% of (token, layer) pairs differently
+from the reference implementation (see ernie4_5_moe.py header). The vendored module is
+installed over the upstream one unconditionally; idempotent.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger("vmlx_engine")
+
+_REGISTERED = False
+_PACKAGE = "mlx_lm.models.ernie4_5_moe"
+_VENDORED = Path(__file__).resolve().parent / "ernie4_5_moe.py"
+
+
+def ernie4_5_runtime_available() -> bool:
+    return _VENDORED.is_file()
+
+
+def register_ernie4_5_runtime() -> bool:
+    """Install the vendored module into ``sys.modules`` (over upstream if present)."""
+    global _REGISTERED
+    if _REGISTERED and sys.modules.get(_PACKAGE) is not None:
+        return True
+    if not _VENDORED.is_file():
+        return False
+    sys.modules.pop(_PACKAGE, None)
+    spec = importlib.util.spec_from_file_location(_PACKAGE, _VENDORED)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[_PACKAGE] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop(_PACKAGE, None)
+        raise
+    try:
+        parent = importlib.import_module("mlx_lm.models")
+        setattr(parent, "ernie4_5_moe", mod)
+    except Exception:
+        pass
+    _REGISTERED = True
+    logger.info("Registered vendored ernie4_5_moe runtime (%s), overriding upstream", _VENDORED)
+    return True

--- a/vmlx_engine/native_mtp.py
+++ b/vmlx_engine/native_mtp.py
@@ -52,6 +52,8 @@ _FAMILY_ALIAS = {
     "qwen3_6_text": "qwen3_5",
     "qwen3_5_moe_text": "qwen3_5_moe",
     "qwen4_exp_text": "qwen4_exp",
+    # config.model_type for the ERNIE-4.5 MoE checkpoints; registry family is ernie4_5
+    "ernie4_5_moe": "ernie4_5",
 }
 
 # Keep this narrow. The copied mlx-lm patch currently wires Qwen3.5/3.6 MTP
@@ -66,6 +68,11 @@ _RUNTIME_SUPPORTED_FAMILIES = {
     "qwen3_5_moe",
     "qwen4_exp",
     "hy_v3",
+    # ernie4_5: vMLX-owned models/ernie4_5 runtime exposes the full contract
+    # (model.mtp module, mtp_forward taking the backbone's pre-norm hidden and
+    # applying model.norm itself, make_mtp_cache = one KVCache). Head parity
+    # gated against a plain-torch reference (see the introducing PR).
+    "ernie4_5",
     # glm5_next: the vendored model owns the layer-45 draft head, pre-output
     # hidden handoff, KDA accepted-prefix snapshots, and trimmable MLA cache.
     # It runs through the same GenerationBatch verifier as Qwen.
@@ -604,10 +611,16 @@ def _index_mtp_keys(bundle_path: str | Path | None) -> tuple[list[str], str | No
 
 
 def _mtp_keys_from_weight_keys(weight_keys: list[str]) -> list[str]:
+    # `mtp.` covers Qwen/DeepSeek-style heads. ERNIE-4.5 ships its head as
+    # `model.mtp_block.N.*`, `model.mtp_emb_norm.N`, `model.mtp_hidden_norm.N`,
+    # `model.mtp_linear_proj.N` (underscore, no `mtp.` segment), so without the
+    # second alternative a preserved ERNIE head counts as 0 tensors and the
+    # status reads "not declared" although config.num_nextn_predict_layers=1.
     return [
         str(key)
         for key in weight_keys
         if re.search(r"(^|\.)mtp(\.|$)", str(key))
+        or re.search(r"(^|\.)mtp_(block|emb_norm|hidden_norm|linear_proj)(\.|$)", str(key))
     ]
 
 
@@ -616,6 +629,8 @@ _MTP_LAYER_PATTERNS = (
     re.compile(r"^mtp\.layers\.(\d+)(?:\.|$)"),
     re.compile(r"(?:^|\.)mtp\.layers\.(\d+)(?:\.|$)"),
     re.compile(r"(?:^|\.)mtp_layers\.(\d+)(?:\.|$)"),
+    # ERNIE-4.5: one decoder block per draft step under model.mtp_block.<n>
+    re.compile(r"(?:^|\.)mtp_block\.(\d+)(?:\.|$)"),
 )
 
 
@@ -865,6 +880,10 @@ def native_mtp_effective_depth(
         family = None
     if family == "hy_v3":
         return 1, "family_default:hy_v3"
+    if family == "ernie4_5":
+        # D1 is the conservative seed; deeper chaining has prompt-dependent
+        # speedups and requires an explicit override or validated tuning.
+        return 1, "family_default:ernie4_5"
     return max(1, min(native_mtp_max_depth(), depth)), source
 
 

--- a/vmlx_engine/patches/mlx_lm_mtp/batch_generator.py
+++ b/vmlx_engine/patches/mlx_lm_mtp/batch_generator.py
@@ -1369,20 +1369,61 @@ def _glm_aligned_head_cache_enabled(gen_batch: Any) -> bool:
     return value not in {"", "0", "false", "off", "no"}
 
 
+# Text-path prompt priming is a measured, per-family policy.  A family is
+# listed here only once its head-input contract (pre-norm trunk hidden at token
+# t plus token t+1, one KVCache per MTP layer) has been proven.  The default is
+# off until an exact-output A/B shows a wall-speed win (see the Qwen3.5 note in
+# mllm_batch_generator._prepare_native_mtp_prompt_priming); a family measured
+# faster may default on, with its env flag as the explicit opt-out.
+# Value: (default_enabled, env flag names checked in order).
+_TEXT_PROMPT_PRIMING_FLAGS: dict[str, tuple[bool, tuple[str, ...]]] = {
+    "glm5_next": (
+        False,
+        (
+            "VMLINUX_GLM5_MTP_PROMPT_PRIMING",
+            "VMLX_GLM5_MTP_PROMPT_PRIMING",
+        ),
+    ),
+    # ERNIE-4.5-21B-A3B JANG_6M, fixed depth 1, prefix cache off, six greedy
+    # prompts, fresh process per arm (2026-09-05, measurements in the PR that
+    # introduced this family).  64-token replies: acceptance 69.4% -> 85.2%
+    # (deterministic across repeats), tok/s +1.7% / +7% (inside noise).
+    # 256-token replies, three alternating pairs: acceptance 74.4% -> 85.1%,
+    # mean tok/s 111.1 -> 115.9 (+4.3%), within-arm spread <=1.5%, every primed
+    # arm faster than every unprimed arm, output identical in all arms.  The
+    # primed acceptance matches the teacher-forced head top-1 band, so the
+    # unprimed gap was the missing prompt context.  Default on; set the flag
+    # to 0 to opt out.
+    "ernie4_5_moe": (
+        True,
+        (
+            "VMLINUX_ERNIE45_MTP_PROMPT_PRIMING",
+            "VMLX_ERNIE45_MTP_PROMPT_PRIMING",
+        ),
+    ),
+}
+
+
 def _glm_prompt_priming_enabled(model: Any) -> bool:
+    """Whether the text-path prompt-priming seam is armed for ``model``.
+
+    Historic name (GLM was the first family); the gate is table-driven.
+    """
     inner = getattr(model, "language_model", model)
     model_type = getattr(inner, "model_type", None)
     if model_type is None:
         config = getattr(inner, "config", None)
         if isinstance(config, dict):
             model_type = config.get("model_type")
-    if str(model_type or "") != "glm5_next":
+    entry = _TEXT_PROMPT_PRIMING_FLAGS.get(str(model_type or ""))
+    if entry is None:
         return False
-    value = os.environ.get(
-        "VMLINUX_GLM5_MTP_PROMPT_PRIMING",
-        os.environ.get("VMLX_GLM5_MTP_PROMPT_PRIMING", "0"),
-    ).strip().lower()
-    return value not in {"", "0", "false", "off", "no"}
+    default_enabled, flags = entry
+    for name in flags:
+        if name in os.environ:
+            value = os.environ[name].strip().lower()
+            return value not in {"", "0", "false", "off", "no"}
+    return bool(default_enabled)
 
 
 def _trim_glm_head_chain(state: "_MtpState") -> bool:

--- a/vmlx_engine/server.py
+++ b/vmlx_engine/server.py
@@ -9775,6 +9775,9 @@ def _bundle_weight_index_status(bundle_path: str | None) -> dict | None:
                 key.startswith("mtp.")
                 or ".mtp." in lowered
                 or (glm_mtp_prefix is not None and key.startswith(glm_mtp_prefix))
+                # ERNIE-4.5: model.mtp_block.N / mtp_emb_norm.N / mtp_hidden_norm.N /
+                # mtp_linear_proj.N (underscore names, no `mtp.` segment)
+                or re.search(r"(?:^|\.)mtp_(?:block|emb_norm|hidden_norm|linear_proj)(?:\.|$)", lowered)
             ):
                 mtp_tensor_count += 1
             if ".switch_mlp." in lowered:

--- a/vmlx_engine/utils/jang_loader.py
+++ b/vmlx_engine/utils/jang_loader.py
@@ -1843,6 +1843,20 @@ def _ensure_jang_family_runtime_supported(path: Path, config: dict | None) -> No
 
     ensure_spark2_5_runtime_registered(path, config=config)
 
+    if "ernie4_5_moe" in model_types:
+        # vMLX-owned runtime installed OVER upstream mlx-lm's ernie4_5_moe, which
+        # drops the router selection bias (models/ernie4_5/ernie4_5_moe.py).
+        # Registering here covers every load path, not just the CLI entry.
+        try:
+            from vmlx_engine.models.ernie4_5.register import register_ernie4_5_runtime
+
+            register_ernie4_5_runtime()
+        except Exception as exc:
+            raise RuntimeError(
+                f"ERNIE-4.5 (ernie4_5_moe) bundle at {path} requires the vendored "
+                f"vmlx_engine/models/ernie4_5 runtime, but registration failed: {exc}"
+            ) from exc
+
     if "openpangu_v2" in model_types:
         # vMLX-owned vendored runtime (no upstream mlx-lm/jang_tools package).
         # Registering here covers every load path, not just the CLI entry.
@@ -5298,6 +5312,11 @@ def load_jang_model(
         from .nanbeige_runtime import validate_nanbeige_loop_cache_contract
 
         model, tokenizer = result
+        # ERNIE sanitizes shard-local dictionaries; absence can only be decided
+        # once the public loader has consumed the complete checkpoint.
+        finalize_ernie = getattr(model, "finalize_ernie_weight_loading", None)
+        if callable(finalize_ernie):
+            finalize_ernie()
         validate_nanbeige_loop_cache_contract(
             model,
             path,

--- a/vmlx_engine/utils/tokenizer.py
+++ b/vmlx_engine/utils/tokenizer.py
@@ -1226,6 +1226,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None, ski
     # draft head.  The finalizer below then proves the head survived model
     # construction instead of silently serving the MTP bundle as plain AR.
     _glm5_next_native_mtp_expected = False
+    _ernie4_5_native_mtp_expected = False
     _glm5_next_runtime_expected = False
     _glm5_next_model_config_override = None
 
@@ -1244,8 +1245,13 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None, ski
     ensure_spark2_5_runtime_registered(local_model_path)
 
     def _finalize_loaded_model(model, tokenizer):
+        # ERNIE sanitizes shard-local dictionaries; absence can only be decided
+        # once the public loader has consumed the complete checkpoint.
+        finalize_ernie = getattr(model, "finalize_ernie_weight_loading", None)
+        if callable(finalize_ernie):
+            finalize_ernie()
         validate_nanbeige_loop_cache_contract(model, local_model_path)
-        if _glm5_next_native_mtp_expected:
+        if _glm5_next_native_mtp_expected or _ernie4_5_native_mtp_expected:
             from ..native_mtp import (
                 deactivate_native_mtp,
                 model_has_native_mtp_runtime,
@@ -1254,7 +1260,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None, ski
             if not model_has_native_mtp_runtime(model):
                 deactivate_native_mtp()
                 raise RuntimeError(
-                    "GLM-5.3 bundle inspection enabled native MTP, but the "
+                    "bundle inspection enabled native MTP, but the "
                     "loaded model has no attached draft head/runtime contract; "
                     "refusing to silently serve it autoregressively"
                 )
@@ -1352,6 +1358,28 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None, ski
                             "num_hidden_layers"
                         ),
                     )
+            if _mt_arch == "ernie4_5_moe" or _tc_mt_arch == "ernie4_5_moe":
+                # ERNIE-4.5 bf16/MXFP bundles take mlx_lm's generic load with the
+                # vMLX-owned runtime registered OVER upstream. Native MTP must be
+                # activated here, before Model construction, for the same reason
+                # as GLM above: only the JANG loaders call maybe_apply_native_mtp,
+                # so a plain safetensors bundle used to inspect as
+                # "native_runtime_ready" and then serve AR with the head idle.
+                from ..models.ernie4_5.register import register_ernie4_5_runtime
+                from ..native_mtp import maybe_apply_native_mtp
+                register_ernie4_5_runtime()
+                _ernie_mtp_status = maybe_apply_native_mtp(
+                    local_model_path,
+                    allow_runtime=True,
+                )
+                if _ernie_mtp_status.get("status") == "runtime_patch_failed":
+                    raise RuntimeError(
+                        "ERNIE-4.5 native-MTP activation failed before model load; "
+                        "refusing to discard the preserved draft head"
+                    )
+                _ernie4_5_native_mtp_expected = bool(
+                    _ernie_mtp_status.get("runtime_active")
+                )
             if _mt_arch == "zaya" or _tc_mt_arch == "zaya":
                 _jcfg_path_arch = Path(local_model_path) / "jang_config.json"
                 _zaya_wf = None


### PR DESCRIPTION
# feat(ernie4_5): ERNIE-4.5 MoE runtime with native MTP

Adds text-only `baidu/ERNIE-4.5-21B-A3B-PT` support with native MTP and matching engine/panel detection. The vendored runtime preserves the trained expert-selection bias discarded by upstream mlx-lm.

## Runtime and loading

Derived from mlx-lm 0.31.3 with Apple's copyright and MIT notice retained. The runtime uses float32 unquantized router logits, bias for selection only, unbiased normalized mixture weights, interleaved RoPE and plain KV caches. The MTP seam preserves pre-norm hidden states for chained drafting, embedding-first fusion and shared final normalization.

Expert tensors and quantization sidecars can span shards. Strict loads and public-loader finalization reject incomplete backbones, expert groups and partial heads. A wholly absent head loads AR-only. Missing routing biases fail by default; `VMLX_ERNIE45_ALLOW_MISSING_ROUTING_BIAS=1` explicitly permits legacy all-biases-missing raw-softmax routing with a warning. Partial or quantized biases still fail. Tied head weights and quantization sidecars are removed together.

Both native-MTP disable aliases and `--disable-native-mtp` suppress head attachment. Disabled whole/sharded, float/quantized loads preserve backbone weights and logits.

## Integration

Engine and panel agree on text-only plain KV, thinking disabled, and no native tool/reasoning parser. Both EOS strings are recognized. Forced multimodal routing is refused. ERNIE prompt priming defaults on, with `VMLX_ERNIE45_MTP_PROMPT_PRIMING=0` as opt-out; GLM precedence and default-off behavior are preserved. ERNIE keeps the conservative D1 default while respecting upstream depth policy and limits.

Reconciled with v1.6.57 (`378eac499`). Upstream's producer-timestamp timing and terminal-persistence fixes are retained; the former separate timing patch is superseded and is not included here.

## Validation

- **457 focused runtime/integration tests passed**, including all **38 ERNIE tests** and upstream timing/persistence contracts. The updated upstream campaign test file adds **13 passes**.
- **131 panel registry/adoption tests passed**; TypeScript checks passed.
- Full Python run: **11,397 passed, 53 failed, 148 skipped, 92 deselected**. All failing nodes were rerun on untouched v1.6.57: **52 also failed upstream**. The remaining source-string assertion needed to include ERNIE alongside HY3; it is corrected and its full test file passes. This is baseline-controlled evidence, not green full CI.
- Fresh JANG_6M checks: six disabled requests produce zero drafts; six D1/D2/D3 requests produce drafts. All twelve return the same 96-token sample. Committed-cache kill/restart restores 441 tokens and identical output; disconnect recovery passes.
- Fresh 12,033-token cold/warm test restores 12,029 cached tokens. A 30-turn growing conversation passes all semantic checks; final ten RSS samples span 0.33%. OpenAI Chat, Responses, Ollama and Anthropic streaming all emit content and correct terminal events.
- Final Electron dev app: UI, launch arguments and health agree; two visible replies at **115.3 / 110.5 tok/s**, warm disk reuse and MTP activity confirmed. This is a short smoke, not a benchmark.
- **10,164 GLM gate/negative-family comparisons passed**. Prior-source real Qwen controls, JANG_4M/bf16 loads and FP32 numerical controls remain separately attributed evidence. Live GLM inference and release-package production are not claimed.

## Limits

Long greedy AR/MTP output is not universally identical: a measured near-tie flips with FP16 computation shape at a 0.015625 margin; rebuilt FP32 controls agree. A seed does not guarantee identical output across changing MTP/AR execution paths. That limitation and a Qwen JANG MoE text-loader failure were reproduced on untouched upstream and remain separate vMLX findings.

Native tools, reasoning, vision and audio are outside this PT runtime. Full maximum context, every family/cache combination and crash-mid-write durability are not claimed.
